### PR TITLE
Feat/tags update

### DIFF
--- a/backend/src/schemas/production.py
+++ b/backend/src/schemas/production.py
@@ -3,6 +3,7 @@ from typing import Optional
 from datetime import datetime
 from src.schemas.tag import TagResponse
 
+
 class Pagination(BaseModel):
     next_cursor: int | None = None
     has_more: bool = False
@@ -36,7 +37,7 @@ class ProductionResponse(BaseModel):
     # A production has a list of tags.
     production_infos: list[ProductionInfoResponse] = Field(default_factory=list)
     events: list[str] = Field(default_factory=list)
-    tags: list[TagResponse] = Field(default_factory=list) # tag_object
+    tags: list[TagResponse] = Field(default_factory=list)  # tag_object
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/src/schemas/production.py
+++ b/backend/src/schemas/production.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Optional
 from datetime import datetime
-
+from src.schemas.tag import TagResponse
 
 class Pagination(BaseModel):
     next_cursor: int | None = None
@@ -36,7 +36,7 @@ class ProductionResponse(BaseModel):
     # A production has a list of tags.
     production_infos: list[ProductionInfoResponse] = Field(default_factory=list)
     events: list[str] = Field(default_factory=list)
-    tags: list[str] = Field(default_factory=list)
+    tags: list[TagResponse] = Field(default_factory=list) # tag_object
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/src/services/production.py
+++ b/backend/src/services/production.py
@@ -1,6 +1,8 @@
 from src.schemas.production import Pagination
 from sqlalchemy.orm import Session
 from src.models import Event, Production, ProdInfo, Tag
