### PR TITLE
[FIX] localstorage not working

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "react-router-serve ./build/server/index.js",
     "lint": "eslint",
     "format": "prettier --write .",
-    "test": "NODE_OPTIONS='--no-experimental-webstorage' vitest run --coverage",
+    "test": "vitest run --coverage",
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "react-router-serve ./build/server/index.js",
     "lint": "eslint",
     "format": "prettier --write .",
-    "test": "vitest run --coverage",
+    "test": "NODE_OPTIONS='--no-experimental-webstorage' vitest run --coverage",
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
     environment: "jsdom",
     reporters: ["default", "hanging-process"],
     globalSetup: ["./tests/globalSetup.ts"],
+	env: {
+		NODE_OPTIONS: "--no-experimental-webstorage"
+	}
   },
 });


### PR DESCRIPTION
### Beschrijving
Testen konden niet uitgevoerd worden op nieuwe versies van node. Hier was er een vlag `--localstorage-file` dat fouten meebracht. Dit is nu opgelost.


### Aangepaste delen
De variabele: `NODE_OPTIONS='--no-experimental-webstorage'` zorgt ervoor dat deze fout niet meer optreed. Bij oudere versies geeft dit ook geen verdere problemen.


### Testen
Testen werken nu weer.


- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
