### PR TITLE
[FEAT] Blog page

### DIFF
--- a/frontend/app/features/blogs/pages/BlogPage.tsx
+++ b/frontend/app/features/blogs/pages/BlogPage.tsx
@@ -1,0 +1,5 @@
+export default function BlogPage() {
+	return (
+		<div />
+	)
+}

--- a/frontend/app/features/blogs/pages/BlogPage.tsx
+++ b/frontend/app/features/blogs/pages/BlogPage.tsx
@@ -1,5 +1,3 @@
 export default function BlogPage() {
-	return (
-		<div />
-	)
+  return <div />;
 }

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -3,6 +3,7 @@
     "home": "Home",
     "archive": "Archive",
     "history": "History",
+	"blogs": "Blogs",
     "users": "Users"
   },
   "footer": {

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -3,7 +3,7 @@
     "home": "Home",
     "archive": "Archive",
     "history": "History",
-	"blogs": "Blogs",
+    "blogs": "Blogs",
     "users": "Users"
   },
   "footer": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -3,7 +3,7 @@
     "home": "Home",
     "archive": "Archief",
     "history": "Geschiedenis",
-	"blogs": "Blogs",
+    "blogs": "Blogs",
     "users": "Gebruikers"
   },
   "footer": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -3,6 +3,7 @@
     "home": "Home",
     "archive": "Archief",
     "history": "Geschiedenis",
