### PR TITLE
Base url fix

### DIFF
--- a/backend/src/services/archive.py
+++ b/backend/src/services/archive.py
@@ -10,11 +10,21 @@ def get_base_url(url: str, remove_last_segments: int = 1) -> str:
         'https://example.com/api/v1'
         >>> get_base_url("https://example.com/api/v1/users/", 2)
         'https://example.com/api'
+        >>> get_base_url("https://example.com/api/v1/archive/productions/?cursor=1&limit=20", 1)
+        'https://example.com/api/v1/archive'
     """
     parsed = urlparse(url)
 
     path_segments = parsed.path.rstrip("/").split("/")
 
     new_path = "/".join(path_segments[:-remove_last_segments])
-    new_url = urlunparse(parsed._replace(path=new_path))
+    # new_url = urlunparse(parsed._replace(path=new_path))
+    new_url = urlunparse(
+        parsed._replace(
+            path=new_path,
+            params="",
+            query="",
+            fragment="",
+        )
+    )
     return new_url

--- a/backend/tests/unit/test_archive_service.py
+++ b/backend/tests/unit/test_archive_service.py
@@ -15,3 +15,8 @@ def test_no_trailing_slash():
 def test_root_url():
     url = "https://example.com/"
     assert get_base_url(url, 1) == "https://example.com"
+
+
+def test_with_query_params_and_deep_path():
+    url = "https://example.com/api/v1/archive/productions/?cursor=1&limit=20"
+    assert get_base_url(url, 1) == "https://example.com/api/v1/archive"


### PR DESCRIPTION
### Beschrijving
fix zodat query params niet blijven staan na het toepassen van get_base_url

### Aangepaste delen
backend/src/services/archive.py:get_base_url

### Testen
Enkel extra doctest toegevoegd voor geval van bug.

Closes #127 
