### PR TITLE
Bug/fix urls

### DIFF
--- a/backend/src/api/v1/archive/events.py
+++ b/backend/src/api/v1/archive/events.py
@@ -67,7 +67,7 @@ def patch_event(
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
     base_url = get_base_url(request, 2)
-    
+
     try:
         return update_event(db, event_id, update_data, base_url)
     except ValueError as e:

--- a/backend/src/api/v1/archive/events.py
+++ b/backend/src/api/v1/archive/events.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 @router.get("/{event_id}", response_model=EventResponse)
 def get_event(event_id: int, request: Request, db: Session = Depends(get_db)):
-    base_url = get_base_url(request, 2)
+    base_url = get_base_url(str(request.url), 2)
 
     try:
         event_data = get_event_by_id(db, event_id, base_url)
@@ -50,7 +50,7 @@ def post_event(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ):
-    base_url = get_base_url(request)
+    base_url = get_base_url(str(request.url))
 
     try:
         return create_event(db, event_in, base_url)
@@ -66,7 +66,7 @@ def patch_event(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
-    base_url = get_base_url(request, 2)
+    base_url = get_base_url(str(request.url), 2)
 
     try:
         return update_event(db, event_id, update_data, base_url)
@@ -76,7 +76,7 @@ def patch_event(
 
 @router.get("/{event_id}/prices", response_model=list[PriceResponse])
 def get_event_prices(event_id: int, request: Request, db: Session = Depends(get_db)):
-    base_url = get_base_url(request, 3)
+    base_url = get_base_url(str(request.url), 3)
 
     try:
         return get_prices_for_event(db, event_id, base_url)
@@ -88,7 +88,7 @@ def get_event_prices(event_id: int, request: Request, db: Session = Depends(get_
 def get_price(
     event_id: int, price_id: int, request: Request, db: Session = Depends(get_db)
 ):
-    base_url = get_base_url(request, 4)
+    base_url = get_base_url(str(request.url), 4)
 
     try:
         return get_event_price(db, event_id, price_id, base_url)

--- a/backend/src/api/v1/archive/events.py
+++ b/backend/src/api/v1/archive/events.py
@@ -9,17 +9,19 @@ from src.services.event_service import (
     get_prices_for_event,
     get_event_price,
 )
+
 from src.schemas.event import EventResponse, EventCreate, EventUpdate, PriceResponse
 from src.services.auth.permissions import Permissions
 from src.api.dependencies import RequirePermissions
 from src.models.user import User
+from src.services.archive import get_base_url
 
 router = APIRouter()
 
 
 @router.get("/{event_id}", response_model=EventResponse)
 def get_event(event_id: int, request: Request, db: Session = Depends(get_db)):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, 2)
 
     try:
         event_data = get_event_by_id(db, event_id, base_url)
@@ -48,7 +50,7 @@ def post_event(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request)
 
     try:
         return create_event(db, event_in, base_url)
@@ -64,8 +66,8 @@ def patch_event(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
-    base_url = str(request.base_url).rstrip("/")
-
+    base_url = get_base_url(request, 2)
+    
     try:
         return update_event(db, event_id, update_data, base_url)
     except ValueError as e:
@@ -74,7 +76,7 @@ def patch_event(
 
 @router.get("/{event_id}/prices", response_model=list[PriceResponse])
 def get_event_prices(event_id: int, request: Request, db: Session = Depends(get_db)):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, 3)
 
     try:
         return get_prices_for_event(db, event_id, base_url)
@@ -86,7 +88,7 @@ def get_event_prices(event_id: int, request: Request, db: Session = Depends(get_
 def get_price(
     event_id: int, price_id: int, request: Request, db: Session = Depends(get_db)
 ):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, 4)
 
     try:
         return get_event_price(db, event_id, price_id, base_url)

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -36,7 +36,7 @@ async def get_productions(
     cursor: int | None = Query(None),
     limit: int = Query(20, ge=1, le=50),
 ) -> ProductionListResponse:
-    base_url = get_base_url(request)
+    base_url = get_base_url(str(request.url))
     return get_productions_paginated(db, base_url, cursor, limit)
 
 
@@ -53,7 +53,7 @@ async def post_production(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ) -> ProductionResponse:
-    base_url = get_base_url(request)
+    base_url = get_base_url(str(request.url))
     try:
         production_data = create_production(db, production_in, base_url)
     except ValueError as e:
@@ -74,7 +74,7 @@ async def get_production(
     db: Session = Depends(get_db),
     language: str | None = Depends(get_accepted_language),
 ) -> ProductionResponse:
-    base_url = get_base_url(request, 2)
+    base_url = get_base_url(str(request.url), 2)
     try:
         production_data = get_production_by_id(db, production_id, base_url, language)
     except ValueError as e:
@@ -96,7 +96,7 @@ async def patch_production(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ) -> ProductionResponse:
-    base_url = get_base_url(request, 2)
+    base_url = get_base_url(str(request.url), 2)
     try:
         production_data = update_production_by_id(
             db, production_in, production_id, base_url

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Depends, Query, Request, HTTPException, status
 from src.services.auth.permissions import Permissions
 from src.api.dependencies import RequirePermissions
 from src.models.user import User
+from src.services.archive import get_base_url
 
 router = APIRouter()
 
@@ -35,7 +36,7 @@ async def get_productions(
     cursor: int | None = Query(None),
     limit: int = Query(20, ge=1, le=50),
 ) -> ProductionListResponse:
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request)
     return get_productions_paginated(db, base_url, cursor, limit)
 
 
@@ -52,7 +53,7 @@ async def post_production(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ) -> ProductionResponse:
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request)
     try:
         production_data = create_production(db, production_in, base_url)
     except ValueError as e:
@@ -73,7 +74,7 @@ async def get_production(
     db: Session = Depends(get_db),
     language: str | None = Depends(get_accepted_language),
 ) -> ProductionResponse:
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, 2)
     try:
         production_data = get_production_by_id(db, production_id, base_url, language)
     except ValueError as e:
@@ -95,7 +96,7 @@ async def patch_production(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ) -> ProductionResponse:
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, 2)
     try:
         production_data = update_production_by_id(
             db, production_in, production_id, base_url

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -14,6 +14,7 @@ from src.services.tag import (
     update_tag,
 )
 from src.services.auth.permissions import Permissions
+from src.services.archive import get_base_url
 from src.api.dependencies import RequirePermissions
 
 router = APIRouter()
@@ -30,7 +31,7 @@ async def get_tags(
     db: Session = Depends(get_db),
     language: str | None = Depends(get_accepted_language),
 ):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request)
     return get_tags_list(db, base_url, language)
 
 
@@ -46,7 +47,7 @@ def get_tag(
     db: Session = Depends(get_db),
     language: str | None = Depends(get_accepted_language),
 ):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, remove_last_segments=2)
     try:
         tag = get_tag_by_id(db, tag_id, base_url, language)
     except ValueError as e:
@@ -67,7 +68,7 @@ async def post_tag(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request)
     try:
         return create_tag(db, tag_in, base_url)
     except ValueError as e:
@@ -82,7 +83,7 @@ async def patch_tag(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request, remove_last_segments=2)
     try:
         return update_tag(db, tag_id, tag_in, base_url)
     except ValueError as e:

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -31,7 +31,7 @@ async def get_tags(
     db: Session = Depends(get_db),
     language: str | None = Depends(get_accepted_language),
 ):
-    base_url = get_base_url(request)
+    base_url = get_base_url(str(request.url))
     return get_tags_list(db, base_url, language)
 
 
@@ -47,7 +47,7 @@ def get_tag(
     db: Session = Depends(get_db),
     language: str | None = Depends(get_accepted_language),
 ):
-    base_url = get_base_url(request, remove_last_segments=2)
+    base_url = get_base_url(str(request.url), remove_last_segments=2)
     try:
         tag = get_tag_by_id(db, tag_id, base_url, language)
     except ValueError as e:
@@ -68,7 +68,7 @@ async def post_tag(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_CREATE])),
 ):
