### PR TITLE
71 feat manuele cd workflow dispatch

### DIFF
--- a/docs/manual_cd.md
+++ b/docs/manual_cd.md
@@ -1,0 +1,26 @@
+# CD pipeline manueel triggeren
+
+## GitHub CLI installeren
+```bash
+sudo apt install gh
+```
+
+## Authenticeren
+Maak een personal access token aan met `workflow` scope:
+Github → Settings (van account) → Developer settings (helemaal onderaan) → Personal access tokens → Tokens (classic) → genereer met `workflow` scope aangevinkt.
+
+Authenticeer dan:
+```bash
+gh auth login
+# Kies: GitHub.com → HTTPS → plak je token
+```
+
+## Deploy triggeren op `dev`
+```bash
+gh workflow run cd.yaml --repo SELab-2/viernulvier-3 --ref dev
+```
+
+## Run bekijken
+```bash
+gh run watch --repo SELab-2/viernulvier-3
+```

--- a/docs/manual_cd.md
+++ b/docs/manual_cd.md
@@ -1,9 +1,21 @@
 # CD pipeline manueel triggeren
 
 ## GitHub CLI installeren
+**Ubuntu/Debian**
 ```bash
 sudo apt install gh
 ```
+
+**Arch Linux**
+```bash
+sudo pacman -S github-cli
+```
+
+**Windows**
+```powershell
+winget install GitHub.cli
+```
+Of via [cli.github.com](https://cli.github.com) de installer downloaden.
 
 ## Authenticeren
 Maak een personal access token aan met `workflow` scope:


### PR DESCRIPTION
### Beschrijving
Instructies voor manuele CD trigger. Na setup kunnen de commando's lokaal worden uitgevoerd om de server de CD workflow te laten doen. Hier is geen SSH connectie met de server voor nodig. 


### Aangepaste delen
Nieuwe doc toegevoegd

Closes #71 

