### PR TITLE
use the format: hour:minutes

### DIFF
--- a/frontend/app/features/archive/components/EventCard.tsx
+++ b/frontend/app/features/archive/components/EventCard.tsx
@@ -9,14 +9,10 @@ export type EventWithResolvedRelations = Event & {
 };
 
 function formatEventTime(date: Date): string {
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
 
-  if (minutes === 0) {
-    return `${hours}u`;
-  }
-
-  return `${hours}u${String(minutes).padStart(2, "0")}`;
+  return `${hours}:${minutes}`;
 }
 
 function formatEventDateTimeRange(

--- a/frontend/tests/unit/productionPage.test.tsx
+++ b/frontend/tests/unit/productionPage.test.tsx
@@ -179,6 +179,9 @@ describe("ProductionPage", () => {
     expect(renderedDates[0]).toHaveTextContent("9/5/2026");
     expect(renderedDates[1]).toHaveTextContent("10/5/2026");
 
+    expect(screen.getByText("18:30")).toBeInTheDocument();
+    expect(screen.getByText("20:00")).toBeInTheDocument();
+
     // Quick check for more button
     expect(screen.getAllByText("I18N_Production_EventMore").length).toBe(2);
   });


### PR DESCRIPTION
### Beschrijving
De tijd in de eventCards worden nu niet meer getoond met 'u' bv: 22u:20. Ze worden nu getoond als 22:20. Wat ook duidelijk is.


### Aangepaste delen
Functie voor het formatten van de tijd in eventCard.tsx.


### Speciale opmerkingen
N/A


### Afhankelijkheden
N/A


### Testen
yes.


Closes #333 

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