-    base_url = get_base_url(request)
+    base_url = get_base_url(str(request.url))
     try:
         return create_tag(db, tag_in, base_url)
     except ValueError as e:
@@ -83,7 +83,7 @@ async def patch_tag(
     db: Session = Depends(get_db),
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ):
-    base_url = get_base_url(request, remove_last_segments=2)
+    base_url = get_base_url(str(request.url), remove_last_segments=2)
     try:
         return update_tag(db, tag_id, tag_in, base_url)
     except ValueError as e:

--- a/backend/src/services/archive.py
+++ b/backend/src/services/archive.py
@@ -1,0 +1,18 @@
+from fastapi import Request
+
+def get_base_url(request: Request, remove_last_segments: int = 1):
+
+    full_url = str(request.url).rstrip('/')
+    
+    current_index = len(full_url) - 1
+    current_amount_removed = 0
+    while current_amount_removed < remove_last_segments:
+        if full_url[current_index] == '/':
+            current_amount_removed+=1
+        current_index-=1
+
+    base = full_url[:current_index+1]
+    
+    return base
+
+

--- a/backend/src/services/archive.py
+++ b/backend/src/services/archive.py
@@ -1,17 +1,20 @@
-from fastapi import Request
+from urllib.parse import urlparse, urlunparse
 
 
-def get_base_url(request: Request, remove_last_segments: int = 1):
+def get_base_url(url: str, remove_last_segments: int = 1) -> str:
+    """
+    Returns the base URL by removing a specified number of path segments from the end.
 
-    full_url = str(request.url).rstrip("/")
+    Examples:
+        >>> get_base_url("https://example.com/api/v1/users/", 1)
+        'https://example.com/api/v1'
+        >>> get_base_url("https://example.com/api/v1/users/", 2)
+        'https://example.com/api'
+    """
+    parsed = urlparse(url)
 
