### PR TITLE
Feat/60 user id in jwt

### DIFF
--- a/backend/src/api/dependencies/auth.py
+++ b/backend/src/api/dependencies/auth.py
@@ -15,7 +15,7 @@ def get_current_user(
     token: HTTPAuthorizationCredentials = Depends(security_scheme),
 ) -> User:
     token_data = auth_service.decode_access_token(token.credentials)
-    user = auth_service.get_user(db, username=token_data.username)
+    user = auth_service.get_user_by_id(db, user_id=token_data.user_id)
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/src/schemas/auth.py
+++ b/backend/src/schemas/auth.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UserBase(BaseModel):
@@ -30,9 +30,9 @@ class AccessTokenResponse(BaseModel):
 
 
 class TokenData(BaseModel):
-    username: Optional[str] = None
-    roles: List[str] = []
-    permissions: List[str] = []
+    user_id: int
+    roles: List[str] = Field(default_factory=list)
+    permissions: List[str] = Field(default_factory=list)
 
 
 class LoginRequest(BaseModel):

--- a/backend/src/services/auth/__init__.py
+++ b/backend/src/services/auth/__init__.py
@@ -5,20 +5,25 @@ from src.services.auth.flows import (
 )
 from src.services.auth.password import get_password_hash, verify_password
 from src.services.auth.token import (
+    build_user_subject,
     create_access_token,
     create_refresh_token,
     decode_access_token,
+    get_token_subject_user_id,
 )
-from src.services.auth.user import get_user
+from src.services.auth.user import get_user, get_user_by_id
 
 __all__ = [
     "get_password_hash",
     "verify_password",
+    "build_user_subject",
     "create_access_token",
     "create_refresh_token",
     "decode_access_token",
+    "get_token_subject_user_id",
     "authenticate_user",
     "login_user",
     "refresh_access_token",
     "get_user",
+    "get_user_by_id",
 ]

--- a/backend/src/services/auth/flows.py
+++ b/backend/src/services/auth/flows.py
@@ -10,10 +10,12 @@ from src.schemas.auth import AccessTokenResponse, Token
 from src.services.auth.password import verify_password
 from src.services.auth.token import (
     build_token_data,
+    build_user_subject,
     create_access_token,
     create_refresh_token,
+    get_token_subject_user_id,
 )
-from src.services.auth.user import get_user
+from src.services.auth.user import get_user, get_user_by_id
 
 
 def authenticate_user(db: Session, username: str, password: str) -> Optional[User]:
@@ -32,7 +34,7 @@ def login_user(db: Session, username: str, password: str) -> Token:
             headers={"WWW-Authenticate": "Bearer"},
         )
     access_token = create_access_token(data=build_token_data(user))
-    refresh_token = create_refresh_token(data={"sub": user.username})
+    refresh_token = create_refresh_token(data={"sub": build_user_subject(user)})
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()
     return Token(access_token=access_token, refresh_token=refresh_token)
@@ -46,13 +48,11 @@ def refresh_access_token(db: Session, refresh_token: str) -> AccessTokenResponse
         payload = jwt.decode(
             refresh_token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
         )
-        username: str = payload.get("sub")
-        if username is None:
-            raise invalid
-    except jwt.PyJWTError as exc:
+        user_id = get_token_subject_user_id(payload)
+    except (jwt.PyJWTError, ValueError) as exc:
         raise invalid from exc
 
-    user = get_user(db, username=username)
+    user = get_user_by_id(db, user_id=user_id)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"

--- a/backend/src/services/auth/token.py
+++ b/backend/src/services/auth/token.py
@@ -8,6 +8,12 @@ from src.models.user import User
 from src.schemas.auth import TokenData
 
 
+def build_user_subject(user: User) -> str:
+    if user.id is None:
+        raise ValueError("Cannot issue a token for a user without an ID")
+    return str(user.id)
+
+
 def build_token_data(user: User) -> dict:
     roles = [role.name for role in user.roles]
     permissions = set()
@@ -15,10 +21,21 @@ def build_token_data(user: User) -> dict:
         for perm in role.permissions:
             permissions.add(perm.name)
     return {
-        "sub": user.username,
+        "sub": build_user_subject(user),
         "roles": roles,
         "permissions": sorted(permissions),
     }
+
+
+def get_token_subject_user_id(payload: dict) -> int:
+    subject = payload.get("sub")
+    if subject is None:
+        raise ValueError("Token subject is missing")
+
+    try:
+        return int(subject)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Token subject must be a valid user ID") from exc
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
@@ -53,13 +70,11 @@ def decode_access_token(token: str) -> TokenData:
         payload = jwt.decode(
             token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM]
         )
-        username: str = payload.get("sub")
-        if username is None:
-            raise credentials_exception
+        user_id = get_token_subject_user_id(payload)
         return TokenData(
-            username=username,
+            user_id=user_id,
             roles=payload.get("roles", []),
             permissions=payload.get("permissions", []),
         )
