### PR TITLE
Feat/production page/uniform frontend/add production info

### DIFF
--- a/frontend/app/features/archive/components/ProductionInfoSection.tsx
+++ b/frontend/app/features/archive/components/ProductionInfoSection.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import ComplexEditableField from "~/shared/components/ArchiveRichTextFieldWrapper";
 
 type ProductionInfoSectionProps = {
-  prodinfo_available: boolean;
   tagline: string;
   teaserHtml: string | undefined;
   descriptionHtml: string | undefined;
@@ -13,7 +12,6 @@ type ProductionInfoSectionProps = {
 };
 
 export function ProductionInfoSection({
-  prodinfo_available,
   tagline,
   teaserHtml,
   descriptionHtml,
@@ -29,14 +27,6 @@ export function ProductionInfoSection({
       setTimeout(() => setEditing(null), 0);
     }
   }, [globalIsEditing]);
-
-  if (!prodinfo_available) {
-    return (
-      <p id="no-prodinfo" className="opacity-75">
-        {t("productionPage.infoNotAvailable")}
-      </p>
-    );
-  }
 
   function handleSave(field: string, html: string) {
     onSave(field, html);

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useBlocker, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import DOMPurify from "dompurify";
 
 import type {
@@ -114,12 +114,6 @@ function isInfoModified(
   );
 }
 
-async function handleInfoAdd(language: string) {
-  if (language) {
-    // TODO: implement
-  }
-}
-
 async function handleInfoSave(
   production_id_url: string,
   originalInfo: ProductionInfo | null,
@@ -127,10 +121,11 @@ async function handleInfoSave(
   setOriginalInfo: React.Dispatch<React.SetStateAction<ProductionInfo | null>>,
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
-  language: string
+  language: string,
+  skipUnloadWarning: React.MutableRefObject<boolean>
 ) {
-  if (!draftInfo || !originalInfo) return;
-
+  if (!draftInfo) return;
+  
   setIsSaving(true);
   try {
     await updateProductionByUrl(production_id_url, {
@@ -152,6 +147,10 @@ async function handleInfoSave(
     setOriginalInfo(draftInfo);
 
     setIsEditing(false);
+    if (!originalInfo) {
+      skipUnloadWarning.current = true;
+      window.location.reload();
+    }
   } catch (err) {
     window.alert(`Save failed: ${err}`);
   } finally {
@@ -258,31 +257,6 @@ function SimpleEditableField({
   }
 
   return normal_view;
-}
-
-function EmptyProductionHeader({ image_url }: { image_url: string }) {
-  const { t } = useTranslation();
-  return (
-    <section
-      id="production-header"
-      className="relative overflow-hidden rounded-[2rem] border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] bg-black/30"
-    >
-      <img
-        src={image_url}
-        alt={t("productionPage.infoNotAvailable")}
-        className="h-[280px] w-full object-cover object-center md:h-[360px]"
-      />
-      <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/35 to-transparent" />
-      <div className="absolute right-7 bottom-8 left-7 md:right-12 md:bottom-10 md:left-12">
-        <h1
-          id="title"
-          className="mt-2 font-serif text-5xl leading-[1.03] text-[#f0e4d3] md:text-7xl"
-        >
-          {t("productionPage.infoNotAvailable")}
-        </h1>
-      </div>
-    </section>
-  );
 }
 
 type ProductionHeaderProps = {
@@ -451,38 +425,8 @@ const Spinner = () => (
   <span className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-white/40 border-t-white" />
 );
 
-type AddInfoButtonProps = {
-  language: string;
-};
-
-function AddInfoButton({ language }: AddInfoButtonProps) {
-  const { t } = useTranslation();
-  const shared_css = `
-    shadow-lg
-    hover:bg-archive-control-hover
-    rounded-full
-    cursor-pointer
-    transition-colors
-    duration-150
-    text-archive-ink
-    inline-flex
-    px-6 py-3
-    font-semibold text-white
-    `;
-  return (
-    <Protected permissions={[ARCHIVE_PERMISSIONS.update]}>
-      <button
-        id="add-production-button"
-        onClick={() => handleInfoAdd(language)}
-        className={`${shared_css} bg-archive-accent`}
-      >
-        {t("productionPage.add.add")}
-      </button>
-    </Protected>
-  );
-}
-
 type EditButtonProps = {
+  action: string,
   isEditing: boolean;
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
   originalInfo: ProductionInfo | null;
@@ -493,6 +437,7 @@ type EditButtonProps = {
 };
 
 function EditButton({
+  action,
   isEditing,
   setIsEditing,
   originalInfo,
@@ -522,7 +467,7 @@ function EditButton({
           onClick={() => setIsEditing(true)}
           className={`${shared_css} bg-archive-accent`}
         >
-          {t("productionPage.edit.edit")}
+          {action}
         </button>
       ) : (
         <div id="edit-actions" className="flex gap-3">
@@ -624,26 +569,34 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       setOriginalInfo,
       setIsEditing,
       setIsSaving,
-      language
+      language,
+      skipUnloadWarning,
     );
 
   // State when editing, keeps track if something has changed
   // (to enable save button)
-  const isModified = useMemo(
-    () => isInfoModified(originalInfo, draftInfo),
-    [originalInfo, draftInfo]
-  );
+  const isModified = useMemo(() => {
+    if (originalInfo === null) {
+      return isEditing; // With add always true.
+    }
+    return isInfoModified(originalInfo, draftInfo);
+  }, [originalInfo, draftInfo, isEditing]);
 
   // Prevent moving away from page when edit is modified (browser aways)
+  // Browser does not show warning when saving.
+  const skipUnloadWarning = useRef(false);
+
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
+      if (skipUnloadWarning.current) return; // skip bij reload na save
       if (isEditing && isModified) e.preventDefault();
     };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
   }, [isEditing, isModified]);
+
   // And the same but for React links
-  useUnsavedChangesBlocker(isEditing && isModified);
+  useUnsavedChangesBlocker(isEditing && isModified && !skipUnloadWarning);
 
   const title = getTextOrDefault(
     productionInfo?.title,
@@ -764,25 +717,20 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
     <div className="bg-archive-paper text-archive-ink min-h-screen">
       <main className="mx-auto flex w-full max-w-[1400px] flex-col gap-4 px-6 pt-10 pb-16 md:px-12">
         <BackToCollectionLink />
-        {productionInfo !== null ? (
-          <ProductionHeader
-            production_info={productionInfo}
-            image_url={imageUrl}
-            isEditing={isEditing}
-            originalInfo={originalInfo}
-            draftInfo={draftInfo}
-            setDraftInfo={setDraftInfo}
-          />
-        ) : (
-          <EmptyProductionHeader image_url={imageUrl} />
-        )}
+        <ProductionHeader
+          production_info={productionInfo}
+          image_url={imageUrl}
+          isEditing={isEditing}
+          originalInfo={originalInfo}
+          draftInfo={draftInfo}
+          setDraftInfo={setDraftInfo}
+        />
 
         <Tags performer_type={production.performer_type} tags={tags} />
 
         <section id="production-events" className="mt-8">
           <article className="space-y-6 text-[1.06rem] leading-[1.62] opacity-92">
             <ProductionInfoSection
-              prodinfo_available={productionInfo !== null}
               tagline={tagline}
               teaserHtml={teaserHtml}
               descriptionHtml={descriptionHtml}
@@ -815,6 +763,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       {productionInfo !== null ? (
         <div className="fixed right-6 bottom-6 z-50 flex gap-3">
           <EditButton
+            action={t("productionPage.edit.edit")}
             isEditing={isEditing}
             setIsEditing={setIsEditing}
             originalInfo={originalInfo}
@@ -832,7 +781,16 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
         </div>
       ) : (
         <div className="fixed right-6 bottom-6 z-50 flex gap-3">
-          <AddInfoButton language={""} />
+          <EditButton
+            action={t("productionPage.edit.add")}
+            isEditing={isEditing}
+            setIsEditing={setIsEditing}
+            originalInfo={null}
+            setDraftInfo={setDraftInfo}
+            enable_save={isModified}
+            is_saving={isSaving}
+            _handleSave={_handleSave}
+          />
         </div>
       )}
     </div>

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -125,7 +125,7 @@ async function handleInfoSave(
   skipUnloadWarning: React.MutableRefObject<boolean>
 ) {
   if (!draftInfo) return;
-  
+
   setIsSaving(true);
   try {
     await updateProductionByUrl(production_id_url, {
@@ -426,7 +426,7 @@ const Spinner = () => (
 );
 
 type EditButtonProps = {
-  action: string,
+  action: string;
   isEditing: boolean;
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
   originalInfo: ProductionInfo | null;
@@ -570,7 +570,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       setIsEditing,
       setIsSaving,
       language,
-      skipUnloadWarning,
+      skipUnloadWarning
     );
 
   // State when editing, keeps track if something has changed

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -52,9 +52,8 @@
   },
 
   "productionPage": {
-    "infoNotAvailable": "Information in this language is not available.",
     "fallback": {
-      "unknownProduction": "Unknown production",
+      "unknownProduction": "Information in this language is not available.",
       "archive": "Archive",
       "defaultArtist": "viernulvier",
       "noTeaser": "No teaser available for this production.",
@@ -78,6 +77,7 @@
     "visualEvidence": "Photos",
 
     "edit": {
+      "add": "Add info",
       "edit": "Edit",
       "save": "Save",
       "cancel": "Cancel",
@@ -93,9 +93,6 @@
       "delete": "Delete",
       "confirm": "Are you sure you want to delete this production info? This action cannot be undone.",
       "error": "Error: Each production should have info in at least one language."
-    },
-    "add": {
-      "add": "Add production info"
     }
   },
 

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -51,9 +51,8 @@
     }
   },
   "productionPage": {
-    "infoNotAvailable": "Informatie in deze taal is niet beschikbaar.",
     "fallback": {
-      "unknownProduction": "Onbekende productie",
+      "unknownProduction": "Informatie in deze taal is niet beschikbaar.",
       "archive": "Archief",
       "defaultArtist": "viernulvier",
       "noTeaser": "Geen teaser beschikbaar voor deze productie.",
@@ -76,6 +75,7 @@
     "visualEvidence": "Foto's",
 
     "edit": {
+      "add": "Voeg info toe",
       "edit": "Pas aan",
       "save": "Sla op",
       "cancel": "Annuleer",
@@ -91,9 +91,6 @@
       "delete": "Verwijder",
       "confirm": "Weet je zeker dat je deze productie-informatie wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
       "error": "Error: Elke productie heeft info in minstens één taal."
-    },
-    "add": {
-      "add": "Voeg productie-informatie toe"
     }
   },
 

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -142,7 +142,6 @@ vi.mock("react-i18next", async () => {
           "productionPage.eventMore": "I18N_Production_EventMore",
           "productionPage.priceLabel": "I18N_Production_PriceLabel",
           "productionPage.noPrice": "I18N_Production_NoPrice",
-          "productionPage.infoNotAvailable": "I18N_ProductionInfo_NotAvailable",
           "productionPage.add.add": "I18N_ProductionInfo_Add",
           "productionPage.delete.delete": "I18N_ProductionInfo_Delete",
         };

--- a/frontend/tests/unit/productionPage.test.tsx
+++ b/frontend/tests/unit/productionPage.test.tsx
@@ -146,8 +146,10 @@ describe("ProductionPage", () => {
 
   it("shows message that there is no information in this language", async () => {
     renderPage({ ...baseProductionOneInfo }, "en");
-    const elements = await screen.findAllByText("I18N_ProductionInfo_NotAvailable");
-    expect(elements).toHaveLength(2);
+    const elements = await screen.findAllByText(
+      "I18N_Production_Fallback_UnknownProduction"
+    );
+    expect(elements).toHaveLength(1);
     // Other information should still be visisble.
     expect(screen.getByText("Opera")).toBeInTheDocument();
     expect(screen.getByText("Classical")).toBeInTheDocument();


### PR DESCRIPTION
### Beschrijving
Deze PR laat het toe om een volledige nieuwe prodinfo in de ontbrekende taal (Engels of Nederlands) toe te voegen. 
Voorbeeld:
Volgende productie heeft enkel productie-info in het Nederlands:
<img width="1745" height="717" alt="image" src="https://github.com/user-attachments/assets/e730b923-5517-4974-a85d-812ec1378ac7" />

Op de archiefpagina wordt er gebruik gemaakt van de fallback.
<img width="773" height="781" alt="image" src="https://github.com/user-attachments/assets/76b197c6-83d4-4156-ae5e-d2a72f957957" />

Maar wanneer je dan naar de productiepagina gaan (in het Engels) zie je dat de info niet beschikbaar is en de mogelijkheid om deze toe te voegen:
<img width="1727" height="726" alt="image" src="https://github.com/user-attachments/assets/d0672a5c-bab1-42d6-9475-6da7aef21009" />

Na klikken op de Add, krijg je weer alle editeerbare veldjes:
<img width="1761" height="751" alt="image" src="https://github.com/user-attachments/assets/1e1bd17f-d5f3-4d7a-94f6-29590ed65fb7" />

### Aangepaste delen
- ProductionInfoSection
- ProductionPage


### Speciale opmerkingen
Ik heb voor deze PR vooral eerder (door mij) gedefinieerde code verwijderd. Zo is de EmptyProductionHeader er nu niet meer. Ook heb ik geen handleAdd en aparte add-button meer voorzien aangezien je dit makkelijk kon verwezenlijken met de edit-button. Er wordt dan gecheckt of de prodinfo bestaat en op basis daarvan wordt dan het juiste teruggegeven. 

Als je geen titel in de taal toevoegt en wel artist enz, zal je nog steeds hetvolgende zien:
<img width="1769" height="657" alt="image" src="https://github.com/user-attachments/assets/50f6e708-b91c-49d7-97bf-e5d83f0e1e52" />

Ik kan dit nog aanpassen maar vind dit eigenlijk ook wel goed zo aangezien de titel nog steeds niet beschikbaar is in die taal en dan kan je gewoon editeren en die toevoegen.

SORRY VOOR DE VERWARRENDE BRANCH-NAAM....

### Afhankelijkheden
Deze PR bouwt verder op #365 dus deze moet eerst gesloten worden. Wacht best met reviewen tot deze branch dan ook gemerged is.


### Testen
Weer qua testing voor deze functionaliteit (dat aanpassingen gebeuren enz.) komen in een aparte PR (door mij of @BWindey of een combinatie, is nog te zien).


Closes  #326 


- [ ] Goede testen toegevoegd.
- [x] Auteur wil zelf mergen.
