### PR TITLE
Feat/301 delete roles

### DIFF
--- a/backend/src/services/auth/role.py
+++ b/backend/src/services/auth/role.py
@@ -115,5 +115,12 @@ def delete_role(db: Session, role_id: int) -> None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Role not found"
         )
+
+    if role.users:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Roles assigned to users cannot be deleted",
+        )
+
     db.delete(role)
     db.commit()

--- a/backend/tests/integration/test_roles_permissions_endpoints.py
+++ b/backend/tests/integration/test_roles_permissions_endpoints.py
@@ -139,3 +139,35 @@ def test_roles_permission_enforcement(client: TestClient, db_session: Session):
 
     response = client.delete(f"/api/v1/auth/roles/{role.id}", headers=headers)
     assert response.status_code == 403
+
+
+def test_delete_role_forbidden_when_assigned_to_user(
+    client: TestClient, db_session: Session
+):
+    create_user_with_permissions(
+        db_session,
+        "admin_delete_role",
+        [
+            Permissions.USERS_READ,
+            Permissions.USERS_DELETE,
+        ],
+    )
+    token = get_token(client, "admin_delete_role")
+    headers = {"Authorization": f"Bearer {token}"}
+
+    protected_role = Role(name="admin", permissions=[])
+    assigned_user = User(
+        username="assigned_user",
+        hashed_password=get_password_hash("pw"),
+        roles=[protected_role],
+    )
+    db_session.add_all([protected_role, assigned_user])
+    db_session.commit()
+
+    response = client.delete(f"/api/v1/auth/roles/{protected_role.id}", headers=headers)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Roles assigned to users cannot be deleted"
+    assert (
+        db_session.query(Role).filter(Role.id == protected_role.id).first() is not None
+    )

--- a/backend/tests/unit/test_role_service.py
+++ b/backend/tests/unit/test_role_service.py
@@ -1,5 +1,6 @@
 import pytest
 from src.models.role import Role
+from src.models.user import User
 from src.schemas.auth import RoleCreate, RoleUpdate
 from src.services.auth import role as role_service
 
@@ -43,3 +44,16 @@ def test_update_role_invalid_permission(db_session):
 def test_delete_role_not_found(db_session):
     with pytest.raises(Exception):
         role_service.delete_role(db_session, 999)
+
+
+def test_delete_role_assigned_to_user_forbidden(db_session):
+    role = Role(name="admin")
+    user = User(username="manager", hashed_password="hashed", roles=[role])
+    db_session.add_all([role, user])
+    db_session.commit()
+
+    with pytest.raises(Exception) as excinfo:
+        role_service.delete_role(db_session, role.id)
+
+    assert excinfo.value.detail == "Roles assigned to users cannot be deleted"
+    assert db_session.query(Role).filter(Role.id == role.id).first() is not None

