### PR TITLE
Implement filtering on productions

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -70,7 +70,7 @@ def seed_db():
             db.commit()
             print("Successfully assigned the 'admin' role to the default admin user.")
 
-        start_sync_date = datetime.fromisocalendar(2004, 1, 1)
+        start_sync_date = datetime.fromisocalendar(2024, 1, 1)
         for sync_type in SyncType:
             for resource_type in ResourceType:
                 sync_state = (

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -70,7 +70,7 @@ def seed_db():
             db.commit()
             print("Successfully assigned the 'admin' role to the default admin user.")
 
-        start_sync_date = datetime.fromisocalendar(2024, 1, 1)
+        start_sync_date = datetime.fromisocalendar(2004, 1, 1)
         for sync_type in SyncType:
             for resource_type in ResourceType:
                 sync_state = (

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -47,9 +47,9 @@ async def get_productions(
             tag_ids = [int(t) for t in tag_ids.split(",")]
         except ValueError:
             raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                    detail="tag_ids must be a comma-separated list of integers."
-                    )
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="tag_ids must be a comma-separated list of integers.",
+            )
 
     if artists:
         artists = artists.split(",")

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -14,7 +14,7 @@ from src.services.production import (
     update_production_by_id,
     delete_production_by_id,
 )
-from fastapi import APIRouter, Depends, Query, Request, status
+from fastapi import APIRouter, Depends, Query, Request, status, HTTPException
 from src.services.auth.permissions import Permissions
 from src.api.dependencies import RequirePermissions
 from src.models.user import User
@@ -35,15 +35,21 @@ async def get_productions(
     db: Session = Depends(get_db),
     cursor: int | None = Query(None),
     limit: int = Query(20, ge=1, le=50),
-    tags: str | None = Query(None),
+    tag_ids: str | None = Query(None),
     artists: str | None = Query(None),
     production_name: str | None = Query(None),
     earliest_at: datetime | None = Query(None),
     latest_at: datetime | None = Query(None),
 ) -> ProductionListResponse:
     base_url = get_base_url(str(request.url))
-    if tags:
-        tags = [int(t) for t in tags.split(",")]
+    if tag_ids:
+        try:
+            tag_ids = [int(t) for t in tag_ids.split(",")]
+        except ValueError:
+            raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="tag_ids must be a comma-separated list of integers."
+                    )
 
     if artists:
         artists = artists.split(",")