-    current_index = len(full_url) - 1
-    current_amount_removed = 0
-    while current_amount_removed < remove_last_segments:
-        if full_url[current_index] == "/":
-            current_amount_removed += 1
-        current_index -= 1
+    path_segments = parsed.path.rstrip("/").split("/")
 
-    base = full_url[: current_index + 1]
-
-    return base
+    new_path = "/".join(path_segments[:-remove_last_segments])
+    new_url = urlunparse(parsed._replace(path=new_path))
+    return new_url

--- a/backend/src/services/archive.py
+++ b/backend/src/services/archive.py
@@ -1,18 +1,17 @@
 from fastapi import Request
 
+
 def get_base_url(request: Request, remove_last_segments: int = 1):
 
-    full_url = str(request.url).rstrip('/')
-    
+    full_url = str(request.url).rstrip("/")
+
     current_index = len(full_url) - 1
     current_amount_removed = 0
     while current_amount_removed < remove_last_segments:
-        if full_url[current_index] == '/':
-            current_amount_removed+=1
-        current_index-=1
+        if full_url[current_index] == "/":
+            current_amount_removed += 1
+        current_index -= 1
 
-    base = full_url[:current_index+1]
-    
+    base = full_url[: current_index + 1]
+
     return base
-
-

--- a/backend/tests/integration/test_events_endpoint.py
+++ b/backend/tests/integration/test_events_endpoint.py
@@ -289,6 +289,9 @@ def test_event_url_contains_full_path(client: TestClient, db_session: Session):
 
     assert str(event.id) in event_url
 
+    response = client.get(event_url)
+    assert response.status_code == 200
+
 
 def test_event_price_url_contains_full_path(client: TestClient, db_session: Session):
 
