### PR TITLE
hotfix

### DIFF
--- a/.github/workflows/cd-dev.yaml
+++ b/.github/workflows/cd-dev.yaml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     name: Deploy to Server (Dev)
     runs-on: self-hosted
+    environment: production
 
     steps:
       - name: Cleanup Docker


### PR DESCRIPTION
### Beschrijving
Probleem was dat de CD repo level secrets aan het zoeken was die er niet zijn. De .env.dev file was dus leeg wat voor problemen zorgde met onder andere postgress.

Een lege site is niet zo nuttig dus ik kijk straks ook nog om een github action te maken die de scraper opstart.

Ik heb de cd manueel gerunnd op deze branch dus momenteel staat de site beschikbaar op:
http://sel2-3.ugent.be:2002/en

Closes #342 