### PR TITLE
Package.json & eslint tweaks

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,2 @@
+engine-strict=true
+fund=false

--- a/frontend/app/features/archive/components/ProductionTimeline.tsx
+++ b/frontend/app/features/archive/components/ProductionTimeline.tsx
@@ -73,7 +73,7 @@ function MonthDisplay({
   return (
     <div>
       {/* Sticky month */}
-      {month != -1 ? (
+      {month !== -1 ? (
         <div className="bg-archive-paper/80 sticky top-20 z-30 mb-3 flex min-h-14 items-center gap-3 overflow-visible backdrop-blur-[14px]">
           <div className="upper text-[14px] font-bold tracking-[0.28em] uppercase opacity-25">
             {month === -1 ? t("Unknown") : getLongMonthName(month, language)}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -19,4 +19,8 @@ export default defineConfig({
     prettierConfig,
     reactHooks.configs.flat.recommended,
   ],
+
+  rules: {
+    eqeqeq: ["error", "always"],
+  },
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,6 +52,10 @@
         "vite": "^7.3.2",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=24",
+        "npm": ">=10"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,10 @@
   "name": "frontend",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24",
+    "npm": ">=10"
+  },
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",


### PR DESCRIPTION
### Beschrijving
Beetje laat in het project, maar kan geen kwaad.
Deze PR voegt strict engine requirements toe dat er voor zorgen dat je node versie minstens v24 of hoger moet zijn voor dat je het project kan uitvoeren. Verder voegt het ook een linting rule toe dat er voor zorgt dat er wordt gecontroleerd op gebruik van `==` ipv `===` 


### Aangepaste delen
- Package.json & package-lock.json
- .npmrc om strict engine te forceren
- eslint.config.mjs om linting rule toe te voegen

### Testen
N/A


- [ ] Auteur wil zelf mergen.