+	"blogs": "Blogs",
     "users": "Gebruikers"
   },
   "footer": {

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -9,6 +9,7 @@ export default [
     route("archive", "routes/archive.tsx"),
     route("archive/productions/:productionId", "routes/productions.$productionId.tsx"),
     route("history", "routes/history.tsx"),
+	route("blogs", "routes/blogs.tsx"),
     route("login", "routes/login.tsx"),
     route("users", "routes/users.tsx"),
     route("*", "routes/not-found.tsx"),

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -9,7 +9,7 @@ export default [
     route("archive", "routes/archive.tsx"),
     route("archive/productions/:productionId", "routes/productions.$productionId.tsx"),
     route("history", "routes/history.tsx"),
-	route("blogs", "routes/blogs.tsx"),
+    route("blogs", "routes/blogs.tsx"),
     route("login", "routes/login.tsx"),
     route("users", "routes/users.tsx"),
     route("*", "routes/not-found.tsx"),

--- a/frontend/app/routes/blogs.tsx
+++ b/frontend/app/routes/blogs.tsx
@@ -1,0 +1,5 @@
+import BlogPage from "~/features/blogs/pages/BlogPage"
+
+export default function BlogRoute() {
+	return <BlogPage />;
+}

--- a/frontend/app/routes/blogs.tsx
+++ b/frontend/app/routes/blogs.tsx
@@ -1,5 +1,5 @@
-import BlogPage from "~/features/blogs/pages/BlogPage"
+import BlogPage from "~/features/blogs/pages/BlogPage";
 
 export default function BlogRoute() {
-	return <BlogPage />;
+  return <BlogPage />;
 }

--- a/frontend/app/shared/components/Navbar.tsx
+++ b/frontend/app/shared/components/Navbar.tsx
@@ -174,7 +174,7 @@ function Navbar(): JSX.Element {
     >
       <div className="mx-auto flex h-20 max-w-[1800px] items-center justify-between px-4 sm:px-6 md:px-24">
         <Logo nav_name={t("nav.archive")} />
-		<ul className="absolute left-1/2 hidden -translate-x-1/2 items-center space-x-8 text-sm font-medium tracking-widest uppercase xl:flex">
+        <ul className="absolute left-1/2 hidden -translate-x-1/2 items-center space-x-8 text-sm font-medium tracking-widest uppercase xl:flex">
           <NavLinks />
         </ul>
         <div className="flex items-center space-x-2 text-sm font-medium tracking-widest uppercase sm:space-x-4">

--- a/frontend/app/shared/components/Navbar.tsx
+++ b/frontend/app/shared/components/Navbar.tsx
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { i18n_key: "nav.home", path: "/" },
   { i18n_key: "nav.archive", path: "/archive" },
   { i18n_key: "nav.history", path: "/history" },
+  { i18n_key: "nav.blogs", path: "/blogs" },
   {
     i18n_key: "nav.users",
     path: "/users",

--- a/frontend/app/shared/components/Navbar.tsx
+++ b/frontend/app/shared/components/Navbar.tsx
@@ -55,7 +55,7 @@ function navLinkClass({ isActive }: { isActive: boolean }) {
 }
 
 const authActionClassName =
-  "hover:text-archive-accent inline-flex cursor-pointer items-center gap-2 border-b-2 border-transparent px-1 py-1 opacity-60 transition-colors hidden lg:flex";
+  "hover:text-archive-accent inline-flex cursor-pointer items-center gap-2 border-b-2 border-transparent px-1 py-1 opacity-60 transition-colors hidden xl:flex";
 
 type NavLinksProps = { onNavigate?: () => void };
 
@@ -153,7 +153,7 @@ function HamburgerMenuButton({ isOpen, onToggle }: HamburgerMenuProps) {
       aria-expanded={isOpen}
       aria-controls="mobile-menu"
       data-testid="hamburger-menu-button"
-      className="ml-auto flex cursor-pointer flex-col space-y-1 lg:hidden"
+      className="ml-auto flex cursor-pointer flex-col space-y-1 xl:hidden"
       onClick={onToggle}
     >
       <span className="h-0.5 w-6 bg-current" />
@@ -174,13 +174,13 @@ function Navbar(): JSX.Element {
     >
       <div className="mx-auto flex h-20 max-w-[1800px] items-center justify-between px-4 sm:px-6 md:px-24">
         <Logo nav_name={t("nav.archive")} />
-        <ul className="absolute left-1/2 hidden -translate-x-1/2 items-center space-x-8 text-sm font-medium tracking-widest uppercase lg:flex">
+		<ul className="absolute left-1/2 hidden -translate-x-1/2 items-center space-x-8 text-sm font-medium tracking-widest uppercase xl:flex">
           <NavLinks />
         </ul>
         <div className="flex items-center space-x-2 text-sm font-medium tracking-widest uppercase sm:space-x-4">
           <LanguageSwitcher />
           <ThemeToggle />
-          <NavbarAuthControls className="hidden lg:flex" />
+          <NavbarAuthControls className="hidden xl:flex" />
           <HamburgerMenuButton
             isOpen={menuOpen}
             onToggle={() => setMenuOpen(!menuOpen)}
@@ -190,7 +190,7 @@ function Navbar(): JSX.Element {
           <div
             data-testid="mobile-menu"
             id="mobile-menu"
-            className="bg-archive-paper border-archive-ink/10 absolute top-20 left-0 w-full border-t lg:hidden"
+            className="bg-archive-paper border-archive-ink/10 absolute top-20 left-0 w-full border-t xl:hidden"
           >
             <ul className="flex flex-col items-center space-y-6 py-6 text-sm font-medium tracking-widest uppercase">
               <NavLinks onNavigate={() => setMenuOpen(false)} />

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -36,7 +36,7 @@ vi.mock("react-i18next", async () => {
           "nav.home": "I18N_Home",
           "nav.archive": "I18N_Archive",
           "nav.history": "I18N_History",
-		  "nav.blogs": "I18N_Blogs",
+          "nav.blogs": "I18N_Blogs",
           "nav.users": "I18N_Users",
           "auth.actions.logout": "I18N_Logout",
           "home.title": "I18N_Title",

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -36,6 +36,7 @@ vi.mock("react-i18next", async () => {
           "nav.home": "I18N_Home",
           "nav.archive": "I18N_Archive",
           "nav.history": "I18N_History",
+		  "nav.blogs": "I18N_Blogs",
           "nav.users": "I18N_Users",
           "auth.actions.logout": "I18N_Logout",
           "home.title": "I18N_Title",

--- a/frontend/tests/unit/components/Navbar.test.tsx
+++ b/frontend/tests/unit/components/Navbar.test.tsx
@@ -26,6 +26,7 @@ describe("Navbar", () => {
     expect(screen.getByText("I18N_History")).toBeInTheDocument();
     // Once for the logo, once for the link
     expect(screen.getAllByText("I18N_Archive").length).toBe(2);
+	expect(screen.getByText("I18N_Blogs")).toBeInTheDocument();
     expect(screen.queryByText("I18N_Users")).not.toBeInTheDocument();
   });
 
@@ -75,6 +76,7 @@ describe("Navbar", () => {
     expect(within(menu).getByText("I18N_Home")).toBeInTheDocument();
     expect(within(menu).getByText("I18N_Archive")).toBeInTheDocument();
     expect(within(menu).getByText("I18N_History")).toBeInTheDocument();
+    expect(within(menu).getByText("I18N_Blogs")).toBeInTheDocument();
     await userEvent.click(button);
   });
 
@@ -118,6 +120,16 @@ describe("Navbar", () => {
     expect(screen.getByText("TEST_HISTORY_PAGE")).toBeInTheDocument();
   });
 
+  it("navigates to blogs page when clicking Blogs link", async () => {
+    // For this we override the routes defined
+    renderWithRouterAndTheme({});
+
+    const user = userEvent.setup();
+    const links = screen.getAllByRole("link", { name: "I18N_Blogs" });
+    await user.click(links[0]);
+    expect(screen.getByText("TEST_BLOGS_PAGE")).toBeInTheDocument();
+  });
+
   it("mobile - navigates to home page when clicking Home link", async () => {
     // For this we override the routes defined
     renderWithRouterAndTheme({});
@@ -158,6 +170,20 @@ describe("Navbar", () => {
     const links = within(menu).getAllByRole("link", { name: "I18N_History" });
     await user.click(links[0]);
     expect(screen.getByText("TEST_HISTORY_PAGE")).toBeInTheDocument();
+  });
+
+  it("mobile - navigates to blogs page when clicking Blogs link", async () => {
+    // For this we override the routes defined
+    renderWithRouterAndTheme({});
+
+    const button = screen.getAllByTestId("hamburger-menu-button")[0];
+    await userEvent.click(button);
+    const menu = screen.getByTestId("mobile-menu");
+
+    const user = userEvent.setup();
+    const links = within(menu).getAllByRole("link", { name: "I18N_Blogs" });
+    await user.click(links[0]);
+    expect(screen.getByText("TEST_BLOGS_PAGE")).toBeInTheDocument();
   });
 
   it("shows no auth action when the user is anonymous", async () => {

--- a/frontend/tests/unit/components/Navbar.test.tsx
+++ b/frontend/tests/unit/components/Navbar.test.tsx
@@ -26,7 +26,7 @@ describe("Navbar", () => {
     expect(screen.getByText("I18N_History")).toBeInTheDocument();
     // Once for the logo, once for the link
     expect(screen.getAllByText("I18N_Archive").length).toBe(2);
-	expect(screen.getByText("I18N_Blogs")).toBeInTheDocument();
+    expect(screen.getByText("I18N_Blogs")).toBeInTheDocument();
     expect(screen.queryByText("I18N_Users")).not.toBeInTheDocument();
   });
 

--- a/frontend/tests/utils/renderWithRouterAndTheme.tsx
+++ b/frontend/tests/utils/renderWithRouterAndTheme.tsx
@@ -7,6 +7,7 @@ import { vi } from "vitest";
 import Home from "~/routes/home";
 import Archive from "~/routes/archive";
 import History from "~/routes/history";
+import Blogs from "~/routes/blogs";
 import Users from "~/routes/users";
 import NotFound from "~/routes/not-found";
 
@@ -18,6 +19,7 @@ export function renderWithRouterAndTheme({
   useRealHome = false,
   useRealArchive = false,
   useRealHistory = false,
+  useRealBlogs = false,
   useRealUsers = false,
   useRealNotFound = false,
   initialPath = "/",
@@ -55,6 +57,17 @@ export function renderWithRouterAndTheme({
           </>
         ) : (
           <History />
+        ),
+      },
+      {
+        path: "/blogs",
+        element: !useRealBlogs ? (
+          <>
+            <Navbar />
+            <div>TEST_BLOGS_PAGE</div>
+          </>
+        ) : (
+          <Blogs />
         ),
       },
       {


### PR DESCRIPTION
### Beschrijving
Voegt een blog pagina toe aan de navbar en als route

### Aangepaste delen
- Navbar: blog pagina toegevoegd + de marge voor hamburgermenu kleiner gemaakt (`lg` -> `xl`)
- Routes: blog route toegevoegd


### Speciale opmerkingen
Door het nieuwe element in de navbar was er enorme overlap van text, daarom zijn de reactive componenten dat reageerden op `lg` veranderd naar `xl`


### Afhankelijkheden
geen


### Testen
Alle testen die van toepassing zijn, zijn geupdated. Specifieke testen voor de blogpagina komen als er effectief inhoud is voor de pagina.


Closes #305 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
