### PR TITLE
ADR voor scraper script

### DIFF
--- a/docs/adr/010-up-to-date-database.md
+++ b/docs/adr/010-up-to-date-database.md
@@ -17,7 +17,7 @@ databank.
 ## Beslissing
 
 We besloten een rechtstreekse verbinding met de databank te gebruiken. Hiervoor
-gebruiken we via docker delen van de code van de backend.
+hergebruiken we via docker delen van de code van de backend.
 
 ## Argumenten
 
@@ -33,8 +33,9 @@ gebruiken we via docker delen van de code van de backend.
 
 ## Gevolgen
 
-- Het script is iets ingewikkelder omdat het rekening moet houden met de databank.
-- De docker configuratie is iets ingewikkelders omdat het script code deelt met
+- Het script is iets ingewikkelder omdat het moet communiceren met een databank
+    in plaats van een web-API.
+- De docker configuratie is iets ingewikkelder omdat het script code deelt met
     de backend.
 - Toekomstige wijzigingen aan de containerisatiestrategie moeten worden
     vastgelegd in een nieuwe ADR of door de status te wijzigen naar `Superseded`.

--- a/docs/adr/010-up-to-date-database.md
+++ b/docs/adr/010-up-to-date-database.md
@@ -1,0 +1,40 @@
+# ADR-007: Up to date archief
+
+**Status:** Proposed
+**Datum:** 2026-02-22
+
+## Context
+
+Om de archief databank automatisch up to date te houden is het nodig dat we
+regelmatig de data uit de hoofdwebsite halen en in onze databank opslaan.
+Dit doen we aan de hand van een Python script dat elke nacht de producties van
+die dag ophaalt en archiveert.
+
+Voor dit script moesten we beslissen om het opslaan van de data te doen via het
+aanspreken van de backend API of via een rechtstreekse verbinding met de
+databank.
+
+## Beslissing
+
+We besloten een rechtstreekse verbinding met de databank te gebruiken. Hiervoor
+gebruiken we via docker delen van de code van de backend.
+
+## Argumenten
+
+- **Onafhankelijkheid:** Door rechstreeks met de databank te praten kan het
+    archiveren doorgaan, ook al is de backend niet beschikbaar.
+- **Eenvoudigere betrouwbaarheid:** Databanken bieden transacties en commits aan
+    die voor de garantie zorgen dat het toevoegen van data zonder fouten gebeurt.
+    Mochten we data toevoegen door de API dan moeten we die garantie zelf ook
+    programmeren in het protocol.
+- **Geen speciale API nodig:** De backend API heeft geen extra endpoints nodig
+    die speciaal op het scraper-script zijn afgestemd en kan zich dus focussen
+    op het communiceren met de frontend.
+
+## Gevolgen
+
+- Het script is iets ingewikkelder omdat het rekening moet houden met de databank.
+- De docker configuratie is iets ingewikkelders omdat het script code deelt met
+    de backend.
+- Toekomstige wijzigingen aan de containerisatiestrategie moeten worden
+    vastgelegd in een nieuwe ADR of door de status te wijzigen naar `Superseded`.

--- a/docs/adr/010-up-to-date-database.md
+++ b/docs/adr/010-up-to-date-database.md
@@ -21,15 +21,19 @@ hergebruiken we via docker delen van de code van de backend.
 
 ## Argumenten
 
-- **Onafhankelijkheid:** Door rechstreeks met de databank te praten kan het
-    archiveren doorgaan, ook al is de backend niet beschikbaar.
-- **Eenvoudigere betrouwbaarheid:** Databanken bieden transacties en commits aan
-    die voor de garantie zorgen dat het toevoegen van data zonder fouten gebeurt.
+- **Onafhankelijkheid:**
+    Door rechstreeks met de databank te praten kan het archiveren doorgaan,
+    ook al is de backend niet beschikbaar.
+- **Eenvoudigere betrouwbaarheid:**
+    Om data-integriteit te garanderen werken databanken met transacties en
+    commits. Als we dus een rechstreekse verbinding met de databank openen
+    dan is het makkelijk te weten wanneer het toevoegen van data correct verliep.
     Mochten we data toevoegen door de API dan moeten we die garantie zelf ook
     programmeren in het protocol.
-- **Geen speciale API nodig:** De backend API heeft geen extra endpoints nodig
-    die speciaal op het scraper-script zijn afgestemd en kan zich dus focussen
-    op het communiceren met de frontend.
+- **Geen speciale API nodig:**
+    De backend API heeft geen extra endpoints nodig die speciaal op het
+    scraper-script zijn afgestemd en kan zich dus focussen op het communiceren
+    met de frontend.
 
 ## Gevolgen
 


### PR DESCRIPTION
> [!WARNING]
> Voor het mergen van de PR moet de status in de ADR geupdatet worden naar `Accepted`

Deze PR voegt het ADR (Architectural Decision Record) toe voor het scraper script.

Deze [guide](https://github.com/joelparkerhenderson/architecture-decision-record?tab=readme-ov-file#file-name-conventions-for-adrs) volgend noemde ik het niet `010-scraper-script.md` maar `010-up-to-date-database.md` omdat dit meer uitlegt waarover de beslissing ging.

Het getal start met `010` om aan te sluiten op #17 , maar kan normaal gemerged worden voor #17 zonder voor conflicten te zorgen.

Closes #14 .