### PR TITLE
Feat/frontend tag service

### DIFF
--- a/frontend/app/features/archive/services/tagService.ts
+++ b/frontend/app/features/archive/services/tagService.ts
@@ -1,0 +1,30 @@
+import {
+  getFromArchive,
+  getFromArchiveList,
+  postToArchive,
+  patchToArchive,
+  deleteFromArchive,
+} from "~/shared/services/sharedService";
+import type { TagCreate, Tag, TagUpdate } from "../types/tagTypes";
+
+const ENDPOINT = "/tags";
+
+export async function getTagList(): Promise<Tag[]> {
+  return getFromArchiveList<Tag>(ENDPOINT);
+}
+
+export async function getTagById(id: number): Promise<Tag> {
+  return getFromArchive<Tag>(`${ENDPOINT}/${id}`);
+}
+
+export async function createTag(request: TagCreate): Promise<Tag> {
+  return postToArchive<Tag>(`${ENDPOINT}`, request);
+}
+
+export async function editTag(id: number, request: TagUpdate): Promise<Tag> {
+  return patchToArchive<Tag>(`${ENDPOINT}/${id}`, request);
+}
+
+export async function deleteTag(id: number): Promise<void> {
+  return deleteFromArchive(`${ENDPOINT}/${id}`);
+}

--- a/frontend/app/features/archive/services/tagService.ts
+++ b/frontend/app/features/archive/services/tagService.ts
@@ -9,7 +9,7 @@ import type { TagCreate, Tag, TagUpdate } from "../types/tagTypes";
 
 const ENDPOINT = "/tags";
 
-export async function getTagList(): Promise<Tag[]> {
+export async function getAllTags(): Promise<Tag[]> {
   return getFromArchiveList<Tag>(ENDPOINT);
 }
 

--- a/frontend/app/features/archive/types/tagTypes.ts
+++ b/frontend/app/features/archive/types/tagTypes.ts
@@ -1,0 +1,17 @@
+export interface TagName {
+  language: string;
+  name: string;
+}
+
+export interface Tag {
+  id: string;
+  names: TagName[];
+}
+
+export interface TagCreate {
+  names: TagName[];
+}
+
+export interface TagUpdate {
+  names?: TagName[];
+}

--- a/frontend/tests/unit/tagService.test.ts
+++ b/frontend/tests/unit/tagService.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import * as envModule from "~/shared/utils/env";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { createApiClient } from "~/shared/services/apiClient";
+import axios from "axios";
+import type { Tag } from "~/features/archive/types/tagTypes";
+import {
+  createTag,
+  deleteTag,
+  editTag,
+  getTagById,
+  getTagList,
+} from "~/features/archive/services/tagService";
+
+describe("tagService", () => {
+  let mockAdapter: AxiosMockAdapter;
+
+  const mockTag1: Tag = {
+    id: "http://localhost/api/v1/archive/tags/1",
+    names: [
+      { language: "nl", name: "tag naam" },
+      { language: "en", name: "tag name" },
+    ],
+  };
+  const mockTag2: Tag = {
+    id: "http://localhost/api/v1/archive/tags/2",
+    names: [
+      { language: "nl", name: "tag naam2" },
+      { language: "en", name: "tag name2" },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.spyOn(envModule, "getEnv").mockReturnValue({
+      API_URL: "http://localhost",
+    });
+
+    // Create a single mocked api client and use this client in all subsequent creations
+    const apiClient = createApiClient();
+    mockAdapter = new AxiosMockAdapter(apiClient);
+    vi.spyOn(axios, "create").mockReturnValue(apiClient);
+  });
+
+  afterEach(() => {
+    mockAdapter.restore();
+    vi.restoreAllMocks();
+  });
+
+  describe("getTagList", () => {
+    it("returns a list of tags on success", async () => {
+      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
+
+      const result = await getTagList();
+      expect(result).toEqual([mockTag1, mockTag2]);
+    });
+  });
+
+  describe("getTagById", () => {
+    it("returns a tag object on success", async () => {
+      mockAdapter.onGet("/api/v1/archive/tags/1").reply(200, mockTag1);
+
+      const result = await getTagById(1);
+      expect(result).toEqual(mockTag1);
+    });
+  });
+
+  describe("createTag", () => {
+    it("creates a tag object and returns it on success", async () => {
+      // Upon calling post, return the request with an added id field
+      mockAdapter.onPost("/api/v1/archive/tags").reply((config) => {
+        const data = {
+          id: mockTag1.id,
+          ...JSON.parse(config.data),
+        };
+        return [201, data];
+      });
+
+      const result = await createTag({ names: mockTag1.names });
+      expect(result).toEqual(mockTag1);
+    });
+  });
+
+  describe("editTag", () => {
+    it("edits a tag by id and returns the updated object", async () => {
+      mockAdapter.onPatch("/api/v1/archive/tags/1").reply((config) => {
+        const data = {
+          id: "http://localhost/api/v1/archive/tags/1",
+          ...JSON.parse(config.data),
+        };
+        return [201, data];
+      });
+
+      const result = await editTag(1, { names: mockTag1.names });
+      expect(result).toEqual(mockTag1);
+    });
+  });
+
+  describe("deleteTag", () => {
+    it("deletes a tag", async () => {
+      mockAdapter.onDelete("/api/v1/archive/tags/1").reply(204);
+      deleteTag(1);
+    });
+  });
+});

--- a/frontend/tests/unit/tagService.test.ts
+++ b/frontend/tests/unit/tagService.test.ts
@@ -9,7 +9,7 @@ import {
   deleteTag,
   editTag,
   getTagById,
-  getTagList,
+  getAllTags,
 } from "~/features/archive/services/tagService";
 
 describe("tagService", () => {
@@ -48,11 +48,11 @@ describe("tagService", () => {
     vi.restoreAllMocks();
   });
 
-  describe("getTagList", () => {
+  describe("getAllTags", () => {
     it("returns a list of tags on success", async () => {
       mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
 
-      const result = await getTagList();
+      const result = await getAllTags();
       expect(result).toEqual([mockTag1, mockTag2]);
     });
   });

--- a/frontend/tests/unit/tagService.test.ts
+++ b/frontend/tests/unit/tagService.test.ts
@@ -100,7 +100,7 @@ describe("tagService", () => {
   describe("deleteTag", () => {
     it("deletes a tag", async () => {
       mockAdapter.onDelete("/api/v1/archive/tags/1").reply(204);
-      deleteTag(1);
+      await deleteTag(1);
     });
   });
 });


### PR DESCRIPTION
### Beschrijving
Implementatie van tag service functies zodat de frontend met de backend kan praten.


### Aangepaste delen
- TagService en TagTypes bestanden aangemaakt


### Afhankelijkheden
N/A

### Testen
Er wordt getest op alle fetch methodes, er wordt hierbij enkel getest op succesvolle responses.
TagService heeft 100% coverage


Closes #89 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
