### PR TITLE
verwijder gebruik van baseUrl in tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -8,9 +8,9 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["./app/*"]
+      "~/*": ["./app/*"],
+      "tests/*": ["./tests/*"]
     },
     "esModuleInterop": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
### Beschrijving
Deze PR verwijdert het gebruik van baseUrl in tsconfig en voegt een pad toe voor tests zodat er geen imports moeten veranderd worden.

Closes #180

- [ ] Auteur wil zelf mergen.
