### PR TITLE
Disable i18next support notice

### DIFF
--- a/frontend/app/i18n.tsx
+++ b/frontend/app/i18n.tsx
@@ -25,6 +25,7 @@ i18n
     react: {
       useSuspense: false,
     },
+	showSupportNotice: false,
   });
 
 export default i18n;

--- a/frontend/app/i18n.tsx
+++ b/frontend/app/i18n.tsx
@@ -25,7 +25,7 @@ i18n
     react: {
       useSuspense: false,
     },
-	showSupportNotice: false,
+    showSupportNotice: false,
   });
 
 export default i18n;


### PR DESCRIPTION
### Beschrijving
Tijdens de testen spamt i18next reclame. Dit hebben ze ondertussen verwijderd in v26, maar volgens npm kunnen we nog niet automatisch updaten. 
Daarom heb ik in de instellingen van i18next de configuratie optie toegevoegd om deze reclame uit te zetten wat zorgt net iets properdere test output.


### Aangepaste delen
Frontend i18next configuratie.


### Speciale opmerkingen
<img width="1645" height="801" alt="image" src="https://github.com/user-attachments/assets/2943c110-fedf-4df0-b6fd-d32e7c5eecf9" />