-    except jwt.PyJWTError as exc:
+    except (jwt.PyJWTError, ValueError) as exc:
         raise credentials_exception from exc

--- a/backend/src/services/auth/user.py
+++ b/backend/src/services/auth/user.py
@@ -9,6 +9,10 @@ def get_user(db: Session, username: str) -> Optional[User]:
     return db.query(User).filter(User.username == username).first()
 
 
+def get_user_by_id(db: Session, user_id: int) -> Optional[User]:
+    return db.query(User).filter(User.id == user_id).first()
+
+
 def get_user_profile(user: User) -> UserResponse:
     roles = [role.name for role in user.roles]
     permissions = set()

--- a/backend/tests/integration/test_auth_endpoints.py
+++ b/backend/tests/integration/test_auth_endpoints.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from src.models.user import User
 from src.services.auth.password import get_password_hash
+from src.services.auth.token import decode_access_token
 
 
 def test_login_integration(client: TestClient, db_session: Session):
@@ -20,6 +21,8 @@ def test_login_integration(client: TestClient, db_session: Session):
     assert "access_token" in data
     assert "refresh_token" in data
     assert data["token_type"] == "bearer"
+    assert decode_access_token(data["access_token"]).user_id == user.id
+    assert decode_access_token(data["refresh_token"]).user_id == user.id
 
 
 def test_login_integration_fail(client: TestClient):
@@ -71,3 +74,4 @@ def test_refresh_token_integration(client: TestClient, db_session: Session):
     data = response.json()
     assert "access_token" in data
     assert data["token_type"] == "bearer"
+    assert decode_access_token(data["access_token"]).user_id == user.id

--- a/backend/tests/unit/test_auth_flows.py
+++ b/backend/tests/unit/test_auth_flows.py
@@ -7,6 +7,7 @@ from src.services.auth.flows import (
     refresh_access_token,
 )
 from src.services.auth.password import get_password_hash
+from src.services.auth.token import decode_access_token
 
 
 def test_authenticate_user_success(db_session: Session):
@@ -48,6 +49,8 @@ def test_login_user_success(db_session: Session):
     assert isinstance(token, Token)
     assert token.access_token is not None
     assert token.refresh_token is not None
+    assert decode_access_token(token.access_token).user_id == user.id
+    assert decode_access_token(token.refresh_token).user_id == user.id
 
 
 def test_refresh_access_token_success(db_session: Session):
@@ -62,3 +65,4 @@ def test_refresh_access_token_success(db_session: Session):
     new_access_token_resp = refresh_access_token(db_session, tokens.refresh_token)
     assert isinstance(new_access_token_resp, AccessTokenResponse)
     assert new_access_token_resp.access_token is not None
+    assert decode_access_token(new_access_token_resp.access_token).user_id == user.id

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -27,32 +27,33 @@ def test_password_hashing():
 def test_token_creation_and_decoding():
     perm = Permission(name="test:perm")
     role = Role(name="test_role", permissions=[perm])
-    user = User(username="testuser", roles=[role])
+    user = User(id=123, username="testuser", roles=[role])
 
     token_data = build_token_data(user)
     access_token = create_access_token(data=token_data)
 
     decoded = decode_access_token(access_token)
-    assert decoded.username == "testuser"
+    assert decoded.user_id == 123
     assert "test_role" in decoded.roles
     assert "test:perm" in decoded.permissions
 
 
 def test_refresh_token_creation():
-    data = {"sub": "testuser"}
+    data = {"sub": "123"}
     refresh_token = create_refresh_token(data=data)
     decoded = decode_access_token(refresh_token)
-    assert decoded.username == "testuser"
+    assert decoded.user_id == 123
 
 
 def test_invalid_token():
-    with pytest.raises(Exception):
+    with pytest.raises(HTTPException) as excinfo:
         decode_access_token("invalid_token")
+    assert excinfo.value.status_code == 401
 
 
 def test_expired_token():
     data = {
-        "sub": "testuser",
+        "sub": "123",
         "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
     }
     expired_token = jwt.encode(
@@ -66,6 +67,14 @@ def test_expired_token():
 
 def test_token_missing_sub():
     data = {"roles": [], "permissions": []}
+    token = jwt.encode(data, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+    with pytest.raises(HTTPException) as excinfo:
+        decode_access_token(token)
+    assert excinfo.value.status_code == 401
+
+
+def test_token_with_non_numeric_sub():
+    data = {"sub": "testuser", "roles": [], "permissions": []}
     token = jwt.encode(data, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
     with pytest.raises(HTTPException) as excinfo:
         decode_access_token(token)


### PR DESCRIPTION
### Beschrijving
We gebruikten de username in het `sub` veld van de jwt token, voor betere consistency en user handling is dit verandert naar de user-id. 


Closes  #60 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