+from src.services.tag import build_tag_response, get_names_for_language
+from src.schemas.tag import TagResponse
 from src.api.dependencies.language import get_accepted_language
 from src.schemas.production import (
     ProductionCreate,
@@ -125,10 +127,14 @@ def get_events_for_production(
 # Returns all tags for a given productoin.
 def get_tags_for_production(
     db: Session, production_id: int, base_url: str
-) -> list[str]:
+) -> list[TagResponse]:
     production = db.query(Production).get(production_id)
     tags = production.tags
-    return [f"{base_url}/tags/{tag.id}" for tag in tags]
+    responses = []
+    for tag in tags:
+        names = get_names_for_language(tag.names, language=None)
+        responses.append(build_tag_response(tag, names, base_url))
+    return responses
 
 
 # Returns a production with given id.

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -84,7 +84,7 @@ def test_get_productions_with_tag(
     assert len(data["productions"]) == 5
     assert all(
         all(
-            int(url.rstrip("/").split("/")[-1]) == tag_id1 for url in production["tags"]
+            int(tag_response["id"].rstrip("/").split("/")[-1]) == tag_id1 for tag_response in production["tags"]
         )
         for production in data["productions"]
     )
@@ -102,7 +102,7 @@ def test_get_productions_with_tag(
     assert len(data["productions"]) == 5
     assert all(
         all(
-            int(url.rstrip("/").split("/")[-1]) == tag_id2 for url in production["tags"]
+            int(tag_response["id"].rstrip("/").split("/")[-1]) == tag_id2 for tag_response in production["tags"]
         )
         for production in data["productions"]
     )
@@ -297,7 +297,7 @@ def test_patch_production_tags_success(
     )
 
     data = response.json()
-    assert {int(url.rstrip("/").split("/")[-1]) for url in data["tags"]} == {1, 3}
+    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 3}
 
     response = client.patch(
         f"{BASE_URL}/{id}",
@@ -307,7 +307,7 @@ def test_patch_production_tags_success(
 
     # Updated in response.
     data = response.json()
-    assert {int(url.rstrip("/").split("/")[-1]) for url in data["tags"]} == {1, 2, 3}
+    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 2, 3}
 
     response = client.get(
         BASE_URL + f"/{id}",
@@ -315,7 +315,7 @@ def test_patch_production_tags_success(
 
     # Updated in database.
     data = response.json()
-    assert {int(url.rstrip("/").split("/")[-1]) for url in data["tags"]} == {1, 2, 3}
+    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 2, 3}
 
 
 # User cannot change tags of a production if one or more tags do not exist.
@@ -331,7 +331,7 @@ def test_patch_production_tags_failure(
     )
 
     data = response.json()
-    assert {int(url.rstrip("/").split("/")[-1]) for url in data["tags"]} == {1, 3}
+    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 3}
 
     response = client.patch(
         f"{BASE_URL}/{id}",
@@ -410,7 +410,7 @@ def test_create_production_with_tags_success(
     data = response.json()
     assert data["performer_type"] == "band"
     assert data["attendance_mode"] == "offline"
-    assert {int(url.rstrip("/").split("/")[-1]) for url in data["tags"]} == {1, 2}
+    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 2}
 
 
 # User should not be able to create a new production with tags if one is not existing in database.

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -84,7 +84,8 @@ def test_get_productions_with_tag(
     assert len(data["productions"]) == 5
     assert all(
         all(
-            int(tag_response["id"].rstrip("/").split("/")[-1]) == tag_id1 for tag_response in production["tags"]
+            int(tag_response["id"].rstrip("/").split("/")[-1]) == tag_id1
+            for tag_response in production["tags"]
         )
         for production in data["productions"]
     )
@@ -102,7 +103,8 @@ def test_get_productions_with_tag(
     assert len(data["productions"]) == 5
     assert all(
         all(
-            int(tag_response["id"].rstrip("/").split("/")[-1]) == tag_id2 for tag_response in production["tags"]
+            int(tag_response["id"].rstrip("/").split("/")[-1]) == tag_id2
+            for tag_response in production["tags"]
         )
         for production in data["productions"]
     )
@@ -297,7 +299,10 @@ def test_patch_production_tags_success(
     )
 
     data = response.json()
-    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 3}
+    assert {
+        int(tag_response["id"].rstrip("/").split("/")[-1])
+        for tag_response in data["tags"]
+    } == {1, 3}
 
     response = client.patch(
         f"{BASE_URL}/{id}",
@@ -307,7 +312,10 @@ def test_patch_production_tags_success(
 
     # Updated in response.
     data = response.json()
-    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 2, 3}
+    assert {
+        int(tag_response["id"].rstrip("/").split("/")[-1])
+        for tag_response in data["tags"]
+    } == {1, 2, 3}
 
     response = client.get(
         BASE_URL + f"/{id}",
@@ -315,7 +323,10 @@ def test_patch_production_tags_success(
 
     # Updated in database.
     data = response.json()
-    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 2, 3}
+    assert {
+        int(tag_response["id"].rstrip("/").split("/")[-1])
+        for tag_response in data["tags"]
+    } == {1, 2, 3}
 
 
 # User cannot change tags of a production if one or more tags do not exist.
@@ -331,7 +342,10 @@ def test_patch_production_tags_failure(
     )
 
     data = response.json()
-    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 3}
+    assert {
+        int(tag_response["id"].rstrip("/").split("/")[-1])
+        for tag_response in data["tags"]
+    } == {1, 3}
 
     response = client.patch(
         f"{BASE_URL}/{id}",
@@ -410,7 +424,10 @@ def test_create_production_with_tags_success(
     data = response.json()
     assert data["performer_type"] == "band"
     assert data["attendance_mode"] == "offline"
-    assert {int(tag_response["id"].rstrip("/").split("/")[-1]) for tag_response in data["tags"]} == {1, 2}
+    assert {
+        int(tag_response["id"].rstrip("/").split("/")[-1])
+        for tag_response in data["tags"]
+    } == {1, 2}
 
 
 # User should not be able to create a new production with tags if one is not existing in database.

--- a/backend/tests/unit/test_production_service.py
+++ b/backend/tests/unit/test_production_service.py
@@ -210,7 +210,8 @@ def test_create_production_with_tags_valid(db_session, productions_limited):
     new_id = int(response.id_url.rstrip("/").split("/")[-1])
     new_prod_from_db = get_production_by_id(db_session, new_id, BASE_URL)
     new_prod_tag_ids = {
-        int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in new_prod_from_db.tags
+        int(tag_response.id.rstrip("/").split("/")[-1])
+        for tag_response in new_prod_from_db.tags
     }
     assert new_prod_tag_ids == {tag.id for tag in valid_tags}
 
@@ -250,11 +251,17 @@ def test_update_production_tags(db_session, productions_limited):
     production_response = get_production_by_id(
         db_session, productions_limited[0].id, BASE_URL
     )
-    ids1 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response.tags}
+    ids1 = {
+        int(tag_response.id.rstrip("/").split("/")[-1])
+        for tag_response in production_response.tags
+    }
     production_response2 = get_production_by_id(
         db_session, productions_limited[1].id, BASE_URL
     )
-    ids2 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response2.tags}
+    ids2 = {
+        int(tag_response.id.rstrip("/").split("/")[-1])
+        for tag_response in production_response2.tags
+    }
     assert ids1 == {1, 3}
     assert ids2 == {3, 2, 4}
 
@@ -265,11 +272,15 @@ def test_update_production_tags(db_session, productions_limited):
     result = update_production_by_id(
         db_session, production_update1, productions_limited[0].id, BASE_URL
     )
-    ids1 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in result.tags}
+    ids1 = {
+        int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in result.tags
+    }
     result2 = update_production_by_id(
         db_session, production_update2, productions_limited[1].id, BASE_URL
     )
-    ids2 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in result2.tags}
+    ids2 = {
+        int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in result2.tags
+    }
 
     assert ids1 == {3, 2, 4}
     assert ids2 == {1, 3}
@@ -278,11 +289,17 @@ def test_update_production_tags(db_session, productions_limited):
     production_response = get_production_by_id(
         db_session, productions_limited[0].id, BASE_URL
     )
-    ids1 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response.tags}
+    ids1 = {
+        int(tag_response.id.rstrip("/").split("/")[-1])
+        for tag_response in production_response.tags
+    }
     production_response2 = get_production_by_id(
         db_session, productions_limited[1].id, BASE_URL
     )
-    ids2 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response2.tags}
+    ids2 = {
+        int(tag_response.id.rstrip("/").split("/")[-1])
+        for tag_response in production_response2.tags
+    }
 
     assert ids1 == {3, 2, 4}
     assert ids2 == {1, 3}
@@ -296,7 +313,10 @@ def test_update_production_tags_invalid(db_session, productions_limited):
     assert len(production_response.tags) == 2
 
     # Create partly invalid taglist.
-    ids = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response.tags}
+    ids = {
+        int(tag_response.id.rstrip("/").split("/")[-1])
+        for tag_response in production_response.tags
+    }
     ids.add(145)
     ids.add(432)
     production_update = ProductionUpdate(tag_ids=ids)

--- a/backend/tests/unit/test_production_service.py
+++ b/backend/tests/unit/test_production_service.py
@@ -118,12 +118,12 @@ def test_get_tags_for_production(db_session, productions_limited):
     tags1 = get_tags_for_production(db_session, productions_limited[0].id, BASE_URL)
     assert len(tags1) == 2
     for i in range(2):
-        assert tags1[i] == f"{BASE_URL}/tags/{productions_limited[0].tags[i].id}"
+        assert tags1[i].id == f"{BASE_URL}/tags/{productions_limited[0].tags[i].id}"
 
     tags2 = get_tags_for_production(db_session, productions_limited[1].id, BASE_URL)
     assert len(tags2) == 3
     for i in range(3):
-        assert tags2[i] == f"{BASE_URL}/tags/{productions_limited[1].tags[i].id}"
+        assert tags2[i].id == f"{BASE_URL}/tags/{productions_limited[1].tags[i].id}"
 
 
 # Get production by id (no/invalid language specified): check if correct production is returned with all correct info and events.
@@ -210,7 +210,7 @@ def test_create_production_with_tags_valid(db_session, productions_limited):
     new_id = int(response.id_url.rstrip("/").split("/")[-1])
     new_prod_from_db = get_production_by_id(db_session, new_id, BASE_URL)
     new_prod_tag_ids = {
-        int(url.rstrip("/").split("/")[-1]) for url in new_prod_from_db.tags
+        int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in new_prod_from_db.tags
     }
     assert new_prod_tag_ids == {tag.id for tag in valid_tags}
 
@@ -250,11 +250,11 @@ def test_update_production_tags(db_session, productions_limited):
     production_response = get_production_by_id(
         db_session, productions_limited[0].id, BASE_URL
     )
-    ids1 = {int(url.rstrip("/").split("/")[-1]) for url in production_response.tags}
+    ids1 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response.tags}
     production_response2 = get_production_by_id(
         db_session, productions_limited[1].id, BASE_URL
     )
