### PR TITLE
Voeg react hooks toe aan eslint config

### DIFF
--- a/frontend/app/features/auth/context/AuthSessionContext.tsx
+++ b/frontend/app/features/auth/context/AuthSessionContext.tsx
@@ -56,13 +56,13 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
         const user = await loadSession();
 
         if (sessionOperationIdRef.current === operationId) {
-          Promise.resolve().then(() => updateAuthState(user));
+          updateAuthState(user);
         }
 
         return user;
       } catch (error) {
         if (fallbackToAnonymous && sessionOperationIdRef.current === operationId) {
-          Promise.resolve().then(() => updateAuthState(null));
+          updateAuthState(null);
         }
 
         throw error;
@@ -80,7 +80,10 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
   }, [runSessionOperation]);
 
   useEffect(() => {
-    void bootstrapSession();
+    async function init() {
+      await bootstrapSession();
+    }
+    void init();
   }, [bootstrapSession]);
 
   useEffect(() => {

--- a/frontend/app/features/auth/context/AuthSessionContext.tsx
+++ b/frontend/app/features/auth/context/AuthSessionContext.tsx
@@ -56,13 +56,13 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
         const user = await loadSession();
 
         if (sessionOperationIdRef.current === operationId) {
-          updateAuthState(user);
+          Promise.resolve().then(() => updateAuthState(user));
         }
 
         return user;
       } catch (error) {
         if (fallbackToAnonymous && sessionOperationIdRef.current === operationId) {
-          updateAuthState(null);
+          Promise.resolve().then(() => updateAuthState(null));
         }
 
         throw error;

--- a/frontend/app/shared/components/LanguageWrapper.tsx
+++ b/frontend/app/shared/components/LanguageWrapper.tsx
@@ -12,7 +12,7 @@ export default function LanguageWrapper() {
     if (i18n.language !== lang) {
       i18n.changeLanguage(lang);
     }
-  }, [lang]);
+  }, [lang, i18n]);
 
   if (!lang || !SUPPORTED_LANGS.includes(lang)) {
     return <Navigate to="/en" replace />;

--- a/frontend/app/shared/hooks/useAsyncFetch.ts
+++ b/frontend/app/shared/hooks/useAsyncFetch.ts
@@ -13,14 +13,18 @@ export function useAsyncFetch<T>(asyncFn: () => Promise<T>): UseAsyncReturn<T> {
   const [error, setError] = useState<Error | null>(null);
 
   // Refresh function used to fetch and refetch data if needed
-  const refresh = useCallback(() => {
+  const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
 
-    asyncFn()
-      .then(setData)
-      .catch(setError)
-      .finally(() => setLoading(false));
+    try {
+      const res = await asyncFn();
+      setData(res);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
   }, [asyncFn]);
 
   useEffect(() => {

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -5,6 +5,7 @@ import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
 
 export default defineConfig({
   ignores: ["**/.react-router/**", ".config/*", "build/**"],
@@ -16,5 +17,6 @@ export default defineConfig({
     eslint.configs.recommended,
     ...tseslint.configs.recommended,
     prettierConfig,
+    reactHooks.configs.flat.recommended,
   ],
 });


### PR DESCRIPTION
### Beschrijving
Blijkbaar was eslint-plugin-react-hooks nog niet toegevoegd aan de configs ookal was de package al geïnstalleerd, deze PR voegt dus de config toe en fixt de bijkomende linting errors.

### Aangepaste delen
- reactHooks toegevoegd aan `eslint.config.mjs`
- useAsyncFetch lichtjes herschreven zodat het voldoet aan de rules of hooks

- [ ] Auteur wil zelf mergen.
