### PR TITLE
Fix `npm run typecheck` errors

### DIFF
--- a/frontend/app/shared/hooks/apiHooks.ts
+++ b/frontend/app/shared/hooks/apiHooks.ts
@@ -1,4 +1,4 @@
-import { getByUrl } from "../services/apiClient";
+import { getByUrl } from "../services/sharedService";
 import { useAsyncFetch, type UseAsyncReturn } from "./useAsyncFetch";
 
 export function useGetByUrl<R>(url: string): UseAsyncReturn<R> {

--- a/frontend/app/shared/services/apiClient.ts
+++ b/frontend/app/shared/services/apiClient.ts
@@ -3,10 +3,10 @@ import { getEnv } from "../utils/env";
 import { refreshToken } from "~/features/auth";
 
 export function createApiClient() {
-  const { API_BASE_URL } = getEnv();
+  const { API_URL } = getEnv();
 
   const apiClient = axios.create({
-    baseURL: API_BASE_URL,
+    baseURL: API_URL,
     timeout: 5000,
     headers: {
       "Content-Type": "application/json",

--- a/frontend/tests/unit/apiClient.test.ts
+++ b/frontend/tests/unit/apiClient.test.ts
@@ -17,7 +17,7 @@ describe("createApiClient", () => {
     vi.clearAllMocks();
 
     vi.spyOn(envModule, "getEnv").mockReturnValue({
-      API_BASE_URL: "http://localhost",
+      API_URL: "http://localhost",
     });
 
     const apiClient = axios.create();
@@ -121,7 +121,7 @@ describe("401 retry token behaviour", () => {
     vi.clearAllMocks();
 
     vi.spyOn(envModule, "getEnv").mockReturnValue({
-      API_BASE_URL: "http://localhost",
+      API_URL: "http://localhost",
     });
   });
 

--- a/frontend/tests/unit/eventService.test.ts
+++ b/frontend/tests/unit/eventService.test.ts
@@ -26,7 +26,7 @@ describe("eventService", () => {
 
   beforeEach(() => {
     vi.spyOn(envModule, "getEnv").mockReturnValue({
-      API_BASE_URL: "http://localhost",
+      API_URL: "http://localhost",
     });
 
     const apiClient = createApiClient();

--- a/frontend/tests/unit/hallService.test.ts
+++ b/frontend/tests/unit/hallService.test.ts
@@ -24,7 +24,7 @@ describe("hallService", () => {
 
   beforeEach(() => {
     vi.spyOn(envModule, "getEnv").mockReturnValue({
-      API_BASE_URL: "http://localhost",
+      API_URL: "http://localhost",
     });
 
     const apiClient = createApiClient();

--- a/frontend/tests/unit/loginService.test.ts
+++ b/frontend/tests/unit/loginService.test.ts
@@ -14,7 +14,7 @@ describe("loginService", () => {
 
   beforeEach(() => {
     vi.spyOn(envModule, "getEnv").mockReturnValue({
-      API_BASE_URL: "http://localhost",
+      API_URL: "http://localhost",
     });
 
     const apiClient = createApiClient();

--- a/frontend/tests/unit/resourceService.test.ts
+++ b/frontend/tests/unit/resourceService.test.ts
@@ -26,7 +26,7 @@ describe("resourceService", () => {
     vi.clearAllMocks();
 
     vi.spyOn(envModule, "getEnv").mockReturnValue({
-      API_BASE_URL: "http://localhost",
+      API_URL: "http://localhost",
     });
 
     const apiClient = createApiClient();


### PR DESCRIPTION
### Beschrijving
We hebben een `npm run typecheck` commando dat blijkbaar niet door iedereen gebruikt werd, waardoor er nog een paar fouten op `dev` stonden. Geen idee waarom de testen toch nog slaagden... (JS being JS is mijn gok)


### Aangepaste delen
2 bestanden onder `app/shared` en een aantal testen, voornamelijk de `API_BASE_URL` die hernoemd werd naar `API_URL` wat niet overal doorgetrokken werd, ook nog 1 verkeerde import.



### Afhankelijkheden
Geen afhankelijkheid, maar wel gerelateerd met #141 , daar zouden we best nog de `npm run typecheck` toevoegen aan de CI om zo'n fouten op te vangen.


### Testen
Geen testen toegevoegd.


- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
