### PR TITLE
Feat/tag endpoint

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -11,8 +11,10 @@ from src.database import SESSION_LOCAL, init_db
 from src.models.permission import Permission
 from src.models.role import Role
 from src.models.user import User
+from src.models.language import Language
 from src.services.auth.password import get_password_hash
 from src.services.auth.permissions import Permissions
+from src.services.language import Languages
 
 
 def seed_db():
@@ -28,6 +30,15 @@ def seed_db():
                 db.commit()
                 db.refresh(perm)
             db_perms.append(perm)
+
+        all_langs = Languages.all()
+        for lang_name in all_langs:
+            lang = db.query(Language).filter(Language.language == lang_name).first()
+            if not lang:
+                lang = Language(language=lang_name)
+                db.add(lang)
+                db.commit()
+                db.refresh(lang)
 
         admin_role = db.query(Role).filter(Role.name == "admin").first()
         if not admin_role:

--- a/backend/src/api/dependencies/__init__.py
+++ b/backend/src/api/dependencies/__init__.py
@@ -1,10 +1,12 @@
 from src.database import get_db
 
 from .auth import RequirePermissions, get_current_user, security_scheme
+from .language import get_accepted_language
 
 __all__ = [
     "get_current_user",
     "RequirePermissions",
     "security_scheme",
     "get_db",
+    "get_accepted_language",
 ]

--- a/backend/src/api/dependencies/language.py
+++ b/backend/src/api/dependencies/language.py
@@ -3,16 +3,16 @@ from fastapi import Header
 from src.services.language import Languages
 
 
-def get_accepted_language(accept_language: str = Header(None, alias="Accept-Language")) -> str:
+def get_accepted_language(
+    accept_language: str = Header(None, alias="Accept-Language"),
+) -> str:
     if not accept_language:
         return Languages.ENGLISH
 
     # Parse de header (bijv. "en-US,en;q=0.9,nl;q=0.8")
     languages = [lang.split(";")[0].strip() for lang in accept_language.split(",")]
 
-    supported = Languages.all()
     for lang in languages:
-        print(lang)
         if lang.lower() in ["en", "english"]:
             return Languages.ENGLISH
         elif lang.lower() in ["nl", "nederlands", "dutch"]:

--- a/backend/src/api/dependencies/language.py
+++ b/backend/src/api/dependencies/language.py
@@ -5,9 +5,9 @@ from src.services.language import Languages
 
 def get_accepted_language(
     accept_language: str = Header(None, alias="Accept-Language"),
-) -> str:
+) -> str | None:
     if not accept_language:
-        return Languages.ENGLISH
+        return None
 
     # Parse de header (bijv. "en-US,en;q=0.9,nl;q=0.8")
     languages = [lang.split(";")[0].strip() for lang in accept_language.split(",")]
@@ -18,4 +18,4 @@ def get_accepted_language(
         elif lang.lower() in ["nl", "nederlands", "dutch"]:
             return Languages.NEDERLANDS
 
-    return Languages.ENGLISH
+    return None

--- a/backend/src/api/dependencies/language.py
+++ b/backend/src/api/dependencies/language.py
@@ -1,0 +1,21 @@
+from fastapi import Header
+
+from src.services.language import Languages
+
+
+def get_accepted_language(accept_language: str = Header(None, alias="Accept-Language")) -> str:
+    if not accept_language:
+        return Languages.ENGLISH
+
+    # Parse de header (bijv. "en-US,en;q=0.9,nl;q=0.8")
+    languages = [lang.split(";")[0].strip() for lang in accept_language.split(",")]
+
+    supported = Languages.all()
+    for lang in languages:
+        print(lang)
+        if lang.lower() in ["en", "english"]:
+            return Languages.ENGLISH
+        elif lang.lower() in ["nl", "nederlands", "dutch"]:
+            return Languages.NEDERLANDS
+
+    return Languages.ENGLISH

--- a/backend/src/api/v1/archive/__init__.py
+++ b/backend/src/api/v1/archive/__init__.py
@@ -1,8 +1,15 @@
 from fastapi import APIRouter
-from src.api.v1.archive import events, productions
+from src.api.v1.archive import events, productions, tags
 
 router = APIRouter()
 
 router.include_router(events.router, prefix="/events", tags=["Events"])
 
 router.include_router(productions.router, prefix="/productions", tags=["Productions"])
+
+router.include_router(
+    tags.router,
+    prefix="/tags",
+    tags=["Tags"]
+)
+

--- a/backend/src/api/v1/archive/__init__.py
+++ b/backend/src/api/v1/archive/__init__.py
@@ -7,9 +7,4 @@ router.include_router(events.router, prefix="/events", tags=["Events"])
 
 router.include_router(productions.router, prefix="/productions", tags=["Productions"])
 
-router.include_router(
-    tags.router,
-    prefix="/tags",
-    tags=["Tags"]
-)
-
+router.include_router(tags.router, prefix="/tags", tags=["Tags"])

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -48,7 +48,7 @@ def get_tag(
 ):
     base_url = str(request.base_url).rstrip("/")
     tag = get_tag_by_id(db, tag_id, base_url, language)
-    return TagResponse.model_validate(tag)
+    return tag
 
 
 @router.post(

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from src.database import get_db
 from src.schemas.tag import TagCreate, TagResponse
-from src.services.tag import create_tag, get_tag_by_id, get_tags_list
+from src.services.tag import create_tag, delete_tag_by_id, get_tag_by_id, get_tags_list
 
 router = APIRouter()
 
@@ -24,5 +24,5 @@ async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_
     return create_tag(db, tag_in, base_url)
 
 @router.delete("/{tag_id}")
-async def delete_tag(tag_id: str) -> dict:
-    return {}
+async def delete_tag(tag_id: str, db: Session=Depends(get_db)):
+    return delete_tag_by_id(db, tag_id)

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -10,13 +10,13 @@ router = APIRouter()
 
 @router.get(
     "/",
-    response_model=List[str],
+    response_model=List[TagResponse],
     summary="Get all tags",
     description="Returns a list of tags."
 )
-async def get_tags(db: Session=Depends(get_db)):
-    tags = get_tags_list(db)
-    return tags
+async def get_tags(request: Request, db: Session=Depends(get_db)):
+    base_url = str(request.base_url).rstrip("/")
+    return get_tags_list(db, base_url)
 
 @router.get(
     "/{tag_id}", 

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.schemas.tag import TagCreate, TagResponse
+from src.services.tag import create_tag, get_tag_by_id, get_tags_list
+
+router = APIRouter()
+
+@router.get("/")
+async def get_tags(db: Session=Depends(get_db)):
+    tags = get_tags_list(db)
+    return tags
+
+@router.get("/{tag_id}", response_model=TagResponse)
+def get_tag(tag_id: int, request: Request, db: Session=Depends(get_db)):
+    base_url = str(request.base_url).rstrip("/")
+    tag = get_tag_by_id(db, tag_id, base_url)
+    return TagResponse.model_validate(tag)
+
+@router.post("/", response_model=TagResponse)
+async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_db)):
+    base_url = str(request.base_url).rstrip("/")
+    return create_tag(db, tag_in, base_url)
+
+@router.delete("/{tag_id}")
+async def delete_tag(tag_id: str) -> dict:
+    return {}

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -72,6 +72,7 @@ async def post_tag(
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
+
 @router.patch("/{tag_id}", response_model=TagResponse, summary="Update a tag")
 async def patch_tag(
     tag_id: int,
@@ -85,7 +86,6 @@ async def patch_tag(
         return update_tag(db, tag_id, tag_in, base_url)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-
 
 
 @router.delete("/{tag_id}", summary="Delete a tag")

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from src.api.dependencies.language import get_accepted_language
@@ -58,6 +58,7 @@ def get_tag(
 @router.post(
     "/",
     response_model=TagResponse,
+    status_code=status.HTTP_201_CREATED,
     summary="Create a new tag",
 )
 async def post_tag(
@@ -88,7 +89,9 @@ async def patch_tag(
         raise HTTPException(status_code=404, detail=str(e))
 
 
-@router.delete("/{tag_id}", summary="Delete a tag")
+@router.delete(
+    "/{tag_id}", status_code=status.HTTP_204_NO_CONTENT, summary="Delete a tag"
+)
 async def delete_tag(
     tag_id: str,
     db: Session = Depends(get_db),

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -28,7 +28,7 @@ router = APIRouter()
 async def get_tags(
     request: Request,
     db: Session = Depends(get_db),
-    language: str = Depends(get_accepted_language),
+    language: str | None = Depends(get_accepted_language),
 ):
     base_url = str(request.base_url).rstrip("/")
     return get_tags_list(db, base_url, language)
@@ -44,7 +44,7 @@ def get_tag(
     tag_id: int,
     request: Request,
     db: Session = Depends(get_db),
-    language: str = Depends(get_accepted_language),
+    language: str | None = Depends(get_accepted_language),
 ):
     base_url = str(request.base_url).rstrip("/")
     tag = get_tag_by_id(db, tag_id, base_url, language)

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -3,8 +3,11 @@ from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
 from src.database import get_db
+from src.models.user import User
 from src.schemas.tag import TagCreate, TagResponse
 from src.services.tag import create_tag, delete_tag_by_id, get_tag_by_id, get_tags_list
+from src.services.auth.permissions import Permissions
+from src.api.dependencies import RequirePermissions
 
 router = APIRouter()
 
@@ -34,7 +37,7 @@ def get_tag(tag_id: int, request: Request, db: Session=Depends(get_db)):
     response_model=TagResponse,
     summary="Create a new tag",
 )
-async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_db)):
+async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE]))):
     base_url = str(request.base_url).rstrip("/")
     return create_tag(db, tag_in, base_url)
 
@@ -42,5 +45,5 @@ async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_
     "/{tag_id}",
     summary="Delete a tag"
 )