@@ -52,7 +58,7 @@ async def get_productions(
         base_url,
         cursor,
         limit,
-        tags=tags,
+        tags=tag_ids,
         artists=artists,
         production_name=production_name,
         earliest_at=earliest_at,

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -35,13 +35,18 @@ async def get_productions(
     db: Session = Depends(get_db),
     cursor: int | None = Query(None),
     limit: int = Query(20, ge=1, le=50),
-    tags: list[int] | None = Query(None),
-    artists: list[str] | None = Query(None),
+    tags: str | None = Query(None),
+    artists: str | None = Query(None),
     production_name: str | None = Query(None),
     earliest_at: datetime | None = Query(None),
     latest_at: datetime | None = Query(None),
 ) -> ProductionListResponse:
     base_url = get_base_url(str(request.url))
+    if tags:
+        tags = [int(t) for t in tags.split(",")]
+
+    if artists:
+        artists = artists.split(",")
     return get_productions_paginated(
         db,
         base_url,

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -82,7 +82,7 @@ def test_get_productions_with_tag(
     tag_id2 = many_productions[1].tags[0].id
 
     # Only asking tag_id1 gives 5 productions.
-    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tags": tag_id1})
+    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tag_ids": tag_id1})
     assert response.status_code == 200
     data = response.json()
     assert len(data["productions"]) == 5
@@ -100,7 +100,7 @@ def test_get_productions_with_tag(
     assert not data["pagination"]["has_more"]
 
     # Only asking tag_id2 gives 5 productions.
-    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tags": tag_id2})
+    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tag_ids": tag_id2})
     assert response.status_code == 200
 
     data = response.json()

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -82,7 +82,7 @@ def test_get_productions_with_tag(
     tag_id2 = many_productions[1].tags[0].id
 
     # Only asking tag_id1 gives 5 productions.
-    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tags": [tag_id1]})
+    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tags": tag_id1})
     assert response.status_code == 200
     data = response.json()
     assert len(data["productions"]) == 5
@@ -100,7 +100,7 @@ def test_get_productions_with_tag(
     assert not data["pagination"]["has_more"]
 
     # Only asking tag_id2 gives 5 productions.
-    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tags": [tag_id2]})
+    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "tags": tag_id2})
     assert response.status_code == 200
 
     data = response.json()
@@ -126,7 +126,7 @@ def test_get_productions_with_artist(
     # 5 productions by Steve, 5 by Bob, 0 by Alice.
     # Artist need to be conform in each production info.
     response = client.get(
-        BASE_PROD_URL + "/", params={"limit": 10, "artists": ["Steve"]}
+        BASE_PROD_URL + "/", params={"limit": 10, "artists": "Steve"}
     )
     assert response.status_code == 200
     data = response.json()
@@ -143,7 +143,7 @@ def test_get_productions_with_artist(
     assert next_cursor is None
     assert not data["pagination"]["has_more"]
 
-    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "artists": ["Bob"]})
+    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "artists": "Bob"})
     assert response.status_code == 200
 
     data = response.json()
@@ -161,7 +161,7 @@ def test_get_productions_with_artist(
 
     # Bob and Steve together gives 10 productions, Alice gives 0, but does not affect the result.
     response = client.get(
-        BASE_PROD_URL + "/", params={"limit": 10, "artists": ["Bob", "Steve", "Alice"]}
+        BASE_PROD_URL + "/", params={"limit": 10, "artists": "Bob,Steve,Alice"}
     )
     assert response.status_code == 200
 

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -125,9 +125,7 @@ def test_get_productions_with_artist(
 ):
     # 5 productions by Steve, 5 by Bob, 0 by Alice.
     # Artist need to be conform in each production info.
-    response = client.get(
-        BASE_PROD_URL + "/", params={"limit": 10, "artists": "Steve"}
-    )
+    response = client.get(BASE_PROD_URL + "/", params={"limit": 10, "artists": "Steve"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["productions"]) == 5

--- a/frontend/app/features/archive/components/FilterSidebar.tsx
+++ b/frontend/app/features/archive/components/FilterSidebar.tsx
@@ -63,6 +63,7 @@ const FilterDateCard: React.FC<DateCardProps> = ({
           <input
             type="date"
             value={dateFrom}
+			max={dateTo}
             onChange={(e) => setDateFrom(e.target.value)}
             className="archive-filter-input"
           />
@@ -74,6 +75,7 @@ const FilterDateCard: React.FC<DateCardProps> = ({
           <input
             type="date"
             value={dateTo}
+			min={dateFrom}
             onChange={(e) => setDateTo(e.target.value)}
             className="archive-filter-input"
           />

--- a/frontend/app/features/archive/components/FilterSidebar.tsx
+++ b/frontend/app/features/archive/components/FilterSidebar.tsx
@@ -63,7 +63,7 @@ const FilterDateCard: React.FC<DateCardProps> = ({
           <input
             type="date"
             value={dateFrom}
-			max={dateTo}
+            max={dateTo}
             onChange={(e) => setDateFrom(e.target.value)}
             className="archive-filter-input"
           />
@@ -75,7 +75,7 @@ const FilterDateCard: React.FC<DateCardProps> = ({
           <input
             type="date"
             value={dateTo}
-			min={dateFrom}
+            min={dateFrom}
             onChange={(e) => setDateTo(e.target.value)}
             className="archive-filter-input"
           />

--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -16,7 +16,13 @@ import type { PaginationRequest } from "../types/paginationTypes";
 const ARCHIVE_PATH: string = "/api/v1/archive";
 
 export async function getProductionsPaginated(
-  params?: PaginationRequest & { tags?: number[] }
+  params?: PaginationRequest & {
+    tags?: number[];
+	artists?: string[];
+	production_name?: string;
+	earliest_at?: string;
+	latest_at?: string;
+  }
 ): Promise<ProductionList> {
   const apiClient = createApiClient();
 
@@ -24,6 +30,7 @@ export async function getProductionsPaginated(
     params: {
       ...params,
       tags: params?.tags?.join(","),
+	  artists: params?.artists?.join("")
     },
   });
 

--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -18,10 +18,10 @@ const ARCHIVE_PATH: string = "/api/v1/archive";
 export async function getProductionsPaginated(
   params?: PaginationRequest & {
     tags?: number[];
-	artists?: string[];
-	production_name?: string;
-	earliest_at?: string;
-	latest_at?: string;
+    artists?: string[];
+    production_name?: string;
+    earliest_at?: string;
+    latest_at?: string;
   }
 ): Promise<ProductionList> {
   const apiClient = createApiClient();
@@ -30,7 +30,7 @@ export async function getProductionsPaginated(
     params: {
       ...params,
       tags: params?.tags?.join(","),
-	  artists: params?.artists?.join(",")
+      artists: params?.artists?.join(","),
     },
   });
 

--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -17,7 +17,7 @@ const ARCHIVE_PATH: string = "/api/v1/archive";
 
 export async function getProductionsPaginated(
   params?: PaginationRequest & {
-    tags?: number[];
+    tag_ids?: string[];
     artists?: string[];
     production_name?: string;
     earliest_at?: string;
@@ -29,7 +29,7 @@ export async function getProductionsPaginated(
   const response = await apiClient.get<ProductionList>(`${ARCHIVE_PATH}/productions`, {
     params: {
       ...params,
-      tags: params?.tags?.join(","),
+      tag_ids: params?.tag_ids?.join(","),
       artists: params?.artists?.join(","),
     },
   });

--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -30,7 +30,7 @@ export async function getProductionsPaginated(
     params: {
       ...params,
       tags: params?.tags?.join(","),
-	  artists: params?.artists?.join("")
+	  artists: params?.artists?.join(",")
     },
   });
 

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Tag } from "~/features/archive/types/tagTypes";
 import FilterSidebar from "../features/archive/components/FilterSidebar";
@@ -98,15 +98,24 @@ function MobileToggleButton({ onClick }: { onClick?: () => void }) {
 function ShowMoreButton({
   productionList,
   setProductionList,
+  filters,
 }: {
   productionList: ProductionList;
   setProductionList: React.Dispatch<React.SetStateAction<ProductionList | null>>;
+  filters: {
+	production_name?: string;
+    earliest_at?: string;
+    latest_at?: string;
+    tags?: number[];
+    artists?: string[];
+  };
 }) {
   const { t } = useTranslation();
 
   async function onClick() {
     const next_productions = await getProductionsPaginated({
       cursor: productionList.pagination.next_cursor,
+	  ...filters,
     });
 
     setProductionList({
@@ -141,6 +150,28 @@ export default function Archive() {
   );
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [selectedArtists, setSelectedArtists] = useState<string[]>([]);
+  const [productionList, setProductionList] = useState<ProductionList | null>(null);
+  // Debounce searchQuery so we don't fire on every keystroke
+  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), 400);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Re-fetch whenever any filter changes
+  useEffect(() => {
+    async function fetchProductions() {
+      const result = await getProductionsPaginated({
+        production_name: debouncedSearch || undefined,
+        earliest_at: dateFrom || undefined,
+        latest_at: dateTo || undefined,
+		tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/")[-1])): undefined,
+        artists: selectedArtists.length > 0 ? selectedArtists : undefined,
+      });
+      setProductionList(result);
+    }
+    fetchProductions();
+  }, [debouncedSearch, dateFrom, dateTo, selectedTags, selectedArtists]);
 
   const toggleMobileFilters = () => {
     setShowFilters((prev) => !prev);
@@ -148,10 +179,6 @@ export default function Archive() {
 
   const { t } = useTranslation();
 
-  const { data: productionList, setData: setProductionList } =
-    useAsyncFetch<ProductionList>(
-      useCallback(async () => await getProductionsPaginated(), [])
-    );
   const productions = productionList?.productions ?? [];
 
   return (
@@ -210,6 +237,13 @@ export default function Archive() {
             <ShowMoreButton
               productionList={productionList}
               setProductionList={setProductionList}
+			  filters={{
+				production_name: debouncedSearch || undefined,
+				earliest_at: dateFrom || undefined,
+				latest_at: dateTo || undefined,
+				tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/")[-1])): undefined,
+				artists: selectedArtists.length > 0 ? selectedArtists : undefined,
+			  }}
             />
           )}
         </div>

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -165,7 +165,7 @@ export default function Archive() {
         production_name: debouncedSearch || undefined,
         earliest_at: dateFrom || undefined,
         latest_at: dateTo || undefined,
-		tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/")[-1])): undefined,
+		tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop())) : undefined,
         artists: selectedArtists.length > 0 ? selectedArtists : undefined,
       });
       setProductionList(result);
@@ -241,7 +241,7 @@ export default function Archive() {
 				production_name: debouncedSearch || undefined,
 				earliest_at: dateFrom || undefined,
 				latest_at: dateTo || undefined,
-				tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/")[-1])): undefined,
+				tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop())) : undefined,
 				artists: selectedArtists.length > 0 ? selectedArtists : undefined,
 			  }}
             />

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -105,7 +105,7 @@ function ShowMoreButton({
     production_name?: string;
     earliest_at?: string;
     latest_at?: string;
-    tags?: number[];
+    tag_ids?: string[];
     artists?: string[];
   };
 }) {
@@ -164,9 +164,9 @@ export default function Archive() {
         production_name: debouncedSearch || undefined,
         earliest_at: dateFrom || undefined,
         latest_at: dateTo || undefined,
-        tags:
+        tag_ids:
           selectedTags.length > 0
-            ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop()))
+            ? selectedTags.map((tag) => tag.id_url.split("/").pop()!)
             : undefined,
         artists: selectedArtists.length > 0 ? selectedArtists : undefined,
       });
@@ -243,9 +243,9 @@ export default function Archive() {
                 production_name: debouncedSearch || undefined,
                 earliest_at: dateFrom || undefined,
                 latest_at: dateTo || undefined,
-                tags:
+                tag_ids:
                   selectedTags.length > 0
-                    ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop()))
+                    ? selectedTags.map((tag) => tag.id_url.split("/").pop()!)
                     : undefined,
                 artists: selectedArtists.length > 0 ? selectedArtists : undefined,
               }}

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Tag } from "~/features/archive/types/tagTypes";
 import FilterSidebar from "../features/archive/components/FilterSidebar";
@@ -9,7 +9,6 @@ import {
   ProductionTimeline,
 } from "~/features/archive/components/ProductionTimeline";
 import { Divider } from "@mui/material";
-import { useAsyncFetch } from "~/shared/hooks/useAsyncFetch";
 import { getProductionsPaginated } from "~/features/archive/services/productionService";
 import type { ProductionList } from "~/features/archive/types/productionTypes";
 import { Protected } from "~/features/auth";
@@ -103,7 +102,7 @@ function ShowMoreButton({
   productionList: ProductionList;
   setProductionList: React.Dispatch<React.SetStateAction<ProductionList | null>>;
   filters: {
-	production_name?: string;
+    production_name?: string;
     earliest_at?: string;
     latest_at?: string;
     tags?: number[];
@@ -115,7 +114,7 @@ function ShowMoreButton({
   async function onClick() {
     const next_productions = await getProductionsPaginated({
       cursor: productionList.pagination.next_cursor,
-	  ...filters,
+      ...filters,
     });
 
     setProductionList({
@@ -165,7 +164,10 @@ export default function Archive() {
         production_name: debouncedSearch || undefined,
         earliest_at: dateFrom || undefined,
         latest_at: dateTo || undefined,
-		tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop())) : undefined,
+        tags:
+          selectedTags.length > 0
+            ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop()))
+            : undefined,
         artists: selectedArtists.length > 0 ? selectedArtists : undefined,
       });
       setProductionList(result);
@@ -237,13 +239,16 @@ export default function Archive() {
             <ShowMoreButton
               productionList={productionList}
               setProductionList={setProductionList}
-			  filters={{
-				production_name: debouncedSearch || undefined,
-				earliest_at: dateFrom || undefined,
-				latest_at: dateTo || undefined,
-				tags: selectedTags.length > 0 ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop())) : undefined,
-				artists: selectedArtists.length > 0 ? selectedArtists : undefined,
-			  }}
+              filters={{
+                production_name: debouncedSearch || undefined,
+                earliest_at: dateFrom || undefined,
+                latest_at: dateTo || undefined,
+                tags:
+                  selectedTags.length > 0
+                    ? selectedTags.map((tag) => Number(tag.id_url.split("/").pop()))
+                    : undefined,
+                artists: selectedArtists.length > 0 ? selectedArtists : undefined,
+              }}
             />
           )}
         </div>

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -102,12 +102,12 @@ describe("Archive", () => {
       // Before clicking show more
       expectEveryProductionVisible([mockProductions[0]]);
       expect(productionService.getProductionsPaginated).toHaveBeenNthCalledWith(1, {
-		artists: undefined,
-		earliest_at: "1970-01-01",
+        artists: undefined,
+        earliest_at: "1970-01-01",
         latest_at: "2026-04-22",
         production_name: undefined,
         tag_ids: undefined,
-	  });
+      });
 
       await user.click(screen.getByText("archive.show_more"));
 
@@ -116,8 +116,8 @@ describe("Archive", () => {
 
       expect(productionService.getProductionsPaginated).toHaveBeenCalledWith({
         cursor: 123,
-		artists: undefined,
-		earliest_at: "1970-01-01",
+        artists: undefined,
+        earliest_at: "1970-01-01",
         latest_at: "2026-04-22",
         production_name: undefined,
         tag_ids: undefined,

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -101,7 +101,13 @@ describe("Archive", () => {
 
       // Before clicking show more
       expectEveryProductionVisible([mockProductions[0]]);
-      expect(productionService.getProductionsPaginated).toHaveBeenNthCalledWith(1);
+      expect(productionService.getProductionsPaginated).toHaveBeenNthCalledWith(1, {
+		artists: undefined,
+		earliest_at: "1970-01-01",
+        latest_at: "2026-04-22",
+        production_name: undefined,
+        tag_ids: undefined,
+	  });
 
       await user.click(screen.getByText("archive.show_more"));
 
@@ -110,6 +116,11 @@ describe("Archive", () => {
 
       expect(productionService.getProductionsPaginated).toHaveBeenCalledWith({
         cursor: 123,
+		artists: undefined,
+		earliest_at: "1970-01-01",
+        latest_at: "2026-04-22",
+        production_name: undefined,
+        tag_ids: undefined,
       });
     });
   });


### PR DESCRIPTION
### Beschrijving
Filters werken nu en filteren de producties


### Aangepaste delen
Correcte afhandelijk van lijsten aan tags en artiesten
getProductionsPaginated support nu tags
archive.tsx geeft de tags door


### Speciale opmerkingen
Door de verschillen in implementatie van tags tussen frontend en backend was het moeilijk om de filters werkend te krijgen. Ik heb uiteindelijk de tag_id uit de id_url gehaald om deze door te sturen.


### Afhankelijkheden
geen


### Testen
Voorlopig geen testen toegevoegd


Closes #169 

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
