### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,27 +1,27 @@
 ---
 name: Bug report
-about: Report a bug
-title: "[BUG] <short description>"
+about: Raporteer een bug
+title: "[BUG] <korte beschrijving>"
 labels: bug
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Omschrijf de bug**
+Een beknopte beschrijving van de bug.
 
-**Expected behaviour**
-A clear and concise description of what you expected to happen.
+**Verwacht gedrag**
+Een beschrijving van wat je verwachte.
 
-**To Reproduce**
-Steps to reproduce the behaviour:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Stappen om de bug te reproduceren**
+1. Ga naar '...'
+2. Klik op '...'
+3. ...
+4. Zie bug
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Schermafbeeldingen**
+Indien mogelijk, voeg hier een of meer schermafbeeldingen toe die het probleem
+tonen.
 
-**Additional context**
-Add any other context about the problem here.
+**Extra context**
+Voeg hier extra context toe als die er is.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report a bug
+title: "[BUG] <short description>"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature
-about: Describe new feature
-title: "[FEAT] <short description>"
+about: Bescrijf een nieuwe feature
+title: "[FEAT] <korte beschrijving>"
 labels: ''
 assignees: ''
 
@@ -18,5 +18,5 @@ assignees: ''
 
 
 ### Specifieke reviewers nodig
-- mens1
-- mens2
+- persoon1
+- persoon2

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature
+about: Describe new feature
+title: "[FEAT] <short description>"
+labels: ''
+assignees: ''
+
+---
+
+### Korte beschrijving:
+<beschrijving>
+
+
+### Lijst van dingen die gedaan moeten zijn
+- item1
+- item2
+- ...
+
+
+### Specifieke reviewers nodig
+- mens1
+- mens2

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,14 @@
+### Beschrijving
+...
+
+
+### Aangepaste delen
+<Beschrijf hier welke delen van de app aangepast waren, frontend, backend, ...
+welk deel ervan?>
+
+
+### Speciale opmerkingen
+<Was er iets dat speciaal aan de implementering?>
+
+
+Closes <issue-nr>

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -11,4 +11,8 @@ welk deel ervan?>
 <Was er iets dat speciaal aan de implementering?>
 
 
+### Afhankelijkheden
+<Welke eventuele PR's moeten eerder gesloten worden voor dit kan gemerged worden>
+
+
 Closes <issue-nr>


### PR DESCRIPTION
### Beschrijving
Deze PR voegt twee issue templates en een pr template toe voor toekomstige issues en pr's.


### Aangepaste delen
Deze templates leven in de `.github/` folder.