-async def delete_tag(tag_id: str, db: Session=Depends(get_db)):
+async def delete_tag(tag_id: str, db: Session=Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_DELETE]))):
     return delete_tag_by_id(db, tag_id)

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -1,3 +1,4 @@
+from typing import List
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
@@ -7,22 +8,39 @@ from src.services.tag import create_tag, delete_tag_by_id, get_tag_by_id, get_ta
 
 router = APIRouter()
 
-@router.get("/")
+@router.get(
+    "/",
+    response_model=List[str],
+    summary="Get all tags",
+    description="Returns a list of tags."
+)
 async def get_tags(db: Session=Depends(get_db)):
     tags = get_tags_list(db)
     return tags
 
-@router.get("/{tag_id}", response_model=TagResponse)
+@router.get(
+    "/{tag_id}", 
+    response_model=TagResponse,
+    summary="Get a tag",
+    description="Get a tag and its corresponding names by id"
+)
 def get_tag(tag_id: int, request: Request, db: Session=Depends(get_db)):
     base_url = str(request.base_url).rstrip("/")
     tag = get_tag_by_id(db, tag_id, base_url)
     return TagResponse.model_validate(tag)
 
-@router.post("/", response_model=TagResponse)
+@router.post(
+    "/", 
+    response_model=TagResponse,
+    summary="Create a new tag",
+)
 async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_db)):
     base_url = str(request.base_url).rstrip("/")
     return create_tag(db, tag_in, base_url)
 
-@router.delete("/{tag_id}")
+@router.delete(
+    "/{tag_id}",
+    summary="Delete a tag"
+)
 async def delete_tag(tag_id: str, db: Session=Depends(get_db)):
     return delete_tag_by_id(db, tag_id)

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from src.database import get_db
 from src.models.user import User
 from src.schemas.tag import TagCreate, TagResponse
-from src.services.tag import create_tag, delete_tag_by_id, get_tag_by_id, get_tags_list
+from src.services.tag import create_tag, delete_tag_by_id, get_tag_by_id, get_tags_list, update_tag
 from src.services.auth.permissions import Permissions
 from src.api.dependencies import RequirePermissions
 
@@ -40,6 +40,15 @@ def get_tag(tag_id: int, request: Request, db: Session=Depends(get_db)):
 async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE]))):
     base_url = str(request.base_url).rstrip("/")
     return create_tag(db, tag_in, base_url)
+
+@router.patch(
+    "/{tag_id}",
+    response_model=TagResponse,
+    summary="Update a tag"
+)
+async def patch_tag(tag_id: int, tag_in: TagCreate, request: Request, db: Session = Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE]))):
+    base_url = str(request.base_url).rstrip("/")
+    return update_tag(db, tag_id, tag_in, base_url)
 
 @router.delete(
     "/{tag_id}",

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -6,78 +6,82 @@ from src.api.dependencies.language import get_accepted_language
 from src.database import get_db
 from src.models.user import User
 from src.schemas.tag import TagCreate, TagResponse
-from src.services.tag import create_tag, delete_tag_by_id, get_tag_by_id, get_tags_list, update_tag
+from src.services.tag import (
+    create_tag,
+    delete_tag_by_id,
+    get_tag_by_id,
+    get_tags_list,
+    update_tag,
+)
 from src.services.auth.permissions import Permissions
 from src.api.dependencies import RequirePermissions
 
 router = APIRouter()
 
+
 @router.get(
     "/",
     response_model=List[TagResponse],
     summary="Get all tags",
-    description="Returns a list of tags."
+    description="Returns a list of tags.",
 )
 async def get_tags(
-    request: Request, 
-    db: Session=Depends(get_db), 
-    language: str=Depends(get_accepted_language)
+    request: Request,
+    db: Session = Depends(get_db),
+    language: str = Depends(get_accepted_language),
 ):
     base_url = str(request.base_url).rstrip("/")
     return get_tags_list(db, base_url, language)
 
+
 @router.get(
-    "/{tag_id}", 
+    "/{tag_id}",
     response_model=TagResponse,
     summary="Get a tag",
-    description="Get a tag and its corresponding names by id"
+    description="Get a tag and its corresponding names by id",
 )
 def get_tag(
-    tag_id: int, 
-    request: Request, 
-    db: Session=Depends(get_db),
-    language: str=Depends(get_accepted_language)
+    tag_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    language: str = Depends(get_accepted_language),
 ):
     base_url = str(request.base_url).rstrip("/")
     tag = get_tag_by_id(db, tag_id, base_url, language)
     return TagResponse.model_validate(tag)
 
+
 @router.post(
-    "/", 
+    "/",
     response_model=TagResponse,
     summary="Create a new tag",
 )
 async def post_tag(
-    tag_in: TagCreate, 
-    request: Request, 
-    db: Session=Depends(get_db), 
+    tag_in: TagCreate,
+    request: Request,
+    db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ):
     base_url = str(request.base_url).rstrip("/")
     return create_tag(db, tag_in, base_url)
 
-@router.patch(
-    "/{tag_id}",
-    response_model=TagResponse,
-    summary="Update a tag"
-)
+
+@router.patch("/{tag_id}", response_model=TagResponse, summary="Update a tag")
 async def patch_tag(
-    tag_id: int, 
-    tag_in: TagCreate, 
-    request: Request, 
-    db: Session = Depends(get_db), 
+    tag_id: int,
+    tag_in: TagCreate,
+    request: Request,
+    db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
     base_url = str(request.base_url).rstrip("/")
     return update_tag(db, tag_id, tag_in, base_url)
 
-@router.delete(
-    "/{tag_id}",
-    summary="Delete a tag"
-)
+
+@router.delete("/{tag_id}", summary="Delete a tag")
 async def delete_tag(
-    tag_id: str, 
-    db: Session=Depends(get_db), 
+    tag_id: str,
+    db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_DELETE])),
 ):
     return delete_tag_by_id(db, tag_id)

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from src.api.dependencies.language import get_accepted_language
@@ -47,7 +47,11 @@ def get_tag(
     language: str | None = Depends(get_accepted_language),
 ):
     base_url = str(request.base_url).rstrip("/")
-    tag = get_tag_by_id(db, tag_id, base_url, language)
+    try:
+        tag = get_tag_by_id(db, tag_id, base_url, language)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
     return tag
 
 
@@ -63,8 +67,10 @@ async def post_tag(
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ):
     base_url = str(request.base_url).rstrip("/")
-    return create_tag(db, tag_in, base_url)
-
+    try:
+        return create_tag(db, tag_in, base_url)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
 @router.patch("/{tag_id}", response_model=TagResponse, summary="Update a tag")
 async def patch_tag(
@@ -75,7 +81,11 @@ async def patch_tag(
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
     base_url = str(request.base_url).rstrip("/")
-    return update_tag(db, tag_id, tag_in, base_url)
+    try:
+        return update_tag(db, tag_id, tag_in, base_url)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
 
 
 @router.delete("/{tag_id}", summary="Delete a tag")
@@ -84,4 +94,6 @@ async def delete_tag(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_DELETE])),
 ):
-    return delete_tag_by_id(db, tag_id)
+    success = delete_tag_by_id(db, tag_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Tag not found")

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -2,6 +2,7 @@ from typing import List
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy.orm import Session
 
+from src.api.dependencies.language import get_accepted_language
 from src.database import get_db
 from src.models.user import User
 from src.schemas.tag import TagCreate, TagResponse
@@ -17,9 +18,13 @@ router = APIRouter()
     summary="Get all tags",
     description="Returns a list of tags."
 )
-async def get_tags(request: Request, db: Session=Depends(get_db)):
+async def get_tags(
+    request: Request, 
+    db: Session=Depends(get_db), 
+    language: str=Depends(get_accepted_language)
+):
     base_url = str(request.base_url).rstrip("/")
-    return get_tags_list(db, base_url)
+    return get_tags_list(db, base_url, language)
 
 @router.get(
     "/{tag_id}", 
@@ -27,9 +32,14 @@ async def get_tags(request: Request, db: Session=Depends(get_db)):
     summary="Get a tag",
     description="Get a tag and its corresponding names by id"
 )