--- a/frontend/app/features/users/components/RoleCard.tsx
+++ b/frontend/app/features/users/components/RoleCard.tsx
@@ -56,7 +56,7 @@ export function RoleCard({ role, onDelete }: RoleCardProps) {
       {onDelete ? (
         <div className="border-archive-border mt-5 border-t pt-4">
           <Button onClick={onDelete} sx={deleteButtonSx}>
-            {t("users.actions.delete")}
+            {t("users.roles.actions.delete")}
           </Button>
         </div>
       ) : null}

--- a/frontend/app/features/users/components/RoleCard.tsx
+++ b/frontend/app/features/users/components/RoleCard.tsx
@@ -1,9 +1,11 @@
+import { Button } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 import type { IRole } from "../users.types";
 
 type RoleCardProps = {
   role: IRole;
+  onDelete?: () => void;
 };
 
 function TokenList({ values, emptyLabel }: { values: string[]; emptyLabel: string }) {
@@ -25,7 +27,7 @@ function TokenList({ values, emptyLabel }: { values: string[]; emptyLabel: strin
   );
 }
 
-export function RoleCard({ role }: RoleCardProps) {
+export function RoleCard({ role, onDelete }: RoleCardProps) {
   const { t } = useTranslation();
 
   return (
@@ -50,6 +52,27 @@ export function RoleCard({ role }: RoleCardProps) {
           />
         </section>
       </div>
+
+      {onDelete ? (
+        <div className="border-archive-border mt-5 border-t pt-4">
+          <Button onClick={onDelete} sx={deleteButtonSx}>
+            {t("users.actions.delete")}
+          </Button>
+        </div>
+      ) : null}
     </article>
   );
 }
+
+const deleteButtonSx = {
+  py: 1,
+  px: 2,
+  borderRadius: "999px",
+  textTransform: "none" as const,
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.72rem",
+  fontWeight: 700,
+  letterSpacing: "0.18em",
+  color: "#c0392b",
+  border: "1px solid rgba(192, 57, 43, 0.35)",
+};

--- a/frontend/app/features/users/pages/UserManagementPage.tsx
+++ b/frontend/app/features/users/pages/UserManagementPage.tsx
@@ -18,11 +18,7 @@ import { UserCard } from "../components/UserCard";
 import { RoleCard } from "../components/RoleCard";
 import { USER_PERMISSIONS } from "../users.constants";
 import { createUser, deleteUser, listUsers } from "../services/userManagementService";
-import {
-  createRole,
-  deleteRole,
-  listRoles,
-} from "../services/roleManagementService";
+import { createRole, deleteRole, listRoles } from "../services/roleManagementService";
 import type {
   IRole,
   IRoleCreateRequest,
@@ -406,7 +402,9 @@ function DeleteRoleDialog({
         backdrop: { sx: dialogBackdropSx },
       }}
     >
-      <DialogTitle sx={dialogTitleSx}>{t("users.roles.dialogs.delete.title")}</DialogTitle>
+      <DialogTitle sx={dialogTitleSx}>
+        {t("users.roles.dialogs.delete.title")}
+      </DialogTitle>
       <DialogContent sx={dialogContentSx}>
         <p className="mb-2 text-sm leading-relaxed text-[color:var(--archive-ink)] opacity-70">
           {t("users.roles.dialogs.delete.description", { roleName: role?.name })}

--- a/frontend/app/features/users/pages/UserManagementPage.tsx
+++ b/frontend/app/features/users/pages/UserManagementPage.tsx
@@ -18,7 +18,11 @@ import { UserCard } from "../components/UserCard";
 import { RoleCard } from "../components/RoleCard";
 import { USER_PERMISSIONS } from "../users.constants";
 import { createUser, deleteUser, listUsers } from "../services/userManagementService";
-import { createRole, listRoles } from "../services/roleManagementService";
+import {
+  createRole,
+  deleteRole,
+  listRoles,
+} from "../services/roleManagementService";
 import type {
   IRole,
   IRoleCreateRequest,
@@ -372,6 +376,63 @@ function CreateRoleDialog({
   );
 }
 
+function DeleteRoleDialog({
+  role,
+  isSubmitting,
+  errorMessage,
+  onClose,
+  onConfirm,
+}: {
+  role: IRole | null;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}) {
+  const { t } = useTranslation();
+
+  async function handleConfirm() {
+    await onConfirm();
+  }
+
+  return (
+    <Dialog
+      open={Boolean(role)}
+      onClose={isSubmitting ? undefined : onClose}
+      fullWidth
+      maxWidth="sm"
+      slotProps={{
+        paper: { sx: dialogPaperSx },
+        backdrop: { sx: dialogBackdropSx },
+      }}
+    >
+      <DialogTitle sx={dialogTitleSx}>{t("users.roles.dialogs.delete.title")}</DialogTitle>
+      <DialogContent sx={dialogContentSx}>
+        <p className="mb-2 text-sm leading-relaxed text-[color:var(--archive-ink)] opacity-70">
+          {t("users.roles.dialogs.delete.description", { roleName: role?.name })}
+        </p>
+
+        <UserMutationAlert message={errorMessage} />
+      </DialogContent>
+      <DialogActions sx={dialogActionsSx}>
+        <Button onClick={onClose} disabled={isSubmitting} sx={secondaryButtonSx}>
+          {t("users.actions.cancel")}
+        </Button>
+        <Button onClick={handleConfirm} disabled={isSubmitting} sx={dangerButtonSx}>
+          {isSubmitting ? (
+            <>
+              <CircularProgress size={13} sx={{ color: "inherit", mr: 1 }} />
+              {t("users.actions.deleting")}
+            </>
+          ) : (
+            t("users.actions.delete")
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
 export function UserManagementAccessDenied() {
   const { t } = useTranslation();
 
@@ -411,11 +472,18 @@ export default function UserManagementPage() {
   const [isCreateRoleDialogOpen, setIsCreateRoleDialogOpen] = useState(false);
   const [createRoleError, setCreateRoleError] = useState<string | null>(null);
   const [isCreatingRole, setIsCreatingRole] = useState(false);
+  const [deleteRoleError, setDeleteRoleError] = useState<string | null>(null);
+  const [isDeletingRole, setIsDeletingRole] = useState(false);
+  const [roleIdToDelete, setRoleIdToDelete] = useState<number | null>(null);
 
   const userToDelete =
     userIdToDelete === null
       ? null
       : (users.find((managedUser) => managedUser.id === userIdToDelete) ?? null);
+  const roleToDelete =
+    roleIdToDelete === null
+      ? null
+      : (roles.find((managedRole) => managedRole.id === roleIdToDelete) ?? null);
 
   useEffect(() => {
     // Ignore any in-flight response once this effect is cleaned up or rerun.
@@ -598,6 +666,43 @@ export default function UserManagementPage() {
     }
   }
 
+  function openDeleteRoleDialog(roleId: number) {
+    setDeleteRoleError(null);
+    setRoleIdToDelete(roleId);
+  }
+
+  function closeDeleteRoleDialog() {
+    if (isDeletingRole) {
+      return;
+    }
+
+    setDeleteRoleError(null);
+    setRoleIdToDelete(null);
+  }
+
+  async function handleDeleteRole() {
+    if (roleIdToDelete === null) {
+      return;
+    }
+
+    setIsDeletingRole(true);
+    setDeleteRoleError(null);
+
+    try {
+      await deleteRole(roleIdToDelete);
+      setRoles((currentRoles) =>
+        currentRoles.filter((managedRole) => managedRole.id !== roleIdToDelete)
+      );
+      setRoleIdToDelete(null);
+    } catch (error) {
+      setDeleteRoleError(
+        getApiErrorMessage(error, t("users.roles.messages.deleteFailed"))
+      );
+    } finally {
+      setIsDeletingRole(false);
+    }
+  }
+
   function formatDateTime(value: string | null) {
     if (!value) {
       return t("users.empty.date");
@@ -629,6 +734,7 @@ export default function UserManagementPage() {
     currentUser?.isSuperUser,
     USER_PERMISSIONS.delete
   );
+  const canDeleteRoles = canDeleteUsers;
 
   return (
     <>
@@ -751,7 +857,13 @@ export default function UserManagementPage() {
           ) : (
             <div className="mt-8 grid gap-5 lg:grid-cols-2 xl:grid-cols-3">
               {roles.map((role) => (
-                <RoleCard key={role.id} role={role} />
+                <RoleCard
+                  key={role.id}
+                  role={role}
+                  onDelete={
+                    canDeleteRoles ? () => openDeleteRoleDialog(role.id) : undefined
+                  }
+                />
               ))}
             </div>
           )}
@@ -772,6 +884,14 @@ export default function UserManagementPage() {
         errorMessage={userToDelete ? deleteMutationError : null}
         onClose={closeDeleteDialog}
         onConfirm={handleDeleteUser}
+      />
+
+      <DeleteRoleDialog
+        role={roleToDelete}
+        isSubmitting={isDeletingRole}
+        errorMessage={roleToDelete ? deleteRoleError : null}
+        onClose={closeDeleteRoleDialog}
+        onConfirm={handleDeleteRole}
       />
 
       {isCreateRoleDialogOpen ? (

--- a/frontend/app/features/users/pages/UserManagementPage.tsx
+++ b/frontend/app/features/users/pages/UserManagementPage.tsx
@@ -256,10 +256,10 @@ function DeleteUserDialog({
           {isSubmitting ? (
             <>
               <CircularProgress size={13} sx={{ color: "inherit", mr: 1 }} />
-              {t("users.actions.deleting")}
+              {t("users.roles.actions.deleting")}
             </>
           ) : (
-            t("users.actions.delete")
+            t("users.roles.actions.delete")
           )}
         </Button>
       </DialogActions>

--- a/frontend/app/features/users/pages/UserManagementPage.tsx
+++ b/frontend/app/features/users/pages/UserManagementPage.tsx
@@ -256,10 +256,10 @@ function DeleteUserDialog({
           {isSubmitting ? (
             <>
               <CircularProgress size={13} sx={{ color: "inherit", mr: 1 }} />
-              {t("users.roles.actions.deleting")}
+              {t("users.actions.deleting")}
             </>
           ) : (
-            t("users.roles.actions.delete")
+            t("users.actions.delete")
           )}
         </Button>
       </DialogActions>
@@ -420,10 +420,10 @@ function DeleteRoleDialog({
           {isSubmitting ? (
             <>
               <CircularProgress size={13} sx={{ color: "inherit", mr: 1 }} />
-              {t("users.actions.deleting")}
+              {t("users.roles.actions.deleting")}
             </>
           ) : (
-            t("users.actions.delete")
+            t("users.roles.actions.delete")
           )}
         </Button>
       </DialogActions>

--- a/frontend/app/features/users/services/roleManagementService.ts
+++ b/frontend/app/features/users/services/roleManagementService.ts
@@ -26,3 +26,10 @@ export async function createRole(
   const response = await apiClient.post<IRoleResponse>(ROLES_API_PATH, payload);
   return mapRole(response.data);
 }
+
+export async function deleteRole(
+  roleId: number,
+  apiClient: AxiosInstance = createApiClient()
+) {
+  await apiClient.delete(`${ROLES_API_PATH}/${roleId}`);
+}

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -253,12 +253,17 @@
       "messages": {
         "loadFailed": "We could not load roles right now.",
         "createFailed": "We could not create the role right now.",
+        "deleteFailed": "We could not delete the role right now.",
         "nameRequired": "A role name is required."
       },
       "dialogs": {
         "create": {
           "title": "Add role",
           "description": "Create a new role. Permissions can be assigned after creation."
+        },
+        "delete": {
+          "title": "Delete role",
+          "description": "Delete the role {{roleName}}? Users assigned to it will lose this role immediately."
         }
       },
       "empty": {

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -248,7 +248,9 @@
       "actions": {
         "add": "Add role",
         "create": "Create role",
-        "creating": "Creating role"
+        "creating": "Creating role",
+        "delete": "Delete role",
+        "deleting": "Deleting role"
       },
       "messages": {
         "loadFailed": "We could not load roles right now.",
@@ -263,7 +265,7 @@
         },
         "delete": {
           "title": "Delete role",
-          "description": "Delete the role {{roleName}}? Users assigned to it will lose this role immediately."
+          "description": "Delete the role {{roleName}}? This is only possible when no users are assigned to it."
         }
       },
       "empty": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -246,7 +246,9 @@
       "actions": {
         "add": "Rol toevoegen",
         "create": "Rol aanmaken",
-        "creating": "Rol wordt aangemaakt"
+        "creating": "Rol wordt aangemaakt",
+        "delete": "Rol verwijderen",
+        "deleting": "Rol wordt verwijderd"
       },
       "messages": {
         "loadFailed": "De rollen konden nu niet geladen worden.",
@@ -261,7 +263,7 @@
         },
         "delete": {
           "title": "Rol verwijderen",
-          "description": "De rol {{roleName}} verwijderen? Gebruikers die eraan gekoppeld zijn, verliezen deze rol meteen."
+          "description": "De rol {{roleName}} verwijderen? Dit is alleen mogelijk als er geen gebruikers aan deze rol gekoppeld zijn."
         }
       },
       "empty": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -251,12 +251,17 @@
       "messages": {
         "loadFailed": "De rollen konden nu niet geladen worden.",
         "createFailed": "De rol kon nu niet worden aangemaakt.",
+        "deleteFailed": "De rol kon nu niet verwijderd worden.",
         "nameRequired": "Een rolnaam is verplicht."
       },
       "dialogs": {
         "create": {
           "title": "Rol toevoegen",
           "description": "Maak een nieuwe rol aan. Permissies kunnen na het aanmaken worden toegewezen."
+        },
+        "delete": {
+          "title": "Rol verwijderen",
+          "description": "De rol {{roleName}} verwijderen? Gebruikers die eraan gekoppeld zijn, verliezen deze rol meteen."
         }
       },
       "empty": {

--- a/frontend/tests/unit/roleManagementService.test.ts
+++ b/frontend/tests/unit/roleManagementService.test.ts
@@ -4,7 +4,11 @@ import AxiosMockAdapter from "axios-mock-adapter";
 
 import * as envModule from "~/shared/utils/env";
 import { createApiClient } from "~/shared/services/apiClient";
-import { createRole, listRoles } from "~/features/users/services/roleManagementService";
+import {
+  createRole,
+  deleteRole,
+  listRoles,
+} from "~/features/users/services/roleManagementService";
 
 describe("roleManagementService", () => {
   let mockAdapter: AxiosMockAdapter;
@@ -76,6 +80,22 @@ describe("roleManagementService", () => {
 
     await expect(createRole({ name: "editor" })).rejects.toMatchObject({
       response: { status: 409 },
+    });
+  });
+
+  it("deletes a role", async () => {
+    mockAdapter.onDelete("/api/v1/auth/roles/12").reply(204);
+
+    await expect(deleteRole(12)).resolves.toBeUndefined();
+  });
+
+  it("rejects when the server returns an error on delete", async () => {
+    mockAdapter
+      .onDelete("/api/v1/auth/roles/99")
+      .reply(404, { detail: "Role not found" });
+
+    await expect(deleteRole(99)).rejects.toMatchObject({
+      response: { status: 404 },
     });
   });
 });

--- a/frontend/tests/unit/userManagementPage.test.tsx
+++ b/frontend/tests/unit/userManagementPage.test.tsx
@@ -475,6 +475,48 @@ describe("UserManagementPage", () => {
       expect(screen.getByText("users.roles.empty.permissions")).toBeInTheDocument();
     });
 
+    it("shows role delete buttons when user has users:delete permission", async () => {
+      authSessionValue.user = {
+        ...authSessionValue.user,
+        permissions: ["users:read", "users:delete"],
+      };
+      vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue(roles);
+
+      render(<UserManagementPage />);
+
+      const editorRoleCard = (
+        await screen.findByRole("heading", { name: "editor" })
+      ).closest("article");
+
+      expect(editorRoleCard).not.toBeNull();
+      expect(
+        within(editorRoleCard as HTMLElement).getByRole("button", {
+          name: "users.actions.delete",
+        })
+      ).toBeInTheDocument();
+    });
+
+    it("hides role delete buttons without users:delete permission", async () => {
+      authSessionValue.user = {
+        ...authSessionValue.user,
+        permissions: ["users:read", "users:create"],
+      };
+      vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue(roles);
+
+      render(<UserManagementPage />);
+
+      const editorRoleCard = (
+        await screen.findByRole("heading", { name: "editor" })
+      ).closest("article");
+
+      expect(editorRoleCard).not.toBeNull();
+      expect(
+        within(editorRoleCard as HTMLElement).queryByRole("button", {
+          name: "users.actions.delete",
+        })
+      ).toBeNull();
+    });
+
     it("renders the empty state when no roles exist", async () => {
       vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue([]);
 
@@ -562,6 +604,39 @@ describe("UserManagementPage", () => {
       expect(screen.queryByText("users.roles.empty.title")).toBeNull();
     });
 
+    it("removes the role from the list after confirming deletion", async () => {
+      authSessionValue.user = {
+        ...authSessionValue.user,
+        permissions: ["users:read", "users:delete"],
+      };
+      vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue(roles);
+      vi.spyOn(roleManagementServiceModule, "deleteRole").mockResolvedValue(undefined);
+
+      const user = userEvent.setup();
+      render(<UserManagementPage />);
+
+      const editorRoleCard = (
+        await screen.findByRole("heading", { name: "editor" })
+      ).closest("article");
+      expect(editorRoleCard).not.toBeNull();
+
+      await user.click(
+        within(editorRoleCard as HTMLElement).getByRole("button", {
+          name: "users.actions.delete",
+        })
+      );
+
+      expect(
+        await screen.findByText("users.roles.dialogs.delete.title")
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+
+      expect(roleManagementServiceModule.deleteRole).toHaveBeenCalledWith(roles[0].id);
+      expect(await screen.findByText("viewer")).toBeInTheDocument();
+      expect(screen.queryByText("editor")).toBeNull();
+    });
+
     it("validates that the role name is required", async () => {
       vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue([]);
 
@@ -578,6 +653,66 @@ describe("UserManagementPage", () => {
 
       expect(
         await screen.findByText("users.roles.messages.nameRequired")
+      ).toBeInTheDocument();
+    });
+
+    it("shows an error message when role deletion fails", async () => {
+      authSessionValue.user = {
+        ...authSessionValue.user,
+        permissions: ["users:read", "users:delete"],
+      };
+      vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue(roles);
+      vi.spyOn(roleManagementServiceModule, "deleteRole").mockRejectedValue({
+        isAxiosError: true,
+        response: { data: { detail: "Role is protected" } },
+      } as AxiosError);
+
+      const user = userEvent.setup();
+      render(<UserManagementPage />);
+
+      const editorRoleCard = (
+        await screen.findByRole("heading", { name: "editor" })
+      ).closest("article");
+
+      await user.click(
+        within(editorRoleCard as HTMLElement).getByRole("button", {
+          name: "users.actions.delete",
+        })
+      );
+
+      await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+
+      expect(await screen.findByText("Role is protected")).toBeInTheDocument();
+      expect(screen.getByText("editor")).toBeInTheDocument();
+    });
+
+    it("falls back to the generic role delete failure message for non-axios errors", async () => {
+      authSessionValue.user = {
+        ...authSessionValue.user,
+        permissions: ["users:read", "users:delete"],
+      };
+      vi.spyOn(roleManagementServiceModule, "listRoles").mockResolvedValue(roles);
+      vi.spyOn(roleManagementServiceModule, "deleteRole").mockRejectedValue(
+        new Error("network error")
+      );
+
+      const user = userEvent.setup();
+      render(<UserManagementPage />);
+
+      const editorRoleCard = (
+        await screen.findByRole("heading", { name: "editor" })
+      ).closest("article");
+
+      await user.click(
+        within(editorRoleCard as HTMLElement).getByRole("button", {
+          name: "users.actions.delete",
+        })
+      );
+
+      await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+
+      expect(
+        await screen.findByText("users.roles.messages.deleteFailed")
       ).toBeInTheDocument();
     });
 

--- a/frontend/tests/unit/userManagementPage.test.tsx
+++ b/frontend/tests/unit/userManagementPage.test.tsx
@@ -358,7 +358,9 @@ describe("UserManagementPage", () => {
 
     expect(await screen.findByText("users.dialogs.delete.title")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+    await user.click(
+      screen.getByRole("button", { name: "users.roles.actions.delete" })
+    );
 
     expect(userManagementServiceModule.deleteUser).toHaveBeenCalledWith(users[0].id);
     expect(await screen.findByText("admin")).toBeInTheDocument();
@@ -392,7 +394,9 @@ describe("UserManagementPage", () => {
       })
     );
 
-    await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+    await user.click(
+      screen.getByRole("button", { name: "users.roles.actions.delete" })
+    );
 
     expect(await screen.findByText("Cannot delete last admin")).toBeInTheDocument();
     // The user should still be in the list
@@ -425,7 +429,9 @@ describe("UserManagementPage", () => {
       })
     );
 
-    await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+    await user.click(
+      screen.getByRole("button", { name: "users.roles.actions.delete" })
+    );
 
     expect(await screen.findByText("users.messages.deleteFailed")).toBeInTheDocument();
   });
@@ -491,7 +497,7 @@ describe("UserManagementPage", () => {
       expect(editorRoleCard).not.toBeNull();
       expect(
         within(editorRoleCard as HTMLElement).getByRole("button", {
-          name: "users.actions.delete",
+          name: "users.roles.actions.delete",
         })
       ).toBeInTheDocument();
     });
@@ -512,7 +518,7 @@ describe("UserManagementPage", () => {
       expect(editorRoleCard).not.toBeNull();
       expect(
         within(editorRoleCard as HTMLElement).queryByRole("button", {
-          name: "users.actions.delete",
+          name: "users.roles.actions.delete",
         })
       ).toBeNull();
     });
@@ -622,7 +628,7 @@ describe("UserManagementPage", () => {
 
       await user.click(
         within(editorRoleCard as HTMLElement).getByRole("button", {
-          name: "users.actions.delete",
+          name: "users.roles.actions.delete",
         })
       );
 
@@ -676,7 +682,7 @@ describe("UserManagementPage", () => {
 
       await user.click(
         within(editorRoleCard as HTMLElement).getByRole("button", {
-          name: "users.actions.delete",
+          name: "users.roles.actions.delete",
         })
       );
 
@@ -705,7 +711,7 @@ describe("UserManagementPage", () => {
 
       await user.click(
         within(editorRoleCard as HTMLElement).getByRole("button", {
-          name: "users.actions.delete",
+          name: "users.roles.actions.delete",
         })
       );
 

--- a/frontend/tests/unit/userManagementPage.test.tsx
+++ b/frontend/tests/unit/userManagementPage.test.tsx
@@ -358,9 +358,7 @@ describe("UserManagementPage", () => {
 
     expect(await screen.findByText("users.dialogs.delete.title")).toBeInTheDocument();
 
-    await user.click(
-      screen.getByRole("button", { name: "users.roles.actions.delete" })
-    );
+    await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
 
     expect(userManagementServiceModule.deleteUser).toHaveBeenCalledWith(users[0].id);
     expect(await screen.findByText("admin")).toBeInTheDocument();
@@ -394,9 +392,7 @@ describe("UserManagementPage", () => {
       })
     );
 
-    await user.click(
-      screen.getByRole("button", { name: "users.roles.actions.delete" })
-    );
+    await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
 
     expect(await screen.findByText("Cannot delete last admin")).toBeInTheDocument();
     // The user should still be in the list
@@ -429,9 +425,7 @@ describe("UserManagementPage", () => {
       })
     );
 
-    await user.click(
-      screen.getByRole("button", { name: "users.roles.actions.delete" })
-    );
+    await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
 
     expect(await screen.findByText("users.messages.deleteFailed")).toBeInTheDocument();
   });
@@ -636,7 +630,9 @@ describe("UserManagementPage", () => {
         await screen.findByText("users.roles.dialogs.delete.title")
       ).toBeInTheDocument();
 
-      await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "users.roles.actions.delete" })
+      );
 
       expect(roleManagementServiceModule.deleteRole).toHaveBeenCalledWith(roles[0].id);
       expect(await screen.findByText("viewer")).toBeInTheDocument();
@@ -686,7 +682,9 @@ describe("UserManagementPage", () => {
         })
       );
 
-      await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "users.roles.actions.delete" })
+      );
 
       expect(await screen.findByText("Role is protected")).toBeInTheDocument();
       expect(screen.getByText("editor")).toBeInTheDocument();
@@ -715,7 +713,9 @@ describe("UserManagementPage", () => {
         })
       );
 
-      await user.click(screen.getByRole("button", { name: "users.actions.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "users.roles.actions.delete" })
+      );
 
       expect(
         await screen.findByText("users.roles.messages.deleteFailed")


### PR DESCRIPTION
### Beschrijving
Verwijderen van rollen in de frontend. Ik heb een kleine aanpassing aan de backend moeten doen om te voorkomen dat men rollen kan verwijderen die nog gebruikt worden.
<img width="1914" height="1047" alt="image" src="https://github.com/user-attachments/assets/36818813-4c85-46e7-8c26-1c3e11d5d56e" />


### Testen
Voldoende testen zijn toegevoegd voor genoeg coverage

Closes #301 
