### PR TITLE
[FIX] Catch errors in sync to prevent crashes

### DIFF
--- a/backend/src/worker/sync/store/event.py
+++ b/backend/src/worker/sync/store/event.py
@@ -23,39 +23,43 @@ def store_new_events(db_session: Session, events: list[dict]):
     orphans = 0
 
     for json_event in events:
-        event, viernulvier_prod_id = api_event_to_model_event(json_event)
+        try:
+            event, viernulvier_prod_id = api_event_to_model_event(json_event)
 
-        # Check if the event is tied to a valid production, else we would get a
-        # ForeignKey violation
-        if not viernulvier_prod_id:
-            logger.warning(
-                f"Not storing event (id={event.viernulvier_id}) because no "
-                "associated production"
-            )
-            orphans += 1
-            continue
+            # Check if the event is tied to a valid production, else we would get a
+            # ForeignKey violation
+            if not viernulvier_prod_id:
+                logger.warning(
+                    f"Not storing event (id={event.viernulvier_id}) because no "
+                    "associated production"
+                )
+                orphans += 1
+                continue
 
-        internal_prod_id = prod_map.get(viernulvier_prod_id)
+            internal_prod_id = prod_map.get(viernulvier_prod_id)
 
-        if not internal_prod_id:
-            logger.warning(
-                f"Not storing event (id={event.viernulvier_id}) because the "
-                f"associated production (id={viernulvier_prod_id}) does not "
-                "exist (anymore)"
-            )
-            orphans += 1
-            continue
+            if not internal_prod_id:
+                logger.warning(
+                    f"Not storing event (id={event.viernulvier_id}) because the "
+                    f"associated production (id={viernulvier_prod_id}) does not "
+                    "exist (anymore)"
+                )
+                orphans += 1
+                continue
 
-        event.production_id = internal_prod_id
+            event.production_id = internal_prod_id
 
-        # Valid production id, so store this event
-        db_session.merge(event)
+            # Valid production id, so store this event
+            db_session.merge(event)
 
-        created_at_str = json_event.get("created_at")
-        if created_at_str:
-            created_at_str = datetime.fromisoformat(created_at_str)
-            if newest_timestamp is None or created_at_str > newest_timestamp:
-                newest_timestamp = created_at_str
+            created_at_str = json_event.get("created_at")
+            if created_at_str:
+                created_at_str = datetime.fromisoformat(created_at_str)
+                if newest_timestamp is None or created_at_str > newest_timestamp:
+                    newest_timestamp = created_at_str
+
+        except Exception as e:
+            logger.warn(f"Error storing event ({json_event}):\n{e}")
 
     if orphans > 2:
         logger.warning(f"Skipped {orphans} events due to no valid production_id")

--- a/backend/src/worker/sync/store/eventprice.py
+++ b/backend/src/worker/sync/store/eventprice.py
@@ -21,39 +21,43 @@ def store_new_eventprices(db_session: Session, eventprices: list[dict]):
     orphans = 0
 
     for json_price in eventprices:
