### PR TITLE
updated ci to include frontend tests

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,6 +29,7 @@ jobs:
           echo "ACCESS_TOKEN_EXPIRE_MINUTES=${{ secrets.ACCESS_TOKEN_EXPIRE_MINUTES }}" >> .env
           echo "REFRESH_TOKEN_EXPIRE_MINUTES=${{ secrets.REFRESH_TOKEN_EXPIRE_MINUTES }}" >> .env
           echo "VIERNULVIER_KEY=${{ secrets.VIERNULVIER_KEY }}" >> .env
+          echo "VITE_API_BASE_URL"=http://localhost/ >> .env
 
       - name: Build and Restart Containers
         run: docker compose -f docker-compose.yml -f docker-compose.prod.yml --project-name viernulvier-prod up --build -d --remove-orphans

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "ACCESS_TOKEN_EXPIRE_MINUTES=${{ secrets.ACCESS_TOKEN_EXPIRE_MINUTES }}" >> .env
           echo "REFRESH_TOKEN_EXPIRE_MINUTES=${{ secrets.REFRESH_TOKEN_EXPIRE_MINUTES }}" >> .env
           echo "VIERNULVIER_KEY=${{ secrets.VIERNULVIER_KEY }}" >> .env
-          echo "VITE_API_BASE_URL"=http://localhost/ >> .env
+          echo "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}" >> .env
 
       - name: Build and Restart Containers
         run: docker compose -f docker-compose.yml -f docker-compose.prod.yml --project-name viernulvier-prod up --build -d --remove-orphans

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
           echo "ACCESS_TOKEN_EXPIRE_MINUTES=30" >> .env
           echo "REFRESH_TOKEN_EXPIRE_MINUTES=43200" >> .env
           echo "VIERNULVIER_KEY=viernulvier_test_api_key" >> .env
+          echo "VITE_API_BASE_URL"=http://localhost/ >> .env
 
       - name: Build Docker Environment
         run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci up -d --build --wait

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,11 @@ jobs:
       - name: Build Docker Environment
         run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci up -d --build --wait
 
-      - name: Run Tests
+      - name: Run Backend Tests
         run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci exec -T backend pytest tests/
+
+      - name: Run Frontend Tests
+        run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci exec -T frontend npm run test
 
       - name: Dump Docker Logs
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci exec -T backend pytest tests/
 
       - name: Run Frontend Tests
-        run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci exec -T frontend npm run test
+        run: docker compose -f docker-compose.ci.yml --project-name viernulvier-ci run --rm frontend npm run test
 
       - name: Dump Docker Logs
         if: failure()

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,6 +18,8 @@ services:
     expose:
       - "3000"
     env_file: .env
+    environment:
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
     depends_on:
       backend:
         condition: service_started

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -17,6 +17,7 @@ services:
       target: test-env
     expose:
       - "3000"
+    env_file: .env
     depends_on:
       backend:
         condition: service_started

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,8 +18,6 @@ services:
     expose:
       - "3000"
     env_file: .env
-    environment:
-      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
     depends_on:
       backend:
         condition: service_started

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -12,7 +12,9 @@ services:
         condition: service_started
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      target: test-env
     expose:
       - "3000"
     depends_on:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ De productie-aanpak rond TLS-terminatie en certificaatbeheer is vastgelegd in
 
 ### 3.2 Frontend
 
-De frontend draait als een aparte **Node.js 20** container.
+De frontend draait als een aparte **Node.js 24** container.
 
 - De image wordt gebouwd via een multi-stage Dockerfile.
 - De container start via `npm run start` en luistert intern op poort `3000`.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,6 +14,12 @@ COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN npm run build
 
+FROM node:20-alpine AS test-env
+COPY . /app
+WORKDIR /app
+RUN npm ci
+CMD ["npm", "run", "test"]
+
 FROM node:20-alpine
 COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,26 +1,26 @@
-FROM node:20-alpine AS development-dependencies-env
+FROM node:24-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine AS production-dependencies-env
+FROM node:24-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev
 
-FROM node:20-alpine AS build-env
+FROM node:24-alpine AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN npm run build
 
-FROM node:20-alpine AS test-env
+FROM node:24-alpine AS test-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 CMD ["npm", "run", "test"]
 
-FROM node:20-alpine
+FROM node:24-alpine
 COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build


### PR DESCRIPTION
### Beschrijving
ci en cd hebben nu alles dat nodig is voor frontend en frontend testen.


### Aangepaste delen
- `ci.yml` en `cd.yml` om `VITE_API_BASE_URL` te ondersteunen
- node versie naar 24 geupdated. 

### Speciale opmerkingen
Node versie is vanaf nu 24 aangezien dit de LTS versie is.


- [ ] Auteur wil zelf mergen.
