### PR TITLE
[FIX] Localize the 'Meer' button on EventCard

### DIFF
--- a/frontend/app/features/archive/components/EventCard.tsx
+++ b/frontend/app/features/archive/components/EventCard.tsx
@@ -130,7 +130,7 @@ function EventCardSummary({
       </div>
 
       <span className="font-sans text-[0.62rem] tracking-[0.18em] uppercase opacity-65 transition group-open:rotate-180">
-	    {t("productionPage.eventMore")}
+        {t("productionPage.eventMore")}
       </span>
     </summary>
   );

--- a/frontend/app/features/archive/components/EventCard.tsx
+++ b/frontend/app/features/archive/components/EventCard.tsx
@@ -108,6 +108,7 @@ function EventCardSummary({
   dateText,
   locationText,
 }: EventCardSummaryProps) {
+  const { t } = useTranslation();
   return (
     <summary className="grid cursor-pointer list-none grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 marker:content-none md:px-5">
       <div className="min-w-0">
@@ -129,7 +130,7 @@ function EventCardSummary({
       </div>
 
       <span className="font-sans text-[0.62rem] tracking-[0.18em] uppercase opacity-65 transition group-open:rotate-180">
-        Meer
+	    {t("productionPage.eventMore")}
       </span>
     </summary>
   );

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -64,7 +64,7 @@
     "headerBrandAria": "VIERNULVIER Archive",
     "archiveLabel": "Archive",
     "backToCollection": "Back to the collection",
-	"eventMore": "More",
+    "eventMore": "More",
     "archiveSchema": "Archive schema",
     "dateLabel": "Date",
     "timeLabel": "Time",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -64,6 +64,7 @@
     "headerBrandAria": "VIERNULVIER Archive",
     "archiveLabel": "Archive",
     "backToCollection": "Back to the collection",
+	"eventMore": "More",
     "archiveSchema": "Archive schema",
     "dateLabel": "Date",
     "timeLabel": "Time",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -63,7 +63,7 @@
     "headerBrandAria": "VIERNULVIER Archief",
     "archiveLabel": "Archief",
     "backToCollection": "Terug naar de collectie",
-	"eventMore": "Meer",
+    "eventMore": "Meer",
     "archiveSchema": "Archiefschema",
     "dateLabel": "Datum",
     "timeLabel": "Tijd",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -63,6 +63,7 @@
     "headerBrandAria": "VIERNULVIER Archief",
     "archiveLabel": "Archief",
     "backToCollection": "Terug naar de collectie",
+	"eventMore": "Meer",
     "archiveSchema": "Archiefschema",
     "dateLabel": "Datum",
     "timeLabel": "Tijd",

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -114,7 +114,7 @@ vi.mock("react-i18next", async () => {
           "productionPage.dateLabel": "I18N_Production_DateLabel",
           "productionPage.placeLabel": "I18N_Production_PlaceLabel",
           "productionPage.timeLabel": "I18N_Production_TimeLabel",
-		  "productionPage.eventMore": "I18N_Production_EventMore",
+          "productionPage.eventMore": "I18N_Production_EventMore",
           "productionPage.priceLabel": "I18N_Production_PriceLabel",
           "productionPage.noPrice": "I18N_Production_NoPrice",
         };

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -114,6 +114,7 @@ vi.mock("react-i18next", async () => {
           "productionPage.dateLabel": "I18N_Production_DateLabel",
           "productionPage.placeLabel": "I18N_Production_PlaceLabel",
           "productionPage.timeLabel": "I18N_Production_TimeLabel",
+		  "productionPage.eventMore": "I18N_Production_EventMore",
           "productionPage.priceLabel": "I18N_Production_PriceLabel",
           "productionPage.noPrice": "I18N_Production_NoPrice",
         };

--- a/frontend/tests/unit/productionPage.test.tsx
+++ b/frontend/tests/unit/productionPage.test.tsx
@@ -178,5 +178,8 @@ describe("ProductionPage", () => {
     const renderedDates = await screen.findAllByText(/\d+\/\d+\/2026/);
     expect(renderedDates[0]).toHaveTextContent("9/5/2026");
     expect(renderedDates[1]).toHaveTextContent("10/5/2026");
+
+	// Quick check for more button
+	expect(screen.getAllByText("I18N_Production_EventMore").length).toBe(2);
   });
 });

--- a/frontend/tests/unit/productionPage.test.tsx
+++ b/frontend/tests/unit/productionPage.test.tsx
@@ -179,7 +179,7 @@ describe("ProductionPage", () => {
     expect(renderedDates[0]).toHaveTextContent("9/5/2026");
     expect(renderedDates[1]).toHaveTextContent("10/5/2026");
 
-	// Quick check for more button
-	expect(screen.getAllByText("I18N_Production_EventMore").length).toBe(2);
+    // Quick check for more button
+    expect(screen.getAllByText("I18N_Production_EventMore").length).toBe(2);
   });
 });


### PR DESCRIPTION
### Beschrijving
Deze PR zorgt ervoor dat de 'Meer' knop vertaald wordt wanneer de gebruiker van taal verwisselt.


### Aangepaste delen
Frontend EventCard en de translation bestanden.


### Testen
Klein deeltje toegevoegd aan de testen om te controleren dat het weldegelijk via de I18N gaat.

- [X] Goede testen toegevoegd.
- [X] Auteur wil zelf mergen.