@@ -314,3 +317,6 @@ def test_event_price_url_contains_full_path(client: TestClient, db_session: Sess
     assert f"/api/v1/archive/events/{event.id}/prices/{price.id}" in price_url
 
     assert str(price.id) in price_url
+
+    response = client.get(price_url)
+    assert response.status_code == 200

--- a/backend/tests/integration/test_events_endpoint.py
+++ b/backend/tests/integration/test_events_endpoint.py
@@ -261,3 +261,65 @@ def test_get_event_price_not_found(client: TestClient, db_session: Session):
     response = client.get(f"{BASE_URL}/{event.id}/prices/9999")
 
     assert response.status_code == 404
+
+
+
+def test_event_url_contains_full_path(client: TestClient, db_session: Session):
+
+    from src.models.hall import Hall
+    from src.models.production import Production
+    from src.models.event import Event
+
+
+    hall = Hall(name="Hall URL Test", address="Street URL Test")
+    production = Production()
+    db_session.add_all([hall, production])
+    db_session.commit()
+
+    event = Event(hall=hall, production=production, order_url="https://order_example")
+    db_session.add(event)
+    db_session.commit()
+
+
+    response = client.get(f"{BASE_URL}/{event.id}")
+    assert response.status_code == 200
+    data = response.json()
+
+   
+    event_url = data.get("id") 
+    assert event_url is not None
+
+    assert "/api/v1/archive/events" in event_url
+
+    assert str(event.id) in event_url
+    
+    
+    
+    
+def test_event_price_url_contains_full_path(client: TestClient, db_session: Session):
+
+    # setup
+    hall = Hall(name="Hall Price Test", address="Street Price Test")
+    production = Production()
+    event = Event(hall=hall, production=production, order_url="https://order_example")
+    db_session.add_all([hall, production, event])
+    db_session.commit()
+
+    price = EventPrice(event=event, amount=20.0, available=50)
+    db_session.add(price)
+    db_session.commit()
+
+    # actual request
+    response = client.get(f"{BASE_URL}/{event.id}/prices/{price.id}")
+    assert response.status_code == 200
+    data = response.json()
+
+
+    price_url = data.get("id") 
+    assert price_url is not None
+
+
+    assert f"/api/v1/archive/events/{event.id}/prices/{price.id}" in price_url
+
+
+    assert str(price.id) in price_url

--- a/backend/tests/integration/test_events_endpoint.py
+++ b/backend/tests/integration/test_events_endpoint.py
@@ -263,13 +263,11 @@ def test_get_event_price_not_found(client: TestClient, db_session: Session):
     assert response.status_code == 404
 
 
-
 def test_event_url_contains_full_path(client: TestClient, db_session: Session):
 
     from src.models.hall import Hall
     from src.models.production import Production
     from src.models.event import Event
-
 
     hall = Hall(name="Hall URL Test", address="Street URL Test")
     production = Production()
@@ -280,22 +278,18 @@ def test_event_url_contains_full_path(client: TestClient, db_session: Session):
     db_session.add(event)
     db_session.commit()
 
-
     response = client.get(f"{BASE_URL}/{event.id}")
     assert response.status_code == 200
     data = response.json()
 
-   
-    event_url = data.get("id") 
+    event_url = data.get("id")
     assert event_url is not None
 
     assert "/api/v1/archive/events" in event_url
 
     assert str(event.id) in event_url
-    
-    
-    
-    
+
+
 def test_event_price_url_contains_full_path(client: TestClient, db_session: Session):
 
     # setup
@@ -314,12 +308,9 @@ def test_event_price_url_contains_full_path(client: TestClient, db_session: Sess
     assert response.status_code == 200
     data = response.json()
 
-
-    price_url = data.get("id") 
+    price_url = data.get("id")
     assert price_url is not None
 
-
     assert f"/api/v1/archive/events/{event.id}/prices/{price.id}" in price_url
-
 
     assert str(price.id) in price_url

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -351,3 +351,41 @@ def test_delete_production_not_found(
     )
     response = client.delete(f"{BASE_URL}/100", headers=headers)
     assert response.status_code == 404
+
+
+
+def test_production_urls_contain_full_path(client: TestClient, db_session: Session):
+    from src.models.production import Production
+    from src.models.event import Event
+    from src.models.hall import Hall
+
+    hall = Hall(name="Test Hall", address="Test Street")
+    production = Production()
+    db_session.add_all([hall, production])
+    db_session.commit()
+
+
+    event1 = Event(hall=hall, production=production, order_url="http://order1.url")
+    event2 = Event(hall=hall, production=production, order_url="http://order2.url")
+    db_session.add_all([event1, event2])
+    db_session.commit()
+
+    response = client.get("/api/v1/archive/productions/")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "productions" in data
+    assert len(data["productions"]) > 0
+
+    prod_data = data["productions"][0]
+
+    production_url = prod_data.get("id_url")
+    assert production_url is not None
+    assert "/api/v1/archive/productions" in production_url
+
+
+    events_urls = prod_data.get("events", [])
+    assert len(events_urls) == 2
+    for event_url, event in zip(events_urls, [event1, event2]):
+        assert "/api/v1/archive/events" in event_url
+        assert str(event.id) in event_url

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -386,3 +386,9 @@ def test_production_urls_contain_full_path(client: TestClient, db_session: Sessi
     for event_url, event in zip(events_urls, [event1, event2]):
         assert "/api/v1/archive/events" in event_url
         assert str(event.id) in event_url
+
+        response = client.get(event_url)
+        assert response.status_code == 200
+
+    response = client.get(production_url)
+    assert response.status_code == 200

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -353,7 +353,6 @@ def test_delete_production_not_found(
     assert response.status_code == 404
 
 
-
 def test_production_urls_contain_full_path(client: TestClient, db_session: Session):
     from src.models.production import Production
     from src.models.event import Event
@@ -363,7 +362,6 @@ def test_production_urls_contain_full_path(client: TestClient, db_session: Sessi
     production = Production()
     db_session.add_all([hall, production])
     db_session.commit()
-
 
     event1 = Event(hall=hall, production=production, order_url="http://order1.url")
     event2 = Event(hall=hall, production=production, order_url="http://order2.url")
@@ -382,7 +380,6 @@ def test_production_urls_contain_full_path(client: TestClient, db_session: Sessi
     production_url = prod_data.get("id_url")
     assert production_url is not None
     assert "/api/v1/archive/productions" in production_url
-
 
     events_urls = prod_data.get("events", [])
     assert len(events_urls) == 2

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -276,3 +276,36 @@ def test_delete_unauthorized(client: TestClient, create_headers, language_nl: La
     # Ensure tag is still present in database
     response = client.get(f"{TAGS_URL}/{tag_id}")
     assert response.status_code == 200
+
+
+
+def test_tag_url_contains_full_path(client: TestClient, db_session: Session, language_nl: Language):
+
+    create_headers = create_user_and_login(
+        client, db_session, "tag_url_user", permissions=[Permissions.ARCHIVE_CREATE]
+    )
+
+    response = client.post(
+        TAGS_URL,
+        json={
+            "names": [
+                {"language_id": language_nl.id, "name": "tag_url_test"},
+            ]
+        },
+        headers=create_headers,
+    )
+    assert response.status_code == 201
+    data = response.json()
+
+
+    tag_url = data.get("id")
+    assert tag_url is not None
+
+    assert "/api/v1/archive/tags" in tag_url
+
+    tag_id = tag_url.split("/")[-1]
+    assert str(tag_id) in tag_url
+
+    names = data.get("names")
+    assert names is not None
+    assert any(n["name"] == "tag_url_test" for n in names)

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -309,3 +309,6 @@ def test_tag_url_contains_full_path(
     names = data.get("names")
     assert names is not None
     assert any(n["name"] == "tag_url_test" for n in names)
+
+    response = client.get(tag_url)
+    assert response.status_code == 200

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -278,8 +278,9 @@ def test_delete_unauthorized(client: TestClient, create_headers, language_nl: La
     assert response.status_code == 200
 
 
-
-def test_tag_url_contains_full_path(client: TestClient, db_session: Session, language_nl: Language):
+def test_tag_url_contains_full_path(
+    client: TestClient, db_session: Session, language_nl: Language
+):
 
     create_headers = create_user_and_login(
         client, db_session, "tag_url_user", permissions=[Permissions.ARCHIVE_CREATE]
@@ -296,7 +297,6 @@ def test_tag_url_contains_full_path(client: TestClient, db_session: Session, lan
     )
     assert response.status_code == 201
     data = response.json()
-
 
     tag_url = data.get("id")
     assert tag_url is not None

--- a/backend/tests/unit/test_archive_service.py
+++ b/backend/tests/unit/test_archive_service.py
@@ -1,0 +1,17 @@
+from src.services.archive import get_base_url
+
+
+def test_basic():
+    url = "https://example.com/api/v1/users/"
+    assert get_base_url(url, 1) == "https://example.com/api/v1"
+    assert get_base_url(url, 2) == "https://example.com/api"
+
+
+def test_no_trailing_slash():
+    url = "https://example.com/api/v1/users"
+    assert get_base_url(url, 1) == "https://example.com/api/v1"
+
+
+def test_root_url():
+    url = "https://example.com/"
+    assert get_base_url(url, 1) == "https://example.com"


### PR DESCRIPTION
### Beschrijving
De responses van veel endpoints gaven foute urls terug. Deze PR heeft dat gefixt.


### Aangepaste delen
De manier waarop de 'base_url' verkregen wordt is aangepast en is nu een vaste functie. 


### Speciale opmerkingen
N/A


### Afhankelijkheden
N/A


### Testen
Ik heb extra testen geschreven voor de endpoints die faalde om te kijken ofdat de paden nu wel goed zijn in de responses.


Closes #77 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