-def get_tag(tag_id: int, request: Request, db: Session=Depends(get_db)):
+def get_tag(
+    tag_id: int, 
+    request: Request, 
+    db: Session=Depends(get_db),
+    language: str=Depends(get_accepted_language)
+):
     base_url = str(request.base_url).rstrip("/")
-    tag = get_tag_by_id(db, tag_id, base_url)
+    tag = get_tag_by_id(db, tag_id, base_url, language)
     return TagResponse.model_validate(tag)
 
 @router.post(
@@ -37,7 +47,12 @@ def get_tag(tag_id: int, request: Request, db: Session=Depends(get_db)):
     response_model=TagResponse,
     summary="Create a new tag",
 )
-async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE]))):
+async def post_tag(
+    tag_in: TagCreate, 
+    request: Request, 
+    db: Session=Depends(get_db), 
+    _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
+):
     base_url = str(request.base_url).rstrip("/")
     return create_tag(db, tag_in, base_url)
 
@@ -46,7 +61,13 @@ async def post_tag(tag_in: TagCreate, request: Request, db: Session=Depends(get_
     response_model=TagResponse,
     summary="Update a tag"
 )
-async def patch_tag(tag_id: int, tag_in: TagCreate, request: Request, db: Session = Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE]))):
+async def patch_tag(
+    tag_id: int, 
+    tag_in: TagCreate, 
+    request: Request, 
+    db: Session = Depends(get_db), 
+    _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
+):
     base_url = str(request.base_url).rstrip("/")
     return update_tag(db, tag_id, tag_in, base_url)
 
@@ -54,5 +75,9 @@ async def patch_tag(tag_id: int, tag_in: TagCreate, request: Request, db: Sessio
     "/{tag_id}",
     summary="Delete a tag"
 )
-async def delete_tag(tag_id: str, db: Session=Depends(get_db), _: User = Depends(RequirePermissions([Permissions.ARCHIVE_DELETE]))):
+async def delete_tag(
+    tag_id: str, 
+    db: Session=Depends(get_db), 
+    _: User = Depends(RequirePermissions([Permissions.ARCHIVE_DELETE])),
+):
     return delete_tag_by_id(db, tag_id)

--- a/backend/src/schemas/tag.py
+++ b/backend/src/schemas/tag.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Sequence
 from pydantic import BaseModel, ConfigDict
 
 
@@ -16,7 +16,7 @@ class Tag(BaseModel):
 
 
 class TagResponse(Tag):
-    names: List[TagNameResponse]
+    names: Sequence[TagNameResponse]
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/src/schemas/tag.py
+++ b/backend/src/schemas/tag.py
@@ -1,9 +1,11 @@
 from typing import List, Optional
 from pydantic import BaseModel, ConfigDict
 
+
 class TagName(BaseModel):
     language_id: int
     name: str
+
 
 class TagNameResponse(TagName):
     model_config = ConfigDict(from_attributes=True)
@@ -11,6 +13,7 @@ class TagNameResponse(TagName):
 
 class Tag(BaseModel):
     id: str
+
 
 class TagResponse(Tag):
     names: List[TagNameResponse]
@@ -21,7 +24,6 @@ class TagResponse(Tag):
 class TagCreate(BaseModel):
     names: List[TagName]
 
+
 class TagUpdate(BaseModel):
     names: Optional[List[TagName]]
-
-

--- a/backend/src/schemas/tag.py
+++ b/backend/src/schemas/tag.py
@@ -2,28 +2,28 @@ from typing import List, Optional, Sequence
 from pydantic import BaseModel, ConfigDict
 
 
-class TagName(BaseModel):
+class TagNameBase(BaseModel):
     language_id: int
     name: str
 
 
