### PR TITLE
Fix .env in front-end werkt niet in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,10 @@ services:
         condition: service_started
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL}
     expose:
       - "3000"
     env_file: .env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /app
 RUN npm ci --omit=dev
 
 FROM node:24-alpine AS build-env
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app


### PR DESCRIPTION
### Beschrijving
Blijkbaar in de PR #126 waarin de .env behandeling werd veranderd werkte de manier nog niet volledig in docker doordat `import.meta.env` de env variabelen enkel tijdens build time overneemt en niet tijdens runtime.  Dit gaf echter nog geen problemen omdat `env.ts` nog nergens werd geïmporteerd die gebruikt werd door de root.

### Aangepaste delen
Dockerfiles aangepast zodat .env variabelen expliciet toegevoegd worden als build-time variables in het buildproces, dit is momenteel redelijk smelly maar ik vind online niet direct een betere manier....

### Speciale opmerkingen
Om te testen of alles werkt zal je manueel ergens in `frontend/app/root.tsx` de lijn `import "./shared/utils/env.ts";
` moeten toevoegen aangezien dit nog steeds nergens wordt geïmporteerd.


Closes #175 
- [ ] Auteur wil zelf mergen.