-        eventprice, viernulvier_event_id = api_eventprice_to_model_eventprice(
-            json_price
-        )
-
-        # Check if the eventprice is tied to a valid event, else we would get a
-        # ForeignKey violation
-        if not viernulvier_event_id:
-            logger.warning(
-                f"Not storing eventprice (id={eventprice.viernulvier_id}) "
-                "because no associated event"
+        try:
+            eventprice, viernulvier_event_id = api_eventprice_to_model_eventprice(
+                json_price
             )
-            orphans += 1
-            continue
 
-        internal_event_id = event_map.get(viernulvier_event_id)
+            # Check if the eventprice is tied to a valid event, else we would get a
+            # ForeignKey violation
+            if not viernulvier_event_id:
+                logger.warning(
+                    f"Not storing eventprice (id={eventprice.viernulvier_id}) "
+                    "because no associated event"
+                )
+                orphans += 1
+                continue
 
-        if not internal_event_id:
-            logger.warning(
-                f"Not storing eventprice (id={eventprice.viernulvier_id}) because "
-                f"the associated event (id={viernulvier_event_id}) does not "
-                "exist (anymore)"
-            )
-            orphans += 1
-            continue
+            internal_event_id = event_map.get(viernulvier_event_id)
 
-        # Valid event id, so store this eventprice
-        db_session.merge(eventprice)
+            if not internal_event_id:
+                logger.warning(
+                    f"Not storing eventprice (id={eventprice.viernulvier_id}) because "
+                    f"the associated event (id={viernulvier_event_id}) does not "
+                    "exist (anymore)"
+                )
+                orphans += 1
+                continue
 
-        created_at_str = json_price.get("created_at")
-        if created_at_str:
-            created_at_str = datetime.fromisoformat(created_at_str)
-            if newest_timestamp is None or created_at_str > newest_timestamp:
-                newest_timestamp = created_at_str
+            # Valid event id, so store this eventprice
+            db_session.merge(eventprice)
+
+            created_at_str = json_price.get("created_at")
+            if created_at_str:
+                created_at_str = datetime.fromisoformat(created_at_str)
+                if newest_timestamp is None or created_at_str > newest_timestamp:
+                    newest_timestamp = created_at_str
+
+        except Exception as e:
+            logger.warn(f"Error storing genre ({json_price}):\n{e}")
 
     if orphans > 2:
         logger.warning(f"Skipped {orphans} eventprices due to no valid event_id")

--- a/backend/src/worker/sync/store/genre.py
+++ b/backend/src/worker/sync/store/genre.py
@@ -1,24 +1,32 @@
+import logging
+
 from datetime import datetime
 from sqlalchemy.orm import Session
 from src.worker.converters.genres import api_genre_to_model_tag
+
+logger = logging.getLogger(__name__)
 
 
 def store_new_genres(db_session: Session, genres: list[dict]):
     newest_timestamp = None
 
     for json_genre in genres:
-        tag, tag_names = api_genre_to_model_tag(json_genre)
-        db_session.add(tag)
-        db_session.flush()
+        try:
+            tag, tag_names = api_genre_to_model_tag(json_genre)
+            db_session.add(tag)
+            db_session.flush()
 
-        for tag_name in tag_names:
-            tag_name.tag_id = tag.id
-            db_session.add(tag_name)
+            for tag_name in tag_names:
+                tag_name.tag_id = tag.id
+                db_session.add(tag_name)
 
-        db_session.flush()
+            db_session.flush()
 
-        created_at = datetime.fromisoformat(json_genre["created_at"])
-        if newest_timestamp is None or created_at > newest_timestamp:
-            newest_timestamp = created_at
+            created_at = datetime.fromisoformat(json_genre["created_at"])
+            if newest_timestamp is None or created_at > newest_timestamp:
+                newest_timestamp = created_at
+
+        except Exception as e:
+            logger.warn(f"Error storing genre ({json_genre}):\n{e}")
 
     return newest_timestamp

--- a/backend/src/worker/sync/store/production.py
+++ b/backend/src/worker/sync/store/production.py
@@ -16,26 +16,30 @@ def store_new_productions(db_session: Session, productions: list[dict]):
     tag_map: dict[int, Tag] = {tag.viernulvier_id: tag for (tag,) in existing_tags}
 
     for json_prod in productions:
-        # The production contains a list of info's with its relation.
-        # sqlalchemy should automatically create all the required objects.
-        prod, vnv_tag_ids = api_prod_to_model_prod(json_prod)
-        tags = []
-        for tag in vnv_tag_ids:
-            internal_tag_id = tag_map.get(tag)
-            if not internal_tag_id:
-                logger.warning(
-                    f"Genre (id={tag}) does not exist in the database, skipping "
-                    f"this tag for production (id={prod.viernulvier_id})"
-                )
-            else:
-                tags.append(internal_tag_id)
+        try:
+            # The production contains a list of info's with its relation.
+            # sqlalchemy should automatically create all the required objects.
+            prod, vnv_tag_ids = api_prod_to_model_prod(json_prod)
+            tags = []
+            for tag in vnv_tag_ids:
+                internal_tag_id = tag_map.get(tag)
+                if not internal_tag_id:
+                    logger.warning(
+                        f"Genre (id={tag}) does not exist in the database, skipping "
+                        f"this tag for production (id={prod.viernulvier_id})"
+                    )
+                else:
+                    tags.append(internal_tag_id)
 
-        prod.tags.extend(tags)
+            prod.tags.extend(tags)
 
-        db_session.merge(prod)
+            db_session.merge(prod)
 
-        created_at = datetime.fromisoformat(json_prod["created_at"])
-        if newest_timestamp is None or created_at > newest_timestamp:
-            newest_timestamp = created_at
+            created_at = datetime.fromisoformat(json_prod["created_at"])
+            if newest_timestamp is None or created_at > newest_timestamp:
+                newest_timestamp = created_at
+
+        except Exception as e:
+            logger.warn(f"Error storing genre ({json_prod}):\n{e}")
 
     return newest_timestamp


### PR DESCRIPTION
### Beschrijving
Deze PR zet een paar try-catches rondom sync code zodat de sync worker niet meer zou mogen crashen als de API vreemde data geeft.

Git's diff algoritme is hier niet zo goed in, dus toont die veel aanpassingen, maar het is eigenlijk 3 lijnen extra (een `try:` en een `catch` met 1 lijn body), en de bestaande code 1 stap extra geindenteerd als `try`-body.


### Aangepaste delen
`backend/src/worker/sync/store/`


### Testen
Geen testen aangepast. Is dit nodig?



- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