-    ids2 = {int(url.rstrip("/").split("/")[-1]) for url in production_response2.tags}
+    ids2 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response2.tags}
     assert ids1 == {1, 3}
     assert ids2 == {3, 2, 4}
 
@@ -265,11 +265,11 @@ def test_update_production_tags(db_session, productions_limited):
     result = update_production_by_id(
         db_session, production_update1, productions_limited[0].id, BASE_URL
     )
-    ids1 = {int(url.rstrip("/").split("/")[-1]) for url in result.tags}
+    ids1 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in result.tags}
     result2 = update_production_by_id(
         db_session, production_update2, productions_limited[1].id, BASE_URL
     )
-    ids2 = {int(url.rstrip("/").split("/")[-1]) for url in result2.tags}
+    ids2 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in result2.tags}
 
     assert ids1 == {3, 2, 4}
     assert ids2 == {1, 3}
@@ -278,11 +278,11 @@ def test_update_production_tags(db_session, productions_limited):
     production_response = get_production_by_id(
         db_session, productions_limited[0].id, BASE_URL
     )
-    ids1 = {int(url.rstrip("/").split("/")[-1]) for url in production_response.tags}
+    ids1 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response.tags}
     production_response2 = get_production_by_id(
         db_session, productions_limited[1].id, BASE_URL
     )
