### PR TITLE
Each production always has at least one info

### DIFF
--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -124,15 +124,9 @@ async def patch_production(
             db, production_in, production_id, base_url
         )
     except NotFoundError as e:
-        raise HTTPException(
-            status_code=404,
-            detail=str(e)
-        )
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
-        raise HTTPException(
-            status_code=400,
-            detail=str(e)
-        )
+        raise HTTPException(status_code=400, detail=str(e))
     return production_data
 
 

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 from src.api.dependencies.language import get_accepted_language
 from src.database import get_db
+from src.api.exceptions import NotFoundError
 from src.schemas.production import (
     ProductionCreate,
     ProductionListResponse,
@@ -118,10 +119,20 @@ async def patch_production(
     _: User = Depends(RequirePermissions([Permissions.ARCHIVE_UPDATE])),
 ) -> ProductionResponse:
     base_url = get_base_url(str(request.url), 2)
-    production_data = update_production_by_id(
-        db, production_in, production_id, base_url
-    )
-
+    try:
+        production_data = update_production_by_id(
+            db, production_in, production_id, base_url
+        )
+    except NotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail=str(e)
+        )
     return production_data
 
 

--- a/backend/src/services/production.py
+++ b/backend/src/services/production.py
@@ -379,9 +379,13 @@ def update_production_by_id(
                 setattr(production_info, field, value)
 
     if production_in.remove_languages:
-        prod_infos = db.query(ProdInfo).filter(ProdInfo.production_id == production_id).all()
+        prod_infos = (
+            db.query(ProdInfo).filter(ProdInfo.production_id == production_id).all()
+        )
         if len(prod_infos) <= len(production_in.remove_languages):
-            raise Exception("Cannot remove all languages. At least one language must remain.")
+            raise Exception(
+                "Cannot remove all languages. At least one language must remain."
+            )
 
         for prod_info in prod_infos:
             if prod_info.language in production_in.remove_languages:

--- a/backend/src/services/production.py
+++ b/backend/src/services/production.py
@@ -379,11 +379,13 @@ def update_production_by_id(
                 setattr(production_info, field, value)
 
     if production_in.remove_languages:
-        for lang in production_in.remove_languages:
-            db.query(ProdInfo).filter(
-                ProdInfo.production_id == production_id,
-                ProdInfo.language == lang,
-            ).delete()
+        prod_infos = db.query(ProdInfo).filter(ProdInfo.production_id == production_id).all()
+        if len(prod_infos) <= len(production_in.remove_languages):
+            raise Exception("Cannot remove all languages. At least one language must remain.")
+
+        for prod_info in prod_infos:
+            if prod_info.language in production_in.remove_languages:
+                db.delete(prod_info)
 
     db.commit()
     # Refreshes the whole production with eager loading (simplest).

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -497,6 +497,24 @@ def test_patch_production_delete_info_success(
     assert len(data["production_infos"]) == 1
 
 
+# User with permissions cannot delete all existing infos of an existing production.
+def test_patch_production_delete_info_failure(
+    client: TestClient, db_session: Session, productions_limited
+):
+    headers = create_user_and_login(
+        client, db_session, "update_production_user", [Permissions.ARCHIVE_UPDATE]
+    )
+    production = productions_limited[0]
+
+    response = client.patch(
+        f"{BASE_PROD_URL}/{production.id}",
+        json={"remove_languages": [Languages.ENGLISH, Languages.NEDERLANDS]},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+
+
 # User should be able to create a new production.
 def test_create_production_success(client: TestClient, db_session: Session):
     headers = create_user_and_login(

--- a/backend/tests/unit/test_production_service.py
+++ b/backend/tests/unit/test_production_service.py
@@ -580,10 +580,12 @@ def test_update_production_info_delete_all(db_session, productions_limited):
     assert len(production_response.production_infos) == 2
 
     # Should throw an exception.
-    update = ProductionUpdate(remove_languages=[Languages.ENGLISH, Languages.NEDERLANDS]) 
+    update = ProductionUpdate(
+        remove_languages=[Languages.ENGLISH, Languages.NEDERLANDS]
+    )
     with pytest.raises(Exception):
         update_production_by_id(db_session, update, productions_limited[0].id, BASE_URL)
-        
+
     # Not updated in database.
     production_response = get_production_by_id(
         db_session, productions_limited[0].id, BASE_URL

--- a/backend/tests/unit/test_production_service.py
+++ b/backend/tests/unit/test_production_service.py
@@ -572,6 +572,25 @@ def test_update_production_info_delete(db_session, productions_limited):
     assert len(production_response.production_infos) == 1
 
 
+# Update an existing production - delete all existing production infos should fail.
+def test_update_production_info_delete_all(db_session, productions_limited):
+    production_response = get_production_by_id(
+        db_session, productions_limited[0].id, BASE_URL
+    )
+    assert len(production_response.production_infos) == 2
+
+    # Should throw an exception.
+    update = ProductionUpdate(remove_languages=[Languages.ENGLISH, Languages.NEDERLANDS]) 
+    with pytest.raises(Exception):
+        update_production_by_id(db_session, update, productions_limited[0].id, BASE_URL)
+        
+    # Not updated in database.
+    production_response = get_production_by_id(
+        db_session, productions_limited[0].id, BASE_URL
+    )
+    assert len(production_response.production_infos) == 2
+
+
 # Update an existing production - delete not existing production info (nothing happens, also no error).
 def test_update_production_info_delete_invalid(db_session, productions_limited):
     production_response = get_production_by_id(


### PR DESCRIPTION
### Beschrijving
Een productie moet minstens 1 info hebben. Bij create wordt dit al verwacht maar bij update kon je ze wel nog allemaal verwijderen. 

Deze PR lost op dat wanneer er meer production_infos verwijderd willen worden dan dat er beschikbaar zijn, dit niet mogelijk is. Faalt ook als je zegt: verwijder FR, ESP, ENG en enkel NED is aanwezig (het checkt gewoon dat de grootte van meegegeven remove_languages minstens kleiner is dan de aanwezig production infos voor die zekere productie. 

### Aangepaste delen
- ProductionService
- ProductionEndpoint
- Production unit test
- Production integration test   


### Speciale opmerkingen
Geen.


### Afhankelijkheden
Geen.


### Testen
Er zijn 2 testen toegevoegd: 1x unit en 1x integratietest.


Closes #197

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.