### PR TITLE
add button to reset filters

### DIFF
--- a/frontend/app/features/archive/components/FilterSidebar.tsx
+++ b/frontend/app/features/archive/components/FilterSidebar.tsx
@@ -402,7 +402,7 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
         type="button"
         onClick={resetFilters}
         disabled={!hasActiveFilters}
-        className="border-archive-ink/15 border-archive-ink-dark/15 hover:border-archive-accent hover:text-archive-accent disabled:hover:border-archive-ink/15 disabled:hover:border-archive-ink-dark/15 w-full cursor-pointer rounded-lg border px-4 py-2 text-[10px] font-semibold tracking-widest uppercase transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-inherit"
+        className="border-archive-ink/15 hover:border-archive-accent hover:text-archive-accent disabled:hover:border-archive-ink/15 w-full cursor-pointer rounded-lg border px-4 py-2 text-[10px] font-semibold tracking-widest uppercase transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-inherit"
       >
         {t("filter.reset")}
       </button>

--- a/frontend/app/features/archive/components/FilterSidebar.tsx
+++ b/frontend/app/features/archive/components/FilterSidebar.tsx
@@ -374,7 +374,23 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
   selectedArtists,
   setSelectedArtists,
 }) => {
+  const { t } = useTranslation();
   const sidebarRef = useRef<HTMLElement>(null);
+
+  const hasActiveFilters =
+    searchQuery.trim().length > 0 ||
+    dateFrom.length > 0 ||
+    dateTo.length > 0 ||
+    selectedTags.length > 0 ||
+    selectedArtists.length > 0;
+
+  const resetFilters = () => {
+    setSearchQuery("");
+    setDateFrom("");
+    setDateTo("");
+    setSelectedTags([]);
+    setSelectedArtists([]);
+  };
 
   return (
     <aside
@@ -382,6 +398,14 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
       id="archive-sidebar"
       className={`${show ? "block" : "hidden"} sticky-scroll mb-10 max-h-[calc(100vh-120px)] w-full min-w-1/4 space-y-6 overflow-y-auto pr-0 lg:sticky lg:top-24 lg:mb-0 lg:block lg:w-80 lg:overflow-y-auto lg:pr-4`}
     >
+      <button
+        type="button"
+        onClick={resetFilters}
+        disabled={!hasActiveFilters}
+        className="border-archive-ink/15 border-archive-ink-dark/15 hover:border-archive-accent hover:text-archive-accent disabled:hover:border-archive-ink/15 disabled:hover:border-archive-ink-dark/15 disabled:hover:text-inherit w-full cursor-pointer rounded-lg border px-4 py-2 text-[10px] font-semibold tracking-widest uppercase transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {t("filter.reset")}
+      </button>
       <FilterSearchCard searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
       <FilterDateCard
         dateFrom={dateFrom}

--- a/frontend/app/features/archive/components/FilterSidebar.tsx
+++ b/frontend/app/features/archive/components/FilterSidebar.tsx
@@ -402,7 +402,7 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
         type="button"
         onClick={resetFilters}
         disabled={!hasActiveFilters}
-        className="border-archive-ink/15 border-archive-ink-dark/15 hover:border-archive-accent hover:text-archive-accent disabled:hover:border-archive-ink/15 disabled:hover:border-archive-ink-dark/15 disabled:hover:text-inherit w-full cursor-pointer rounded-lg border px-4 py-2 text-[10px] font-semibold tracking-widest uppercase transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+        className="border-archive-ink/15 border-archive-ink-dark/15 hover:border-archive-accent hover:text-archive-accent disabled:hover:border-archive-ink/15 disabled:hover:border-archive-ink-dark/15 w-full cursor-pointer rounded-lg border px-4 py-2 text-[10px] font-semibold tracking-widest uppercase transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-inherit"
       >
         {t("filter.reset")}
       </button>

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -152,14 +152,8 @@ export default function Archive() {
 
   const [showFilters, setShowFilters] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [dateFrom, setDateFrom] = useState(
-    // "1970-01-01"
-    ""
-  );
-  const [dateTo, setDateTo] = useState(
-    ""
-    // `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
-  );
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [selectedArtists, setSelectedArtists] = useState<string[]>([]);
   const [productionList, setProductionList] = useState<ProductionList | null>(null);

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -152,11 +152,14 @@ export default function Archive() {
 
   const [showFilters, setShowFilters] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [dateFrom, setDateFrom] = useState("1970-01-01");
+  const [dateFrom, setDateFrom] = useState(
+    // "1970-01-01"
+    ""
+  );
   const date = new Date();
   const pad = (n: number) => String(n).padStart(2, "0");
-  const [dateTo, setDateTo] = useState(
-    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+  const [dateTo, setDateTo] = useState(""
+    // `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
   );
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [selectedArtists, setSelectedArtists] = useState<string[]>([]);

--- a/frontend/app/routes/archive.tsx
+++ b/frontend/app/routes/archive.tsx
@@ -156,9 +156,8 @@ export default function Archive() {
     // "1970-01-01"
     ""
   );
-  const date = new Date();
-  const pad = (n: number) => String(n).padStart(2, "0");
-  const [dateTo, setDateTo] = useState(""
+  const [dateTo, setDateTo] = useState(
+    ""
     // `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
   );
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -20,6 +20,7 @@
     "halls": "Venues",
     "artists": "Artists",
     "search_artists": "Search for artists",
+    "reset": "Reset filters",
     "toggle_menu": "Filter & Search"
   },
 

--- a/frontend/public/locales/nl/translation.json
+++ b/frontend/public/locales/nl/translation.json
@@ -20,6 +20,7 @@
     "halls": "Locaties",
     "artists": "Artiesten",
     "search_artists": "Zoek naar artiesten",
+    "reset": "Filters resetten",
     "toggle_menu": "Filteren & Zoeken"
   },
 

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -104,8 +104,8 @@ describe("Archive", () => {
 
       expect(productionService.getProductionsPaginated).toHaveBeenNthCalledWith(1, {
         artists: undefined,
-        earliest_at: "1970-01-01",
-        latest_at: expect.anything(),
+        earliest_at: undefined,
+        latest_at: undefined,
         production_name: undefined,
         sort_order: "Descending",
         tag_ids: undefined,
@@ -119,8 +119,8 @@ describe("Archive", () => {
       expect(productionService.getProductionsPaginated).toHaveBeenCalledWith({
         cursor: 123,
         artists: undefined,
-        earliest_at: "1970-01-01",
-        latest_at: expect.anything(),
+        earliest_at: undefined,
+        latest_at: undefined,
         sort_order: "Descending",
         production_name: undefined,
         tag_ids: undefined,

--- a/frontend/tests/unit/filterSideBar.test.tsx
+++ b/frontend/tests/unit/filterSideBar.test.tsx
@@ -183,3 +183,26 @@ describe("FilterSidebar – data fetching edge cases", () => {
     expect(screen.getByText("Theater")).toBeInTheDocument();
   });
 });
+
+describe("FilterSidebar – reset filters button", () => {
+  it("resets all filters when reset button is clicked", async () => {
+    const props = {
+      ...defaultProps(),
+      searchQuery: "zoekterm",
+      dateFrom: "2024-01-01",
+      dateTo: "2024-12-31",
+      selectedTags: [TAGS[0]],
+      selectedArtists: ["Alice"],
+    };
+
+    render(<FilterSidebar {...props} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "filter.reset" }));
+
+    expect(props.setSearchQuery).toHaveBeenCalledWith("");
+    expect(props.setDateFrom).toHaveBeenCalledWith("");
+    expect(props.setDateTo).toHaveBeenCalledWith("");
+    expect(props.setSelectedTags).toHaveBeenCalledWith([]);
+    expect(props.setSelectedArtists).toHaveBeenCalledWith([]);
+  });
+});


### PR DESCRIPTION
### Beschrijving
We willen een button in de archive page die alle filters in 1 keer reset/cleared.


### Aangepaste delen
Er is nu een extra button die disabled is als er nog geen filters geselecteerd zijn. Anders staat deze actief en cleared hij alles.


### Speciale opmerkingen
Ik heb de standaard datums naar leeg gezet ipv naar de standaard 1970-nu. Ik snapte niet goed waarvoor dit goed was?
Het lijkt me logisch dat standaard niets ingevuld is.


### Afhankelijkheden
N/A


### Testen
Ik heb extra testen hiervoor toegevoegd in de filterSideBar


Closes #246 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