-class TagNameResponse(TagName):
+class TagNameResponse(TagNameBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class Tag(BaseModel):
+class TagBase(BaseModel):
     id: str
 
 
-class TagResponse(Tag):
+class TagResponse(TagBase):
     names: Sequence[TagNameResponse]
 
     model_config = ConfigDict(from_attributes=True)
 
 
 class TagCreate(BaseModel):
-    names: List[TagName]
+    names: List[TagNameBase]
 
 
 class TagUpdate(BaseModel):
-    names: Optional[List[TagName]]
+    names: Optional[List[TagNameBase]]

--- a/backend/src/schemas/tag.py
+++ b/backend/src/schemas/tag.py
@@ -1,0 +1,27 @@
+from typing import List, Optional
+from pydantic import BaseModel, ConfigDict
+
+class TagName(BaseModel):
+    language_id: int
+    name: str
+
+class TagNameResponse(TagName):
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Tag(BaseModel):
+    id: str
+
+class TagResponse(Tag):
+    names: List[TagNameResponse]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TagCreate(BaseModel):
+    names: List[TagName]
+
+class TagUpdate(BaseModel):
+    names: Optional[List[TagName]]
+
+

--- a/backend/src/services/language.py
+++ b/backend/src/services/language.py
@@ -1,0 +1,11 @@
+class Languages:
+    ENGLISH = "en"
+    NEDERLANDS = "nl"
+
+    @classmethod
+    def all(cls) -> list[str]:
+        return [
+            v
+            for k, v in vars(cls).items()
+            if not k.startswith("_") and isinstance(v, str)
+        ]

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -19,7 +19,7 @@ def build_tag_response(
     )
 
 
-def get_names_for_language(names, language: str):
+def get_names_for_language(names, language: str | None):
     if language:
         for name in names:
             if name.language.language == language:
@@ -29,7 +29,9 @@ def get_names_for_language(names, language: str):
         return names
 
 
-def get_tags_list(db: Session, base_url: str, language: str) -> List[TagResponse]:
+def get_tags_list(
+    db: Session, base_url: str, language: str | None
+) -> List[TagResponse]:
     tags = db.query(Tag).all()
 
     responses = []
@@ -40,7 +42,7 @@ def get_tags_list(db: Session, base_url: str, language: str) -> List[TagResponse
 
 
 def get_tag_by_id(
-    db: Session, tag_id: int, base_url: str, language: str
+    db: Session, tag_id: int, base_url: str, language: str | None
 ) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -54,3 +54,23 @@ def create_tag(db: Session, tag_in: TagCreate, base_url: str):
 
     return build_tag_response(db_tag, db_tag_names, base_url)
 
+def delete_tag_by_id(db: Session, tag_id):
+    stmt = (
+        select(Tag)
+        .where(Tag.id == tag_id)
+        .options(selectinload(Tag.names))
+    )
+
+    tag = db.execute(stmt).scalar_one_or_none()
+
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    for tagname in tag.names:
+        db.delete(tagname)
+
+    db.delete(tag)
+    db.commit()
+
+    return { "status": "ok" }
+

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -25,7 +25,7 @@ def get_names_for_language(names, language: str | None):
 
 
 def get_tags_list(
-    db: Session, base_url: str, language: str | None
+    db: Session, base_url: str, language: str | None = None
 ) -> List[TagResponse]:
     tags = db.query(Tag).all()
 
@@ -37,7 +37,7 @@ def get_tags_list(
 
 
 def get_tag_by_id(
-    db: Session, tag_id: int, base_url: str, language: str | None
+    db: Session, tag_id: int, base_url: str, language: str | None = None
 ) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -23,7 +23,6 @@ def get_names_for_language(names, language: str):
     if language:
         for name in names:
             if name.language.language == language:
-                print(language)
                 return [name]
         return names
     else:

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence
+from typing import List
 from sqlalchemy.orm import Session, selectinload
 from sqlalchemy import select
 from fastapi import HTTPException
@@ -55,6 +55,37 @@ def create_tag(db: Session, tag_in: TagCreate, base_url: str):
     db.refresh(db_tag)
 
     return build_tag_response(db_tag, db_tag_names, base_url)
+
+def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResponse:
+    stmt = (
+        select(Tag)
+        .where(Tag.id == tag_id)
+        .options(selectinload(Tag.names))
+    )
+
+    tag = db.execute(stmt).scalar_one_or_none()
+
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    # Get a list of names that already exist (these will need to be adjusted instead of added)
+    existing_names = {name.language_id: name for name in tag.names}
+
+    for name in tag_in.names:
+        if name.language_id in existing_names:
+            existing_names[name.language_id].name = name.name
+        else:
+            db_tag_name = TagName(
+                tag_id=tag.id,
+                language_id=name.language_id,
+                name=name.name,
+            )
+            db.add(db_tag_name)
+            tag.names.append(db_tag_name)
+    db.commit()
+    db.refresh(tag)
+
+    return build_tag_response(tag, tag.names, base_url)
 
 def delete_tag_by_id(db: Session, tag_id):
     stmt = (

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -6,16 +6,12 @@ from src.models.tag import Tag, TagName
 from src.schemas.tag import TagCreate, TagNameResponse, TagResponse
 
 
-def build_tag_name_response(tag_name: TagName):
-    return TagNameResponse.model_validate(tag_name)
-
-
 def build_tag_response(
     tag: Tag, tag_names: List[TagName], base_url: str
 ) -> TagResponse:
     return TagResponse(
         id=f"{base_url}/tags/{tag.id}",
-        names=[build_tag_name_response(tag_name) for tag_name in tag_names],
+        names=tag_names,
     )
 
 

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -16,20 +16,11 @@ def build_tag_response(tag: Tag, tag_names: List[TagName], base_url: str) -> Tag
     )
 
 def get_tags_list(db: Session, base_url: str) -> List[TagResponse]:
-    stmt = select(Tag).options(selectinload(Tag.names))
-    tags = db.execute(stmt).scalars().all()
-
+    tags = db.query(Tag).all()
     return [ build_tag_response(tag, tag.names, base_url) for tag in tags ]
     
 def get_tag_by_id(db: Session, tag_id: int, base_url: str) -> TagResponse:
-    stmt = (
-        select(Tag)
-        .where(Tag.id == tag_id)
-        .options(selectinload(Tag.names))
-    )
-
-    tag = db.execute(stmt).scalar_one_or_none()
-
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 
@@ -57,20 +48,12 @@ def create_tag(db: Session, tag_in: TagCreate, base_url: str):
     return build_tag_response(db_tag, db_tag_names, base_url)
 
 def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResponse:
-    stmt = (
-        select(Tag)
-        .where(Tag.id == tag_id)
-        .options(selectinload(Tag.names))
-    )
-
-    tag = db.execute(stmt).scalar_one_or_none()
-
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 
     # Get a list of names that already exist (these will need to be adjusted instead of added)
     existing_names = {name.language_id: name for name in tag.names}
-
     for name in tag_in.names:
         if name.language_id in existing_names:
             existing_names[name.language_id].name = name.name
@@ -88,14 +71,7 @@ def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResp
     return build_tag_response(tag, tag.names, base_url)
 
 def delete_tag_by_id(db: Session, tag_id):
-    stmt = (
-        select(Tag)
-        .where(Tag.id == tag_id)
-        .options(selectinload(Tag.names))
-    )
-
-    tag = db.execute(stmt).scalar_one_or_none()
-
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -2,6 +2,7 @@ from typing import List
 from sqlalchemy.orm import Session
 
 from src.models.tag import Tag, TagName
+from src.models.language import Language
 from src.schemas.tag import TagCreate, TagResponse
 
 
@@ -49,10 +50,16 @@ def get_tag_by_id(
 
 
 def create_tag(db: Session, tag_in: TagCreate, base_url: str):
-    db_tag = Tag()
+    language_ids = [name.language_id for name in tag_in.names]
+    languages = db.query(Language).filter(Language.id.in_(language_ids)).all()
+    if len(languages) != len(language_ids):
+        raise ValueError("One or more languages not found")
 
+    db_tag = Tag()
     db.add(db_tag)
     db.flush()
+    db.commit()
+    db.refresh(db_tag)
 
     db_tag_names = []
     for name in tag_in.names:

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -7,10 +7,7 @@ from src.models.tag import Tag, TagName
 from src.schemas.tag import TagCreate, TagNameResponse, TagResponse
 
 def build_tag_name_response(tag_name: TagName):
-    return TagNameResponse(
-        language_id=tag_name.language_id,
-        name=tag_name.name
-    )
+    return TagNameResponse.model_validate(tag_name)
 
 def build_tag_response(tag: Tag, tag_names: List[TagName], base_url: str) -> TagResponse:
     return TagResponse(

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -1,0 +1,59 @@
+from typing import List, Sequence
+from sqlalchemy.orm import Session, selectinload
+from sqlalchemy import select
+from fastapi import HTTPException
+
+from src.models.tag import Tag, TagName
+from src.schemas.tag import TagCreate, TagNameResponse, TagResponse
+
+def build_tag_name_response(tag_name: TagName):
+    return TagNameResponse(
+        language_id=tag_name.language_id,
+        name=tag_name.name
+    )
+
+def build_tag_response(tag: Tag, tag_names: List[TagName], base_url: str) -> TagResponse:
+    return TagResponse(
+        id=f"{base_url}/tags/{tag.id}",
+        names=[build_tag_name_response(tag_name) for tag_name in tag_names],
+    )
+
+def get_tags_list(db: Session) -> Sequence[Tag]:
+    stmt = select(Tag)
+    return db.execute(stmt).scalars().all()
+    
+def get_tag_by_id(db: Session, tag_id: int, base_url: str) -> TagResponse:
+    stmt = (
+        select(Tag)
+        .where(Tag.id == tag_id)
+        .options(selectinload(Tag.names))
+    )
+
+    tag = db.execute(stmt).scalar_one_or_none()
+
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+
+    return build_tag_response(tag, tag.names, base_url)
+
+def create_tag(db: Session, tag_in: TagCreate, base_url: str):
+    db_tag = Tag()
+
+    db.add(db_tag)
+    db.flush()
+    
+    db_tag_names = []
+    for name in tag_in.names:
+        db_tag_name = TagName(
+            tag_id=db_tag.id,
+            language_id=name.language_id,
+            name=name.name
+        )
+        db_tag_names.append(db_tag_name)
+        db.add(db_tag_name)
+
+    db.commit()
+    db.refresh(db_tag)
+
+    return build_tag_response(db_tag, db_tag_names, base_url)
+

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -4,16 +4,20 @@ from fastapi import HTTPException
 
 from src.models.tag import Tag, TagName
 from src.schemas.tag import TagCreate, TagNameResponse, TagResponse
-from src.services.language import Languages
+
 
 def build_tag_name_response(tag_name: TagName):
     return TagNameResponse.model_validate(tag_name)
 
-def build_tag_response(tag: Tag, tag_names: List[TagName], base_url: str) -> TagResponse:
+
+def build_tag_response(
+    tag: Tag, tag_names: List[TagName], base_url: str
+) -> TagResponse:
     return TagResponse(
         id=f"{base_url}/tags/{tag.id}",
         names=[build_tag_name_response(tag_name) for tag_name in tag_names],
     )
+
 
 def get_names_for_language(names, language: str):
     if language:
@@ -25,6 +29,7 @@ def get_names_for_language(names, language: str):
     else:
         return names
 
+
 def get_tags_list(db: Session, base_url: str, language: str) -> List[TagResponse]:
     tags = db.query(Tag).all()
 
@@ -33,26 +38,30 @@ def get_tags_list(db: Session, base_url: str, language: str) -> List[TagResponse
         names = get_names_for_language(tag.names, language)
         responses.append(build_tag_response(tag, names, base_url))
     return responses
-   
-def get_tag_by_id(db: Session, tag_id: int, base_url: str, language: str) -> TagResponse:
+
+
+def get_tag_by_id(
+    db: Session, tag_id: int, base_url: str, language: str
+) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 
-    return build_tag_response(tag, get_names_for_language(tag.names, language), base_url)
+    return build_tag_response(
+        tag, get_names_for_language(tag.names, language), base_url
+    )
+
 
 def create_tag(db: Session, tag_in: TagCreate, base_url: str):
     db_tag = Tag()
 
     db.add(db_tag)
     db.flush()
-    
+
     db_tag_names = []
     for name in tag_in.names:
         db_tag_name = TagName(
-            tag_id=db_tag.id,
-            language_id=name.language_id,
-            name=name.name
+            tag_id=db_tag.id, language_id=name.language_id, name=name.name
         )
         db_tag_names.append(db_tag_name)
         db.add(db_tag_name)
@@ -61,6 +70,7 @@ def create_tag(db: Session, tag_in: TagCreate, base_url: str):
     db.refresh(db_tag)
 
     return build_tag_response(db_tag, db_tag_names, base_url)
+
 
 def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
@@ -85,6 +95,7 @@ def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResp
 
     return build_tag_response(tag, tag.names, base_url)
 
+
 def delete_tag_by_id(db: Session, tag_id):
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
@@ -96,5 +107,4 @@ def delete_tag_by_id(db: Session, tag_id):
     db.delete(tag)
     db.commit()
 
-    return { "status": "ok" }
-
+    return {"status": "ok"}

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -15,9 +15,11 @@ def build_tag_response(tag: Tag, tag_names: List[TagName], base_url: str) -> Tag
         names=[build_tag_name_response(tag_name) for tag_name in tag_names],
     )
 
-def get_tags_list(db: Session) -> Sequence[Tag]:
-    stmt = select(Tag)
-    return db.execute(stmt).scalars().all()
+def get_tags_list(db: Session, base_url: str) -> List[TagResponse]:
+    stmt = select(Tag).options(selectinload(Tag.names))
+    tags = db.execute(stmt).scalars().all()
+
+    return [ build_tag_response(tag, tag.names, base_url) for tag in tags ]
     
 def get_tag_by_id(db: Session, tag_id: int, base_url: str) -> TagResponse:
     stmt = (

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -1,10 +1,10 @@
 from typing import List
-from sqlalchemy.orm import Session, selectinload
-from sqlalchemy import select
+from sqlalchemy.orm import Session
 from fastapi import HTTPException
 
 from src.models.tag import Tag, TagName
 from src.schemas.tag import TagCreate, TagNameResponse, TagResponse
+from src.services.language import Languages
 
 def build_tag_name_response(tag_name: TagName):
     return TagNameResponse.model_validate(tag_name)
@@ -15,16 +15,31 @@ def build_tag_response(tag: Tag, tag_names: List[TagName], base_url: str) -> Tag
         names=[build_tag_name_response(tag_name) for tag_name in tag_names],
     )
 
-def get_tags_list(db: Session, base_url: str) -> List[TagResponse]:
+def get_names_for_language(names, language: str):
+    if language:
+        for name in names:
+            if name.language.language == language:
+                print(language)
+                return [name]
+        return names
+    else:
+        return names
+
+def get_tags_list(db: Session, base_url: str, language: str) -> List[TagResponse]:
     tags = db.query(Tag).all()
-    return [ build_tag_response(tag, tag.names, base_url) for tag in tags ]
-    
-def get_tag_by_id(db: Session, tag_id: int, base_url: str) -> TagResponse:
+
+    responses = []
+    for tag in tags:
+        names = get_names_for_language(tag.names, language)
+        responses.append(build_tag_response(tag, names, base_url))
+    return responses
+   
+def get_tag_by_id(db: Session, tag_id: int, base_url: str, language: str) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")
 
-    return build_tag_response(tag, tag.names, base_url)
+    return build_tag_response(tag, get_names_for_language(tag.names, language), base_url)
 
 def create_tag(db: Session, tag_in: TagCreate, base_url: str):
     db_tag = Tag()

--- a/backend/src/services/tag.py
+++ b/backend/src/services/tag.py
@@ -1,9 +1,8 @@
 from typing import List
 from sqlalchemy.orm import Session
-from fastapi import HTTPException
 
 from src.models.tag import Tag, TagName
-from src.schemas.tag import TagCreate, TagNameResponse, TagResponse
+from src.schemas.tag import TagCreate, TagResponse
 
 
 def build_tag_response(
@@ -42,7 +41,7 @@ def get_tag_by_id(
 ) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
-        raise HTTPException(status_code=404, detail="Tag not found")
+        raise ValueError("Tag not found")
 
     return build_tag_response(
         tag, get_names_for_language(tag.names, language), base_url
@@ -72,7 +71,7 @@ def create_tag(db: Session, tag_in: TagCreate, base_url: str):
 def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResponse:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
-        raise HTTPException(status_code=404, detail="Tag not found")
+        raise ValueError("Tag not found")
 
     # Get a list of names that already exist (these will need to be adjusted instead of added)
     existing_names = {name.language_id: name for name in tag.names}
@@ -93,10 +92,10 @@ def update_tag(db: Session, tag_id, tag_in: TagCreate, base_url: str) -> TagResp
     return build_tag_response(tag, tag.names, base_url)
 
 
-def delete_tag_by_id(db: Session, tag_id):
+def delete_tag_by_id(db: Session, tag_id) -> bool:
     tag = db.query(Tag).filter(Tag.id == tag_id).first()
     if not tag:
-        raise HTTPException(status_code=404, detail="Tag not found")
+        return False
 
     for tagname in tag.names:
         db.delete(tagname)
@@ -104,4 +103,4 @@ def delete_tag_by_id(db: Session, tag_id):
     db.delete(tag)
     db.commit()
 
-    return {"status": "ok"}
+    return True

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -1,7 +1,12 @@
+from fastapi.testclient import TestClient
 import pytest
 from sqlalchemy.orm import Session
 
+from src.models.user import User
+from src.models.role import Role
 from src.models.language import Language
+from src.services.auth.password import get_password_hash
+from src.services.auth.permissions import Permissions
 
 TAGS_URL = "/api/v1/archive/tags"
 
@@ -18,27 +23,89 @@ def language(db_session: Session):
 
     return lang
 
-def test_create_tag(client, language):
+@pytest.fixture
+def create_headers(client: TestClient, db_session: Session):
+    return create_user_and_login(
+        client, 
+        db_session, 
+        "create_tag_user", 
+        permissions=[Permissions.ARCHIVE_CREATE]
+    )
+
+
+# gekopieerd van PR #42, kan deze niet beter in een aparte file?
+def create_user_and_login(client: TestClient, db_session: Session, username: str, permissions=None):
+    password = "test_pw"
+    hashed = get_password_hash(password)
+
+    role = Role(name=f"{username}_role")
+
+    # Voeg Permission objecten toe
+    if permissions:
+        from src.models.permission import Permission
+        perm_objs = []
+        for p in permissions:
+            perm = db_session.query(Permission).filter_by(name=p).first()
+            if not perm:
+                perm = Permission(name=p)
+                db_session.add(perm)
+            perm_objs.append(perm)
+        role.permissions = perm_objs
+
+    user = User(username=username, hashed_password=hashed, roles=[role])
+
+    db_session.add(role)
+    db_session.add(user)
+    db_session.commit()
+
+    login_response = client.post(
+        "/api/v1/auth/login/",
+        json={"username": username, "password": password}
+    )
+
+    token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_tag(client: TestClient, create_headers, language: Language):
     response = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language.id, "name": "tag_1"},
+                {"language_id": language.id, "name": "tag1"},
             ]
-        }
+        },
+        headers=create_headers
     )
     assert response.status_code == 200
 
     data = response.json()
     assert "id" in data
     assert len(data["names"]) == 1
-    assert data["names"][0]["name"] == "tag_1"
+    assert data["names"][0]["name"] == "tag1"
 
 
-def test_get_tag(client, language):
+def test_create_tag_unauthorized(client: TestClient, language: Language):
+    response = client.post(
+        TAGS_URL,
+        json={
+            "names": [
+                {"language_id": language.id, "name": "tag1"},
+            ]
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_get_tag(client: TestClient, create_headers, language: Language):
     created_tag = client.post(
         TAGS_URL,
-        json={"names": [{"language_id": language.id, "name": "tag1"}]}
+        json={
+            "names": [
+                {"language_id": language.id, "name": "tag1"}
+            ]
+        },
+        headers=create_headers
     )
 
     tag_url = created_tag.json()["id"]
@@ -51,13 +118,17 @@ def test_get_tag(client, language):
     assert data["names"][0]["name"] == "tag1"
 
 
-
-def test_get_tags(client, language):
+def test_get_tags(client: TestClient, create_headers, language: Language):
     n = 5
     for i in range(n):
         client.post(
             TAGS_URL,
-            json={"names": [{"language_id": language.id, "name": f"tag{i}"}]}
+            json={
+                "names": [
+                    {"language_id": language.id, "name": f"tag{i}"}
+                ]
+            },
+            headers=create_headers
         )
 
     response = client.get(TAGS_URL)
@@ -71,16 +142,49 @@ def test_get_tags(client, language):
         assert any(data[j]["names"][0]["name"] == f"tag{i}" for j in range(n))
 
 
-def test_delete_tag(client, language):
+def test_delete_tag(client: TestClient, db_session: Session, create_headers, language: Language):
     created_tag = client.post(
         TAGS_URL,
-        json={"names": [{"language_id": language.id, "name": "tag1"}]}
+        json={
+            "names": [
+                {"language_id": language.id, "name": "tag1"}
+            ]
+        },
+        headers=create_headers
+    )
+
+    tag_id = created_tag.json()["id"].split("/")[-1]
+
+    delete_headers = create_user_and_login(
+        client, 
+        db_session, 
+        "delete_tag_user", 
+        permissions=[Permissions.ARCHIVE_DELETE]
+    )
+    response = client.delete(f"{TAGS_URL}/{tag_id}", headers=delete_headers)
+    assert response.status_code == 200
+
+    get_response = client.get(f"{TAGS_URL}/{tag_id}")
+    assert get_response.status_code == 404
+
+
+def test_delete_unauthorized(client: TestClient, create_headers, language: Language):
+    created_tag = client.post(
+        TAGS_URL,
+        json={
+            "names": [
+                {"language_id": language.id, "name": "tag1"}
+            ]
+        },
+        headers=create_headers
     )
 
     tag_id = created_tag.json()["id"].split("/")[-1]
 
     response = client.delete(f"{TAGS_URL}/{tag_id}")
+    assert response.status_code == 401
+
+    # Ensure tag is still present in database
+    response = client.get(f"{TAGS_URL}/{tag_id}")
     assert response.status_code == 200
 
-    get_response = client.get(f"{TAGS_URL}/{tag_id}")
-    assert get_response.status_code == 404

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -123,6 +123,13 @@ def test_get_tag(
     tag_url = created_tag.json()["id"]
     tag_id = tag_url.split("/")[-1]
 
+    response = client.get(f"{TAGS_URL}/{tag_id}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["names"]) == 2
+
+    # Test if nl header only gives nl tag
     response = client.get(f"{TAGS_URL}/{tag_id}", headers={"Accept-Language": "nl"})
     assert response.status_code == 200
 
@@ -130,6 +137,7 @@ def test_get_tag(
     assert len(data["names"]) == 1
     assert data["names"][0]["name"] == "tag1_nl"
 
+    # Test if en header only gives en tag
     response = client.get(f"{TAGS_URL}/{tag_id}", headers={"Accept-Language": "en"})
     assert response.status_code == 200
 

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -10,44 +10,40 @@ from src.services.auth.permissions import Permissions
 
 TAGS_URL = "/api/v1/archive/tags"
 
+
 @pytest.fixture
 def language_nl(db_session: Session):
-    lang = Language(
-        id=1,
-        language="nl"
-    )
+    lang = Language(id=1, language="nl")
 
     db_session.add(lang)
     db_session.commit()
     db_session.refresh(lang)
 
     return lang
+
 
 @pytest.fixture
 def language_en(db_session: Session):
-    lang = Language(
-        id=2,
-        language="en"
-    )
+    lang = Language(id=2, language="en")
 
     db_session.add(lang)
     db_session.commit()
     db_session.refresh(lang)
 
     return lang
+
 
 @pytest.fixture
 def create_headers(client: TestClient, db_session: Session):
     return create_user_and_login(
-        client, 
-        db_session, 
-        "create_tag_user", 
-        permissions=[Permissions.ARCHIVE_CREATE]
+        client, db_session, "create_tag_user", permissions=[Permissions.ARCHIVE_CREATE]
     )
 
 
 # gekopieerd van PR #42, kan deze niet beter in een aparte file?
-def create_user_and_login(client: TestClient, db_session: Session, username: str, permissions=None):
+def create_user_and_login(
+    client: TestClient, db_session: Session, username: str, permissions=None
+):
     password = "test_pw"
     hashed = get_password_hash(password)
 
@@ -56,6 +52,7 @@ def create_user_and_login(client: TestClient, db_session: Session, username: str
     # Voeg Permission objecten toe
     if permissions:
         from src.models.permission import Permission
+
         perm_objs = []
         for p in permissions:
             perm = db_session.query(Permission).filter_by(name=p).first()
@@ -72,8 +69,7 @@ def create_user_and_login(client: TestClient, db_session: Session, username: str
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/",
-        json={"username": username, "password": password}
+        "/api/v1/auth/login/", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]
@@ -88,7 +84,7 @@ def test_create_tag(client: TestClient, create_headers, language_nl: Language):
                 {"language_id": language_nl.id, "name": "tag1"},
             ]
         },
-        headers=create_headers
+        headers=create_headers,
     )
     assert response.status_code == 200
 
@@ -110,16 +106,18 @@ def test_create_tag_unauthorized(client: TestClient, language_nl: Language):
     assert response.status_code == 401
 
 
-def test_get_tag(client: TestClient, create_headers, language_nl: Language, language_en: Language):
+def test_get_tag(
+    client: TestClient, create_headers, language_nl: Language, language_en: Language
+):
     created_tag = client.post(
         TAGS_URL,
         json={
             "names": [
                 {"language_id": language_nl.id, "name": "tag1_nl"},
-                {"language_id": language_en.id, "name": "tag1_en"}
+                {"language_id": language_en.id, "name": "tag1_en"},
             ]
         },
-        headers=create_headers
+        headers=create_headers,
     )
 
     tag_url = created_tag.json()["id"]
@@ -131,7 +129,7 @@ def test_get_tag(client: TestClient, create_headers, language_nl: Language, lang
     data = response.json()
     assert len(data["names"]) == 1
     assert data["names"][0]["name"] == "tag1_nl"
-    
+
     response = client.get(f"{TAGS_URL}/{tag_id}", headers={"Accept-Language": "en"})
     assert response.status_code == 200
 
@@ -140,7 +138,9 @@ def test_get_tag(client: TestClient, create_headers, language_nl: Language, lang
     assert data["names"][0]["name"] == "tag1_en"
 
 
-def test_get_tags(client: TestClient, create_headers, language_nl: Language, language_en: Language):
+def test_get_tags(
+    client: TestClient, create_headers, language_nl: Language, language_en: Language
+):
     n = 5
     for i in range(n):
         client.post(
@@ -148,10 +148,10 @@ def test_get_tags(client: TestClient, create_headers, language_nl: Language, lan
             json={
                 "names": [
                     {"language_id": language_nl.id, "name": f"tag{i}_nl"},
-                    {"language_id": language_en.id, "name": f"tag{i}_en"}
+                    {"language_id": language_en.id, "name": f"tag{i}_en"},
                 ]
             },
-            headers=create_headers
+            headers=create_headers,
         )
 
     response = client.get(TAGS_URL, headers={"Accept-Language": "nl"})
@@ -161,38 +161,37 @@ def test_get_tags(client: TestClient, create_headers, language_nl: Language, lan
     assert len(data) == n
 
     for i in range(n):
-        assert(len(data[i]["names"]) == 1)
+        assert len(data[i]["names"]) == 1
         # check if all tags are present in list of tags (independent of order)
         assert any(data[j]["names"][0]["name"] == f"tag{i}_nl" for j in range(n))
 
 
-def test_patch_tag(client: TestClient, db_session: Session, create_headers, language_nl: Language, language_en: Language):
+def test_patch_tag(
+    client: TestClient,
+    db_session: Session,
+    create_headers,
+    language_nl: Language,
+    language_en: Language,
+):
     created_tag = client.post(
         TAGS_URL,
-        json={
-            "names": [
-                {"language_id": language_nl.id, "name": "tag1"}
-            ]
-        },
-        headers=create_headers
+        json={"names": [{"language_id": language_nl.id, "name": "tag1"}]},
+        headers=create_headers,
     )
     tag_id = created_tag.json()["id"].split("/")[-1]
 
     patch_headers = create_user_and_login(
-        client, 
-        db_session, 
-        "patch_tag_user", 
-        permissions=[Permissions.ARCHIVE_UPDATE]
+        client, db_session, "patch_tag_user", permissions=[Permissions.ARCHIVE_UPDATE]
     )
     response = client.patch(
         f"{TAGS_URL}/{tag_id}",
         json={
             "names": [
                 {"language_id": language_nl.id, "name": "tag1_updated"},
-                {"language_id": language_en.id, "name": "tag1_en"}
+                {"language_id": language_en.id, "name": "tag1_en"},
             ]
         },
-        headers=patch_headers
+        headers=patch_headers,
     )
     assert response.status_code == 200
 
@@ -204,15 +203,13 @@ def test_patch_tag(client: TestClient, db_session: Session, create_headers, lang
     assert names[language_en.id] == "tag1_en"
 
 
-def test_patch_tag_unauthorized(client: TestClient, create_headers, language_nl: Language, language_en: Language):
+def test_patch_tag_unauthorized(
+    client: TestClient, create_headers, language_nl: Language, language_en: Language
+):
     created_tag = client.post(
         TAGS_URL,
-        json={
-            "names": [
-                {"language_id": language_nl.id, "name": "tag1"}
-            ]
-        },
-        headers=create_headers
+        json={"names": [{"language_id": language_nl.id, "name": "tag1"}]},
+        headers=create_headers,
     )
     tag_id = created_tag.json()["id"].split("/")[-1]
 
@@ -221,7 +218,7 @@ def test_patch_tag_unauthorized(client: TestClient, create_headers, language_nl:
         json={
             "names": [
                 {"language_id": language_nl.id, "name": "tag1_updated"},
-                {"language_id": language_en.id, "name": "tag1_en"}
+                {"language_id": language_en.id, "name": "tag1_en"},
             ]
         },
     )
@@ -235,24 +232,19 @@ def test_patch_tag_unauthorized(client: TestClient, create_headers, language_nl:
     assert names[language_nl.id] == "tag1"
 
 
-def test_delete_tag(client: TestClient, db_session: Session, create_headers, language_nl: Language):
+def test_delete_tag(
+    client: TestClient, db_session: Session, create_headers, language_nl: Language
+):
     created_tag = client.post(
         TAGS_URL,
-        json={
-            "names": [
-                {"language_id": language_nl.id, "name": "tag1"}
-            ]
-        },
-        headers=create_headers
+        json={"names": [{"language_id": language_nl.id, "name": "tag1"}]},
+        headers=create_headers,
     )
 
     tag_id = created_tag.json()["id"].split("/")[-1]
 
     delete_headers = create_user_and_login(
-        client, 
-        db_session, 
-        "delete_tag_user", 
-        permissions=[Permissions.ARCHIVE_DELETE]
+        client, db_session, "delete_tag_user", permissions=[Permissions.ARCHIVE_DELETE]
     )
     response = client.delete(f"{TAGS_URL}/{tag_id}", headers=delete_headers)
     assert response.status_code == 200
@@ -264,12 +256,8 @@ def test_delete_tag(client: TestClient, db_session: Session, create_headers, lan
 def test_delete_unauthorized(client: TestClient, create_headers, language_nl: Language):
     created_tag = client.post(
         TAGS_URL,
-        json={
-            "names": [
-                {"language_id": language_nl.id, "name": "tag1"}
-            ]
-        },
-        headers=create_headers
+        json={"names": [{"language_id": language_nl.id, "name": "tag1"}]},
+        headers=create_headers,
     )
 
     tag_id = created_tag.json()["id"].split("/")[-1]
@@ -280,4 +268,3 @@ def test_delete_unauthorized(client: TestClient, create_headers, language_nl: La
     # Ensure tag is still present in database
     response = client.get(f"{TAGS_URL}/{tag_id}")
     assert response.status_code == 200
-

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -11,10 +11,10 @@ from src.services.auth.permissions import Permissions
 TAGS_URL = "/api/v1/archive/tags"
 
 @pytest.fixture
-def language(db_session: Session):
+def language_nl(db_session: Session):
     lang = Language(
         id=1,
-        language="English"
+        language="nl"
     )
 
     db_session.add(lang)
@@ -22,6 +22,21 @@ def language(db_session: Session):
     db_session.refresh(lang)
 
     return lang
+
+@pytest.fixture
+def language_en(db_session: Session):
+    lang = Language(
+        id=2,
+        language="en"
+    )
+
+    db_session.add(lang)
+    db_session.commit()
+    db_session.refresh(lang)
+
+    return lang
+
+
 
 @pytest.fixture
 def create_headers(client: TestClient, db_session: Session):
@@ -67,12 +82,12 @@ def create_user_and_login(client: TestClient, db_session: Session, username: str
     return {"Authorization": f"Bearer {token}"}
 
 
-def test_create_tag(client: TestClient, create_headers, language: Language):
+def test_create_tag(client: TestClient, create_headers, language_nl: Language):
     response = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language.id, "name": "tag1"},
+                {"language_id": language_nl.id, "name": "tag1"},
             ]
         },
         headers=create_headers
@@ -85,24 +100,24 @@ def test_create_tag(client: TestClient, create_headers, language: Language):
     assert data["names"][0]["name"] == "tag1"
 
 
-def test_create_tag_unauthorized(client: TestClient, language: Language):
+def test_create_tag_unauthorized(client: TestClient, language_nl: Language):
     response = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language.id, "name": "tag1"},
+                {"language_id": language_nl.id, "name": "tag1"},
             ]
         },
     )
     assert response.status_code == 401
 
 
-def test_get_tag(client: TestClient, create_headers, language: Language):
+def test_get_tag(client: TestClient, create_headers, language_nl: Language):
     created_tag = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language.id, "name": "tag1"}
+                {"language_id": language_nl.id, "name": "tag1"}
             ]
         },
         headers=create_headers
@@ -118,14 +133,14 @@ def test_get_tag(client: TestClient, create_headers, language: Language):
     assert data["names"][0]["name"] == "tag1"
 
 
-def test_get_tags(client: TestClient, create_headers, language: Language):
+def test_get_tags(client: TestClient, create_headers, language_nl: Language):
     n = 5
     for i in range(n):
         client.post(
             TAGS_URL,
             json={
                 "names": [
-                    {"language_id": language.id, "name": f"tag{i}"}
+                    {"language_id": language_nl.id, "name": f"tag{i}"}
                 ]
             },
             headers=create_headers
@@ -142,12 +157,81 @@ def test_get_tags(client: TestClient, create_headers, language: Language):
         assert any(data[j]["names"][0]["name"] == f"tag{i}" for j in range(n))
 
 
-def test_delete_tag(client: TestClient, db_session: Session, create_headers, language: Language):
+def test_patch_tag(client: TestClient, db_session: Session, create_headers, language_nl: Language, language_en: Language):
     created_tag = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language.id, "name": "tag1"}
+                {"language_id": language_nl.id, "name": "tag1"}
+            ]
+        },
+        headers=create_headers
+    )
+    tag_id = created_tag.json()["id"].split("/")[-1]
+
+    patch_headers = create_user_and_login(
+        client, 
+        db_session, 
+        "patch_tag_user", 
+        permissions=[Permissions.ARCHIVE_UPDATE]
+    )
+    response = client.patch(
+        f"{TAGS_URL}/{tag_id}",
+        json={
+            "names": [
+                {"language_id": language_nl.id, "name": "tag1_updated"},
+                {"language_id": language_en.id, "name": "tag1_en"}
+            ]
+        },
+        headers=patch_headers
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["names"]) == 2
+
+    names = {n["language_id"]: n["name"] for n in data["names"]}
+    assert names[language_nl.id] == "tag1_updated"
+    assert names[language_en.id] == "tag1_en"
+
+
+def test_patch_tag_unauthorized(client: TestClient, create_headers, language_nl: Language, language_en: Language):
+    created_tag = client.post(
+        TAGS_URL,
+        json={
+            "names": [
+                {"language_id": language_nl.id, "name": "tag1"}
+            ]
+        },
+        headers=create_headers
+    )
+    tag_id = created_tag.json()["id"].split("/")[-1]
+
+    response = client.patch(
+        f"{TAGS_URL}/{tag_id}",
+        json={
+            "names": [
+                {"language_id": language_nl.id, "name": "tag1_updated"},
+                {"language_id": language_en.id, "name": "tag1_en"}
+            ]
+        },
+    )
+    assert response.status_code == 401
+
+    get_response = client.get(f"{TAGS_URL}/{tag_id}")
+    data = get_response.json()
+    assert len(data["names"]) == 1
+
+    names = {n["language_id"]: n["name"] for n in data["names"]}
+    assert names[language_nl.id] == "tag1"
+
+
+def test_delete_tag(client: TestClient, db_session: Session, create_headers, language_nl: Language):
+    created_tag = client.post(
+        TAGS_URL,
+        json={
+            "names": [
+                {"language_id": language_nl.id, "name": "tag1"}
             ]
         },
         headers=create_headers
@@ -168,12 +252,12 @@ def test_delete_tag(client: TestClient, db_session: Session, create_headers, lan
     assert get_response.status_code == 404
 
 
-def test_delete_unauthorized(client: TestClient, create_headers, language: Language):
+def test_delete_unauthorized(client: TestClient, create_headers, language_nl: Language):
     created_tag = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language.id, "name": "tag1"}
+                {"language_id": language_nl.id, "name": "tag1"}
             ]
         },
         headers=create_headers

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -86,7 +86,7 @@ def test_create_tag(client: TestClient, create_headers, language_nl: Language):
         },
         headers=create_headers,
     )