-    ids2 = {int(url.rstrip("/").split("/")[-1]) for url in production_response2.tags}
+    ids2 = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response2.tags}
 
     assert ids1 == {3, 2, 4}
     assert ids2 == {1, 3}
@@ -296,7 +296,7 @@ def test_update_production_tags_invalid(db_session, productions_limited):
     assert len(production_response.tags) == 2
 
     # Create partly invalid taglist.
-    ids = {int(url.rstrip("/").split("/")[-1]) for url in production_response.tags}
+    ids = {int(tag_response.id.rstrip("/").split("/")[-1]) for tag_response in production_response.tags}
     ids.add(145)
     ids.add(432)
     production_update = ProductionUpdate(tag_ids=ids)


### PR DESCRIPTION
### Beschrijving
Deze kleine pr staat in voor het rechtstreeks meegeven van tags bij een productie (om zo meerdere requests te vermijden). 

Ziet er dus nu zo uit (de bug van de argumenten in de url moet er nog uit natuurlijk):
```
{
  "id_url": "http://testserver/api/v1/archive?limit=10&tags=2/productions/1",
  "performer_type": "theater",
  "attendance_mode": "offline",
  "media_gallery_id": null,
  "created_at": "2026-03-28T12:59:11",
  "updated_at": "2026-03-28T12:59:11",
  "production_infos": [
    {
      "production_id_url": "http://testserver/api/v1/archive?limit=10&tags=2/productions/1",
      "language": "en",
      "title": "prod0_en",
      "supertitle": null,
      "artist": null,
      "tagline": null,
      "teaser": null,
      "description": null,
      "info": null
    },
    {
      "production_id_url": "http://testserver/api/v1/archive?limit=10&tags=2/productions/1",
      "language": "nl",
      "title": "prod0_nl",
      "supertitle": null,
      "artist": null,
      "tagline": null,
      "teaser": null,
      "description": null,
      "info": null
    }
  ],
  "events": [],
  "tags": [
    {
      "id": "http://testserver/api/v1/archive?limit=10&tags=2/tags/2",
      "names": [
        {
          "language": "en",
          "name": "band"
        },
        {
          "language": "nl",
          "name": "band"
        }
      ]
    }
  ]
}
```


### Aangepaste delen
- Production Schema
- Production Service
- test_production_service.py
- test_production_endpoint.py


### Speciale opmerkingen
Aangezien in een TagResponse al de url meegegeven wordt, kon ik gewoon een lijst van TagResponses teruggeven in een ProductionResponse (een tuple zoals eerder gedacht was dus niet nodig). In een Create/Update wordt er wel nog steeds gewerkt met ids natuurlijk.


### Afhankelijkheden
Niet van toepassing.


### Testen
Er zijn geen nieuwe testen geschreven (enkel aangepast). De aangepaste testen slagen nog steeds.


Closes #139 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
