### PR TITLE
Fix/Pass language to axios client as header

### DIFF
--- a/frontend/app/features/archive/components/FilterSidebar.tsx
+++ b/frontend/app/features/archive/components/FilterSidebar.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { getArtists } from "~/features/archive/services/artistService";
 import { getAllTags, getTagByName } from "~/features/archive/services/tagService";
 import type { Tag } from "~/features/archive/types/tagTypes";
-import i18n from "~/i18n";
 import FilterCard from "./FilterCard";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
@@ -91,6 +90,7 @@ interface TagCardProps {
 }
 
 const FilterTagCard: React.FC<TagCardProps> = ({ selectedTags, setSelectedTags }) => {
+  const { i18n } = useTranslation();
   const [tags, setTags] = useState<Tag[]>([]);
   const [popTags, setPopTags] = useState<Tag[]>([]);
   const [tagQuery, setTagQuery] = useState("");
@@ -116,7 +116,7 @@ const FilterTagCard: React.FC<TagCardProps> = ({ selectedTags, setSelectedTags }
 
   useEffect(() => {
     getAllTags().then(setTags).catch(console.error);
-  }, []);
+  }, [i18n.resolvedLanguage]);
 
   useEffect(() => {
     const mostPopularTags = [

--- a/frontend/app/features/archive/components/ProductionPage.tsx
+++ b/frontend/app/features/archive/components/ProductionPage.tsx
@@ -645,7 +645,7 @@ export function ProductionPage({
     return () => {
       isCancelled = true;
     };
-  }, [production.event_id_urls]);
+  }, [production.event_id_urls, i18n.resolvedLanguage]);
 
   return (
     <div className="bg-archive-paper text-archive-ink min-h-screen">

--- a/frontend/app/features/archive/components/ProductionPage.tsx
+++ b/frontend/app/features/archive/components/ProductionPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useBlocker } from "react-router";
+import { Link, useBlocker, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import React, { useEffect, useMemo, useState } from "react";
 import DOMPurify from "dompurify";
@@ -122,7 +122,8 @@ async function handleSave(
   draftInfo: ProductionInfo | null,
   setOriginalInfo: React.Dispatch<React.SetStateAction<ProductionInfo | null>>,
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
-  setIsSaving: React.Dispatch<React.SetStateAction<boolean>>
+  setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
+  language: string
 ) {
   if (!draftInfo || !originalInfo) return;
 
@@ -131,7 +132,7 @@ async function handleSave(
     await updateProductionByUrl(production_id_url, {
       production_infos: [
         {
-          language: draftInfo.language,
+          language: language,
           title: draftInfo.title,
           supertitle: draftInfo.supertitle,
           artist: draftInfo.artist,
@@ -477,13 +478,11 @@ function EditButton({
   );
 }
 
-export function ProductionPage({
-  production,
-  preferredLanguage = "nl",
-}: ProductionPageProps) {
+export function ProductionPage({ production, preferredLanguage }: ProductionPageProps) {
   const { t, i18n } = useTranslation();
+  const { lang } = useParams();
 
-  const language = i18n.resolvedLanguage ?? preferredLanguage;
+  const language = preferredLanguage ?? lang!;
   const productionInfo = getProductionInfoByLanguage(
     production.production_infos,
     language
@@ -511,7 +510,8 @@ export function ProductionPage({
       draftInfo,
       setOriginalInfo,
       setIsEditing,
-      setIsSaving
+      setIsSaving,
+      language
     );
 
   // State when editing, keeps track if something has changed

--- a/frontend/app/features/archive/components/ProductionTimeline.tsx
+++ b/frontend/app/features/archive/components/ProductionTimeline.tsx
@@ -58,13 +58,17 @@ function groupProductions(productions: Production[]): GroupedProductions {
 function MonthDisplay({
   productions,
   month,
+  preferredLanguage,
 }: {
   productions: Production[];
   year: number;
   month: number;
+  preferredLanguage?: string;
 }) {
   const { lang } = useParams();
   const { t } = useTranslation();
+
+  const language = preferredLanguage ?? lang;
 
   return (
     <div>
@@ -72,7 +76,7 @@ function MonthDisplay({
       {month != -1 ? (
         <div className="bg-archive-paper/80 sticky top-20 z-30 mb-3 flex min-h-14 items-center gap-3 overflow-visible backdrop-blur-[14px]">
           <div className="upper text-[14px] font-bold tracking-[0.28em] uppercase opacity-25">
-            {month === -1 ? t("Unknown") : getLongMonthName(month, lang)}
+            {month === -1 ? t("Unknown") : getLongMonthName(month, language)}
           </div>
           <Divider className="bg-archive-ink/15 flex-1" />
         </div>
@@ -85,7 +89,12 @@ function MonthDisplay({
       {/* Productions */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3">
         {productions.map((prod) => (
-          <ProductionCard key={prod.id_url} production={prod} className="" />
+          <ProductionCard
+            key={prod.id_url}
+            production={prod}
+            className=""
+            preferredLanguage={language}
+          />
         ))}
       </div>
     </div>
@@ -96,15 +105,18 @@ function YearDisplay({
   productionsPerMonth,
   year,
   sortOrder,
+  preferredLanguage,
 }: {
   productionsPerMonth: Map<number, Production[]>;
   year: number;
   sortOrder?: ArchiveSortOrder;
+  preferredLanguage?: string;
 }) {
   const { t } = useTranslation();
   const months = [...productionsPerMonth.keys()];
 
   const sortFunction = getSortFunction(sortOrder);
+  const language = preferredLanguage;
 
   return (
     <div>
@@ -119,6 +131,7 @@ function YearDisplay({
           productions={productionsPerMonth.get(month)!}
           month={month}
           year={year}
+          preferredLanguage={language}
         />
       ))}
     </div>
@@ -129,15 +142,18 @@ export function ProductionTimeline({
   productions,
   className,
   sortOrder,
+  preferredLanguage,
 }: {
   productions: Production[];
   className?: string;
   sortOrder?: ArchiveSortOrder;
+  preferredLanguage?: string;
 }) {
   const groupedProductions = groupProductions(productions);
   const years = [...groupedProductions.keys()];
 
   const sortFunction = getSortFunction(sortOrder);
+  const language = preferredLanguage;
 
   return (
     <div className={className}>
@@ -147,6 +163,7 @@ export function ProductionTimeline({
           productionsPerMonth={groupedProductions.get(year)!}
           year={year}
           sortOrder={sortOrder}
+          preferredLanguage={language}
         />
       ))}
     </div>

--- a/frontend/app/features/archive/components/ProductionTimeline.tsx
+++ b/frontend/app/features/archive/components/ProductionTimeline.tsx
@@ -72,7 +72,7 @@ function MonthDisplay({
       {month != -1 ? (
         <div className="bg-archive-paper/80 sticky top-20 z-30 mb-3 flex min-h-14 items-center gap-3 overflow-visible backdrop-blur-[14px]">
           <div className="upper text-[14px] font-bold tracking-[0.28em] uppercase opacity-25">
-            {month == -1 ? t("Unknown") : getLongMonthName(month, lang)}
+            {month === -1 ? t("Unknown") : getLongMonthName(month, lang)}
           </div>
           <Divider className="bg-archive-ink/15 flex-1" />
         </div>
@@ -109,7 +109,7 @@ function YearDisplay({
   return (
     <div>
       <h2 className="mt-5 min-h-18 font-serif text-6xl font-black tracking-tighter opacity-20 transition-all">
-        {year == -1 ? t("archive.unknownDate") : year}
+        {year === -1 ? t("archive.unknownDate") : year}
       </h2>
       <Divider className="bg-archive-accent/15 flex-1" />
 

--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -40,12 +40,18 @@ export async function getProductionsPaginated(
   return response.data;
 }
 
-export async function getProduction(productionId: number): Promise<Production> {
-  return getFromArchive<Production>(`/productions/${productionId}`);
+export async function getProduction(
+  productionId: number,
+  lang?: string
+): Promise<Production> {
+  return getFromArchive<Production>(`/productions/${productionId}`, lang);
 }
 
-export async function getProductionByUrl(productionUrl: string): Promise<Production> {
-  return getByUrl<Production>(productionUrl);
+export async function getProductionByUrl(
+  productionUrl: string,
+  lang?: string
+): Promise<Production> {
+  return getByUrl<Production>(productionUrl, lang);
 }
 
 export async function createProduction(

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -231,7 +231,7 @@ export default function Archive() {
               <p className="italic opacity-60 md:text-lg">
                 {/* Result count */}
                 {productions.length}{" "}
-                {productions.length == 1 ? t("archive.result") : t("archive.results")}
+                {productions.length === 1 ? t("archive.result") : t("archive.results")}
               </p>
               <CreateProductionButton />
             </div>

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -144,6 +144,8 @@ function ShowMoreButton({
 }
 
 export default function Archive() {
+  const { t, i18n } = useTranslation();
+
   const [sortOrder, setSortOrder] = useState<ArchiveSortOrder>(
     ArchiveSortOrder.NewestFirst
   );
@@ -183,14 +185,20 @@ export default function Archive() {
       setProductionList(result);
     }
     fetchProductions();
-  }, [debouncedSearch, dateFrom, dateTo, selectedTags, selectedArtists, sortOrder]);
+  }, [
+    debouncedSearch,
+    dateFrom,
+    dateTo,
+    selectedTags,
+    selectedArtists,
+    sortOrder,
+    i18n.resolvedLanguage,
+  ]);
   const productions = productionList?.productions ?? [];
 
   const toggleMobileFilters = () => {
     setShowFilters((prev) => !prev);
   };
-
-  const { t } = useTranslation();
 
   return (
     <div className="mx-6 md:mx-10">

--- a/frontend/app/routes/productions.$productionId.tsx
+++ b/frontend/app/routes/productions.$productionId.tsx
@@ -7,6 +7,7 @@ import {
   getProductionByUrl,
 } from "~/features/archive/services/productionService";
 import type { Production } from "~/features/archive/types/productionTypes";
+import { useTranslation } from "react-i18next";
 
 function getProductionNumericIdFromInput(
   productionIdInput: string
@@ -31,6 +32,7 @@ export default function ProductionDetailRoute() {
     () => decodeURIComponent(productionId),
     [productionId]
   );
+  const { i18n } = useTranslation();
   const [production, setProduction] = useState<Production | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
@@ -77,7 +79,7 @@ export default function ProductionDetailRoute() {
     return () => {
       isCancelled = true;
     };
-  }, [decodedProductionId]);
+  }, [decodedProductionId, i18n.resolvedLanguage]);
 
   if (isLoading) {
     return <div>Loading production...</div>;

--- a/frontend/app/routes/productions.$productionId.tsx
+++ b/frontend/app/routes/productions.$productionId.tsx
@@ -33,6 +33,7 @@ export default function ProductionDetailRoute() {
     [productionId]
   );
   const { i18n } = useTranslation();
+  const { lang } = useParams();
   const [production, setProduction] = useState<Production | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
@@ -47,10 +48,18 @@ export default function ProductionDetailRoute() {
       try {
         const numericId = getProductionNumericIdFromInput(decodedProductionId);
 
-        const productionData =
+        let productionData =
           typeof numericId === "number"
             ? await getProduction(numericId)
             : await getProductionByUrl(decodedProductionId);
+
+        if (productionData.production_infos.length == 0 && !isCancelled) {
+          const otherLanguage = lang == "en" ? "nl" : "en";
+          productionData =
+            typeof numericId === "number"
+              ? await getProduction(numericId, otherLanguage)
+              : await getProductionByUrl(decodedProductionId, otherLanguage);
+        }
 
         if (!isCancelled) {
           setProduction(productionData);
@@ -79,7 +88,7 @@ export default function ProductionDetailRoute() {
     return () => {
       isCancelled = true;
     };
-  }, [decodedProductionId, i18n.resolvedLanguage]);
+  }, [decodedProductionId, i18n.resolvedLanguage, lang]);
 
   if (isLoading) {
     return <div>Loading production...</div>;

--- a/frontend/app/routes/productions.$productionId.tsx
+++ b/frontend/app/routes/productions.$productionId.tsx
@@ -53,6 +53,7 @@ export default function ProductionDetailRoute() {
             ? await getProduction(numericId)
             : await getProductionByUrl(decodedProductionId);
 
+        // Check if the frontend received a production info, otherwise refetch with another language
         if (productionData.production_infos.length === 0 && !isCancelled) {
           const otherLanguage = lang === "en" ? "nl" : "en";
           productionData =

--- a/frontend/app/routes/productions.$productionId.tsx
+++ b/frontend/app/routes/productions.$productionId.tsx
@@ -53,8 +53,8 @@ export default function ProductionDetailRoute() {
             ? await getProduction(numericId)
             : await getProductionByUrl(decodedProductionId);
 
-        if (productionData.production_infos.length == 0 && !isCancelled) {
-          const otherLanguage = lang == "en" ? "nl" : "en";
+        if (productionData.production_infos.length === 0 && !isCancelled) {
+          const otherLanguage = lang === "en" ? "nl" : "en";
           productionData =
             typeof numericId === "number"
               ? await getProduction(numericId, otherLanguage)

--- a/frontend/app/shared/services/apiClient.ts
+++ b/frontend/app/shared/services/apiClient.ts
@@ -7,6 +7,7 @@ import {
 } from "~/features/auth/services/tokenStorage";
 
 import { getEnv } from "../utils/env";
+import i18n from "~/i18n";
 
 type RetryableRequestConfig = InternalAxiosRequestConfig & {
   _retry?: boolean;
@@ -39,9 +40,15 @@ export function createApiClient() {
 
   apiClient.interceptors.request.use((config) => {
     const accessToken = getStoredAccessToken();
+    const lang = i18n.language;
 
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    if (lang) {
+      config.headers["Accept-Language"] = lang;
+      config.headers["Preferred-Language"] = lang;
     }
 
     return config;

--- a/frontend/app/shared/services/apiClient.ts
+++ b/frontend/app/shared/services/apiClient.ts
@@ -27,7 +27,7 @@ function shouldRetryUnauthorized(request: RetryableRequestConfig | undefined): b
 
 let activeRefreshRequest: Promise<string> | null = null;
 
-export function createApiClient() {
+export function createApiClient(lang?: string) {
   const { API_BASE_URL } = getEnv();
 
   const apiClient = axios.create({
@@ -35,20 +35,22 @@ export function createApiClient() {
     timeout: 5000,
     headers: {
       "Content-Type": "application/json",
+      "Accept-Language": lang,
+      "Preferred-Language": lang,
     },
   });
 
   apiClient.interceptors.request.use((config) => {
     const accessToken = getStoredAccessToken();
-    const lang = i18n.language;
+    const i18nlang = i18n.language;
 
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
 
-    if (lang) {
-      config.headers["Accept-Language"] = lang;
-      config.headers["Preferred-Language"] = lang;
+    if (!lang && i18nlang) {
+      config.headers["Accept-Language"] = i18nlang;
+      config.headers["Preferred-Language"] = i18nlang;
     }
 
     return config;

--- a/frontend/app/shared/services/sharedService.ts
+++ b/frontend/app/shared/services/sharedService.ts
@@ -23,14 +23,14 @@ export interface PaginationParams {
   limit?: number;
 }
 
-export async function getByUrl<T>(url: string): Promise<T> {
-  const apiClient = createApiClient();
+export async function getByUrl<T>(url: string, lang?: string): Promise<T> {
+  const apiClient = createApiClient(lang);
   const data = await apiClient.get<T>(normalizeRequestUrl(url));
   return data.data;
 }
 
-export async function getFromArchive<T>(url: string): Promise<T> {
-  const apiClient = createApiClient();
+export async function getFromArchive<T>(url: string, lang?: string): Promise<T> {
+  const apiClient = createApiClient(lang);
   const data = await apiClient.get<T>(`${ARCHIVE_PATH}${url}`);
   return data.data;
 }

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -105,7 +105,7 @@ describe("Archive", () => {
       expect(productionService.getProductionsPaginated).toHaveBeenNthCalledWith(1, {
         artists: undefined,
         earliest_at: "1970-01-01",
-        latest_at: "2026-04-22",
+        latest_at: new Date(),
         production_name: undefined,
         sort_order: "Descending",
         tag_ids: undefined,
@@ -120,7 +120,7 @@ describe("Archive", () => {
         cursor: 123,
         artists: undefined,
         earliest_at: "1970-01-01",
-        latest_at: "2026-04-22",
+        latest_at: new Date(),
         sort_order: "Descending",
         production_name: undefined,
         tag_ids: undefined,

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -105,7 +105,7 @@ describe("Archive", () => {
       expect(productionService.getProductionsPaginated).toHaveBeenNthCalledWith(1, {
         artists: undefined,
         earliest_at: "1970-01-01",
-        latest_at: new Date(),
+        latest_at: expect.anything(),
         production_name: undefined,
         sort_order: "Descending",
         tag_ids: undefined,
@@ -120,7 +120,7 @@ describe("Archive", () => {
         cursor: 123,
         artists: undefined,
         earliest_at: "1970-01-01",
-        latest_at: new Date(),
+        latest_at: expect.anything(),
         sort_order: "Descending",
         production_name: undefined,
         tag_ids: undefined,

--- a/frontend/tests/unit/apiClient.test.ts
+++ b/frontend/tests/unit/apiClient.test.ts
@@ -4,6 +4,7 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import { createApiClient } from "~/shared/services/apiClient";
 import * as envModule from "~/shared/utils/env";
 import * as tokenRefreshModule from "~/features/auth/services/tokenRefresh";
+import i18n from "~/i18n";
 import { getByUrl } from "~/shared/services/sharedService";
 
 vi.mock("~/features/auth");
@@ -51,6 +52,26 @@ describe("createApiClient", () => {
 
     await client.get("/test");
     expect(capturedAuthHeader).toBe("Bearer test_token1234");
+  });
+  it("adds language headers when i18n.language is set", async () => {
+    vi.spyOn(i18n, "language", "get").mockReturnValue("en");
+
+    const client = createApiClient();
+
+    let acceptLanguage: string | undefined;
+    let preferredLanguage: string | undefined;
+
+    const mockAdapter = new AxiosMockAdapter(client);
+    mockAdapter.onGet("/test-lang").reply((config) => {
+      acceptLanguage = config.headers?.["Accept-Language"] as string;
+      preferredLanguage = config.headers?.["Preferred-Language"] as string;
+      return [200, {}];
+    });
+
+    await client.get("/test-lang");
+
+    expect(acceptLanguage).toBe("en");
+    expect(preferredLanguage).toBe("en");
   });
 
   it("returns response data on GET request", async () => {

--- a/frontend/tests/unit/components/ProductionTimeline.test.tsx
+++ b/frontend/tests/unit/components/ProductionTimeline.test.tsx
@@ -1,20 +1,28 @@
 import { screen, within, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import type { ReactElement } from "react";
 import { mockProductions } from "tests/mocks/productions.mock";
 import { describe, it, expect } from "vitest";
 import {
   ArchiveSortOrder,
   ProductionTimeline,
 } from "~/features/archive/components/ProductionTimeline";
+import type { Production } from "~/features/archive/types/productionTypes";
 
-function renderTimeline(ui: ReactElement) {
-  return render(<MemoryRouter initialEntries={["/en/archive"]}>{ui}</MemoryRouter>);
+function renderTimeline(productions: Production[], sortOrder?: ArchiveSortOrder) {
+  return render(
+    <MemoryRouter initialEntries={["/en/archive"]}>
+      <ProductionTimeline
+        productions={productions}
+        sortOrder={sortOrder}
+        preferredLanguage="en"
+      />
+    </MemoryRouter>
+  );
 }
 
 describe("ProductionTimeline", () => {
   it("displays all passed productions", () => {
-    renderTimeline(<ProductionTimeline productions={mockProductions} />);
+    renderTimeline(mockProductions);
 
     for (const prod of mockProductions) {
       const exists = prod.production_infos.some(
@@ -26,7 +34,7 @@ describe("ProductionTimeline", () => {
   });
 
   it("displays months grouped per year", async () => {
-    renderTimeline(<ProductionTimeline productions={mockProductions} />);
+    renderTimeline(mockProductions);
 
     // Check if we can find a year header
     const yearHeader = screen.getByText("2026");
@@ -43,36 +51,27 @@ describe("ProductionTimeline", () => {
 
   describe("unknown date header", () => {
     it("displays when a production's date is not known", () => {
-      renderTimeline(
-        <ProductionTimeline
-          productions={[
-            ...mockProductions,
-            {
-              ...mockProductions[0],
-              earliest_at: undefined,
-              latest_at: undefined,
-              events: [],
-            },
-          ]}
-        />
-      );
+      renderTimeline([
+        ...mockProductions,
+        {
+          ...mockProductions[0],
+          earliest_at: undefined,
+          latest_at: undefined,
+          events: [],
+        },
+      ]);
 
       expect(screen.getByText("archive.unknownDate")).toBeInTheDocument();
     });
     it("does not display when all production's dates are known", () => {
-      renderTimeline(<ProductionTimeline productions={mockProductions} />);
+      renderTimeline(mockProductions);
       expect(screen.queryByText("archive.unknownDate")).toBeNull();
     });
   });
 
   describe("sort order", () => {
     it("lists years in descending order when passing ArchiveSortOrder.NewestFirst", () => {
-      renderTimeline(
-        <ProductionTimeline
-          sortOrder={ArchiveSortOrder.NewestFirst}
-          productions={mockProductions}
-        />
-      );
+      renderTimeline(mockProductions, ArchiveSortOrder.NewestFirst);
 
       const year2026 = screen.getByText("2026");
       const year2025 = screen.getByText("2025");
@@ -84,12 +83,7 @@ describe("ProductionTimeline", () => {
     });
 
     it("lists years in ascending order when passing ArchiveSortOrder.OldestFirst", () => {
-      renderTimeline(
-        <ProductionTimeline
-          sortOrder={ArchiveSortOrder.OldestFirst}
-          productions={mockProductions}
-        />
-      );
+      renderTimeline(mockProductions, ArchiveSortOrder.OldestFirst);
 
       const year2026 = screen.getByText("2026");
       const year2025 = screen.getByText("2025");

--- a/frontend/tests/unit/filterSideBar.test.tsx
+++ b/frontend/tests/unit/filterSideBar.test.tsx
@@ -118,7 +118,9 @@ describe("FilterSidebar – tags filter", () => {
     await waitFor(() => screen.getByPlaceholderText("filter.search_tags"));
     const tagInput = screen.getByPlaceholderText("filter.search_tags");
     await userEvent.type(tagInput, "dan");
-    expect(screen.getByText("Dans")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Dans") ?? screen.queryByText("Dance")
+    ).toBeInTheDocument();
   });
 
   it("selecting a tag from the dropdown calls setSelectedTags and clears query", async () => {
@@ -128,7 +130,7 @@ describe("FilterSidebar – tags filter", () => {
     await waitFor(() => screen.getByPlaceholderText("filter.search_tags"));
     const tagInput = screen.getByPlaceholderText("filter.search_tags");
     await userEvent.type(tagInput, "dan");
-    fireEvent.mouseDown(screen.getByText("Dans"));
+    fireEvent.mouseDown(screen.queryByText("Dans") ?? screen.getByText("Dance"));
     expect(props.setSelectedTags).toHaveBeenCalled();
     expect(tagInput).toHaveValue("");
   });

--- a/frontend/tests/unit/productionPage.test.tsx
+++ b/frontend/tests/unit/productionPage.test.tsx
@@ -28,7 +28,7 @@ function renderPage(production: Production) {
     [
       {
         path: "/:lang/productions/:productionId",
-        element: <ProductionPage production={production} />,
+        element: <ProductionPage production={production} preferredLanguage="en" />,
       },
     ],
     {


### PR DESCRIPTION
### Beschrijving
De huidige taal van de frontend werd nog niet meegegeven aan de axios client waarmee alle fetch requests gebeuren waardoor de browser enkel data binnen kreeg in de taal van de browser zelf en niet van de frontend.

### Aangepaste delen
- Axios client zet preferred-language en accept-language headers op de huidig geselecteerde taal.
- Voegt i18n taal als dependency aan verschillende useEffects zodat deze data automatisch wordt gerefetched. (filtersidebar tags, production page fetch, archive productions fetch, production page) 

- frontend tests aangepast
  - integration/ArchivePage, latest_at is niet langer gehardcodeerd zodat de werking van de testen niet gebonden is aan welke dag dat het is.
  - unit/filterSideBar aangepast zodat ze werken onafhankelijk van de default taal van de pagina
- test toegevoegd voor of de headers wel worden meegestuurd in de apiClient


- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