-    assert response.status_code == 200
+    assert response.status_code == 201
 
     data = response.json()
     assert "id" in data
@@ -255,7 +255,7 @@ def test_delete_tag(
         client, db_session, "delete_tag_user", permissions=[Permissions.ARCHIVE_DELETE]
     )
     response = client.delete(f"{TAGS_URL}/{tag_id}", headers=delete_headers)
-    assert response.status_code == 200
+    assert response.status_code == 204
 
     get_response = client.get(f"{TAGS_URL}/{tag_id}")
     assert get_response.status_code == 404

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -66,6 +66,10 @@ def test_get_tags(client, language):
 
     assert len(data) == n
 
+    for i in range(n):
+        # check if all tags are present in list of tags (independent of order)
+        assert any(data[j]["names"][0]["name"] == f"tag{i}" for j in range(n))
+
 
 def test_delete_tag(client, language):
     created_tag = client.post(

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -36,8 +36,6 @@ def language_en(db_session: Session):
 
     return lang
 
-
-
 @pytest.fixture
 def create_headers(client: TestClient, db_session: Session):
     return create_user_and_login(
@@ -112,12 +110,13 @@ def test_create_tag_unauthorized(client: TestClient, language_nl: Language):
     assert response.status_code == 401
 
 
-def test_get_tag(client: TestClient, create_headers, language_nl: Language):
+def test_get_tag(client: TestClient, create_headers, language_nl: Language, language_en: Language):
     created_tag = client.post(
         TAGS_URL,
         json={
             "names": [
-                {"language_id": language_nl.id, "name": "tag1"}
+                {"language_id": language_nl.id, "name": "tag1_nl"},
+                {"language_id": language_en.id, "name": "tag1_en"}
             ]
         },
         headers=create_headers
@@ -126,35 +125,45 @@ def test_get_tag(client: TestClient, create_headers, language_nl: Language):
     tag_url = created_tag.json()["id"]
     tag_id = tag_url.split("/")[-1]
 
-    response = client.get(f"{TAGS_URL}/{tag_id}")
+    response = client.get(f"{TAGS_URL}/{tag_id}", headers={"Accept-Language": "nl"})
     assert response.status_code == 200
 
     data = response.json()
-    assert data["names"][0]["name"] == "tag1"
+    assert len(data["names"]) == 1
+    assert data["names"][0]["name"] == "tag1_nl"
+    
+    response = client.get(f"{TAGS_URL}/{tag_id}", headers={"Accept-Language": "en"})
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data["names"]) == 1
+    assert data["names"][0]["name"] == "tag1_en"
 
 
-def test_get_tags(client: TestClient, create_headers, language_nl: Language):
+def test_get_tags(client: TestClient, create_headers, language_nl: Language, language_en: Language):
     n = 5
     for i in range(n):
         client.post(
             TAGS_URL,
             json={
                 "names": [
-                    {"language_id": language_nl.id, "name": f"tag{i}"}
+                    {"language_id": language_nl.id, "name": f"tag{i}_nl"},
+                    {"language_id": language_en.id, "name": f"tag{i}_en"}
                 ]
             },
             headers=create_headers
         )
 
-    response = client.get(TAGS_URL)
+    response = client.get(TAGS_URL, headers={"Accept-Language": "nl"})
     assert response.status_code == 200
     data = response.json()
 
     assert len(data) == n
 
     for i in range(n):
+        assert(len(data[i]["names"]) == 1)
         # check if all tags are present in list of tags (independent of order)
-        assert any(data[j]["names"][0]["name"] == f"tag{i}" for j in range(n))
+        assert any(data[j]["names"][0]["name"] == f"tag{i}_nl" for j in range(n))
 
 
 def test_patch_tag(client: TestClient, db_session: Session, create_headers, language_nl: Language, language_en: Language):

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -1,0 +1,82 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from src.models.language import Language
+
+TAGS_URL = "/api/v1/archive/tags"
+
+@pytest.fixture
+def language(db_session: Session):
+    lang = Language(
+        id=1,
+        language="English"
+    )
+
+    db_session.add(lang)
+    db_session.commit()
+    db_session.refresh(lang)
+
+    return lang
+
+def test_create_tag(client, language):
+    response = client.post(
+        TAGS_URL,
+        json={
+            "names": [
+                {"language_id": language.id, "name": "tag_1"},
+            ]
+        }
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "id" in data
+    assert len(data["names"]) == 1
+    assert data["names"][0]["name"] == "tag_1"
+
+
+def test_get_tag(client, language):
+    created_tag = client.post(
+        TAGS_URL,
+        json={"names": [{"language_id": language.id, "name": "tag1"}]}
+    )
+
+    tag_url = created_tag.json()["id"]
+    tag_id = tag_url.split("/")[-1]
+
+    response = client.get(f"{TAGS_URL}/{tag_id}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["names"][0]["name"] == "tag1"
+
+
+
+def test_get_tags(client, language):
+    n = 5
+    for i in range(n):
+        client.post(
+            TAGS_URL,
+            json={"names": [{"language_id": language.id, "name": f"tag{i}"}]}
+        )
+
+    response = client.get(TAGS_URL)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data) == n
+
+
+def test_delete_tag(client, language):
+    created_tag = client.post(
+        TAGS_URL,
+        json={"names": [{"language_id": language.id, "name": "tag1"}]}
+    )
+
+    tag_id = created_tag.json()["id"].split("/")[-1]
+
+    response = client.delete(f"{TAGS_URL}/{tag_id}")
+    assert response.status_code == 200
+
+    get_response = client.get(f"{TAGS_URL}/{tag_id}")
+    assert get_response.status_code == 404

--- a/backend/tests/unit/test_tag_service.py
+++ b/backend/tests/unit/test_tag_service.py
@@ -1,0 +1,160 @@
+import pytest
+
+from src.services.tag import (
+    get_tags_list,
+    get_tag_by_id,
+    create_tag,
+    update_tag,
+    delete_tag_by_id,
+    get_names_for_language,
+)
+
+from src.models.tag import Tag, TagName
+from src.models.language import Language
+from src.schemas.tag import TagCreate, TagNameBase
+
+BASE_URL = "http://test"
+
+
+@pytest.fixture
+def language_nl(db_session):
+    lang = Language(id=1, language="nl")
+    db_session.add(lang)
+    db_session.commit()
+    return lang
+
+
+@pytest.fixture
+def language_en(db_session):
+    lang = Language(id=2, language="en")
+    db_session.add(lang)
+    db_session.commit()
+    return lang
+
+
+@pytest.fixture
+def tag(db_session, language_nl, language_en):
+    tag = Tag()
+    db_session.add(tag)
+    db_session.flush()
+
+    name_nl = TagName(tag_id=tag.id, language_id=language_nl.id, name="tag_nl")
+    name_en = TagName(tag_id=tag.id, language_id=language_en.id, name="tag_en")
+
+    db_session.add_all([name_nl, name_en])
+    db_session.commit()
+
+    db_session.refresh(tag)
+    return tag
+
+
+def test_get_tags_list(db_session, tag):
+    result = get_tags_list(db_session, BASE_URL)
+
+    assert len(result) == 1
+    assert result[0].id == f"{BASE_URL}/tags/{tag.id}"
+    assert len(result[0].names) == 2
+
+
+@pytest.mark.usefixtures("tag")
+def test_get_tags_list_language_filter(db_session):
+    result = get_tags_list(db_session, BASE_URL, "nl")
+
+    assert len(result) == 1
+    assert len(result[0].names) == 1
+    assert result[0].names[0].name == "tag_nl"
+
+
+def test_get_tag_by_id_success(db_session, tag):
+    result = get_tag_by_id(db_session, tag.id, BASE_URL)
+
+    assert result.id == f"{BASE_URL}/tags/{tag.id}"
+    assert len(result.names) == 2
+
+
+def test_get_tag_by_id_language_filter(db_session, tag):
+    result = get_tag_by_id(db_session, tag.id, BASE_URL, "en")
+
+    assert len(result.names) == 1
+    assert result.names[0].name == "tag_en"
+
+
+def test_get_tag_by_id_not_found(db_session):
+    with pytest.raises(ValueError):
+        get_tag_by_id(db_session, 999, BASE_URL)
+
+
+def test_create_tag(db_session, language_nl, language_en):
+    tag_in = TagCreate(
+        names=[
+            TagNameBase(language_id=language_nl.id, name="tag_nl"),
+            TagNameBase(language_id=language_en.id, name="tag_en"),
+        ]
+    )
+
+    result = create_tag(db_session, tag_in, BASE_URL)
+
+    assert result.id.startswith(f"{BASE_URL}/tags/")
+    assert len(result.names) == 2
+
+    names = {n.language_id: n.name for n in result.names}
+    assert names[language_nl.id] == "tag_nl"
+    assert names[language_en.id] == "tag_en"
+
+
+def test_update_tag_existing_and_new_language(
+    db_session, tag, language_nl, language_en
+):
+    tag_in = TagCreate(
+        names=[
+            TagNameBase(language_id=language_nl.id, name="updated_nl"),
+            TagNameBase(language_id=language_en.id, name="new_en"),
+        ]
+    )
+
+    result = update_tag(db_session, tag.id, tag_in, BASE_URL)
+
+    assert len(result.names) == 2
+
+    names = {n.language_id: n.name for n in result.names}
+    assert names[language_nl.id] == "updated_nl"
+    assert names[language_en.id] == "new_en"
+
+
+def test_update_tag_not_found(db_session, language_nl):
+    tag_in = TagCreate(names=[TagNameBase(language_id=language_nl.id, name="tag")])
+
+    with pytest.raises(ValueError):
+        update_tag(db_session, 999, tag_in, BASE_URL)
+
+
+def test_delete_tag_success(db_session, tag):
+    result = delete_tag_by_id(db_session, tag.id)
+
+    assert result is True
+
+
+def test_delete_tag_not_found(db_session):
+    result = delete_tag_by_id(db_session, 999)
+
+    assert result is False
+
+
+def test_get_names_for_language_found(tag):
+    result = get_names_for_language(tag.names, "nl")
+
+    assert len(result) == 1
+    assert result[0].name == "tag_nl"
+
+
+def test_get_names_for_language_not_found(tag):
+    result = get_names_for_language(tag.names, "fr")
+
+    # fallback returns all names
+    assert len(result) == 2
+
+
+def test_get_names_for_language_none(tag):
+    result = get_names_for_language(tag.names, None)
+
+    assert len(result) == 2


### PR DESCRIPTION
### Beschrijving
Deze branch implementeert al de functionaliteit voor 

### Aangepaste delen
- Schema voor tags
- Functies voor het query'en, aanmaken, aanpassen en verwijderen van data over tags en tag namen 
- Accept-Language header support

### Speciale Opmerkingen
TagResponse bevat nog steeds een lijst van TagNames met language_id en name per TagName ookal is er een accept-language header meegegeven (deze lijst bevat dan enkel de TagName van de relevante taal) is dit ok of zou dit beter op een andere manier? 

Closes #47 

- [x] Auteur wil zelf mergen.
