### PR TITLE
[BUGFIX] all gets redirect

### DIFF
--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -29,7 +29,7 @@ export async function getProductionsPaginated(
 ): Promise<ProductionList> {
   const apiClient = createApiClient();
 
-  const response = await apiClient.get<ProductionList>(`${ARCHIVE_PATH}/productions`, {
+  const response = await apiClient.get<ProductionList>(`${ARCHIVE_PATH}/productions/`, {
     params: {
       ...params,
       tag_ids: params?.tag_ids?.join(","),

--- a/frontend/app/features/blogs/services/blogService.ts
+++ b/frontend/app/features/blogs/services/blogService.ts
@@ -17,7 +17,7 @@ export async function getBlogsPaginated(
 ): Promise<BlogList> {
   const apiClient = createApiClient();
 
-  const response = await apiClient.get<BlogList>(`${ARCHIVE_PATH}/blogs`, {
+  const response = await apiClient.get<BlogList>(`${ARCHIVE_PATH}/blogs/`, {
     params: { ...params },
   });
 

--- a/frontend/app/shared/services/sharedService.ts
+++ b/frontend/app/shared/services/sharedService.ts
@@ -3,19 +3,26 @@ import { createApiClient } from "./apiClient";
 
 const ARCHIVE_PATH: string = "/api/v1/archive";
 
+function ensureTrailingSlash(url: string): string {
+  const [path, ...rest] = url.split(/(?=[?#])/);
+  return path.endsWith("/") ? url : `${path}/${rest.join("")}`;
+}
+
 function normalizeRequestUrl(url: string): string {
   const trimmedUrl = url.trim();
-
   if (trimmedUrl.startsWith("http://") || trimmedUrl.startsWith("https://")) {
     try {
       const parsedUrl = new URL(trimmedUrl);
-      return `${parsedUrl.pathname}${parsedUrl.search}`;
+      return ensureTrailingSlash(`${parsedUrl.pathname}${parsedUrl.search}`);
     } catch {
-      return trimmedUrl;
+      return ensureTrailingSlash(trimmedUrl);
     }
   }
+  return ensureTrailingSlash(trimmedUrl);
+}
 
-  return trimmedUrl;
+function archivePath(url: string): string {
+  return ensureTrailingSlash(`${ARCHIVE_PATH}${url}`);
 }
 
 export async function getByUrl<T>(url: string, lang?: string): Promise<T> {
@@ -26,19 +33,19 @@ export async function getByUrl<T>(url: string, lang?: string): Promise<T> {
 
 export async function getFromArchive<T>(url: string, lang?: string): Promise<T> {
   const apiClient = createApiClient(lang);
-  const data = await apiClient.get<T>(`${ARCHIVE_PATH}${url}`);
+  const data = await apiClient.get<T>(archivePath(url));
   return data.data;
 }
 
 export async function postToArchive<T>(url: string, data: unknown): Promise<T> {
   const apiClient = createApiClient();
-  const response = await apiClient.post<T>(`${ARCHIVE_PATH}${url}`, data);
+  const response = await apiClient.post<T>(archivePath(url), data);
   return response.data;
 }
 
 export async function patchToArchive<T>(url: string, data: unknown): Promise<T> {
   const apiClient = createApiClient();
-  const response = await apiClient.patch<T>(`${ARCHIVE_PATH}${url}`, data);
+  const response = await apiClient.patch<T>(archivePath(url), data);
   return response.data;
 }
 
@@ -50,7 +57,7 @@ export async function patchByUrl<T>(url: string, data: unknown): Promise<T> {
 
 export async function deleteFromArchive(url: string): Promise<void> {
   const apiClient = createApiClient();
-  await apiClient.delete(`${ARCHIVE_PATH}${url}`);
+  await apiClient.delete(archivePath(url));
 }
 
 export async function getFromArchiveList<T, CursorT = number>(
@@ -58,8 +65,6 @@ export async function getFromArchiveList<T, CursorT = number>(
   params?: PaginationRequest<CursorT>
 ): Promise<T[]> {
   const apiClient = createApiClient();
-  const data = await apiClient.get<T[]>(`${ARCHIVE_PATH}${url}`, {
-    params,
-  });
+  const data = await apiClient.get<T[]>(archivePath(url), { params });
   return data.data;
 }

--- a/frontend/tests/unit/apiClient.test.ts
+++ b/frontend/tests/unit/apiClient.test.ts
@@ -130,7 +130,7 @@ describe("getByUrl", () => {
   });
 
   it("returns response data", async () => {
-    mockAdapter.onGet("/test").reply(200, { foo: "bar" });
+    mockAdapter.onGet("/test/").reply(200, { foo: "bar" });
 
     const result = await getByUrl("/test");
     expect(result).toEqual({ foo: "bar" });

--- a/frontend/tests/unit/artistService.test.ts
+++ b/frontend/tests/unit/artistService.test.ts
@@ -25,7 +25,7 @@ describe("artistService", () => {
 
   describe("getArtists", () => {
     it("returns the nl list when lang_code is 'nl'", async () => {
-      mockAdapter.onGet("/api/v1/archive/artists").reply(200, MOCK_RESPONSE);
+      mockAdapter.onGet("/api/v1/archive/artists/").reply(200, MOCK_RESPONSE);
 
       const result = await getArtists("nl");
 
@@ -33,7 +33,7 @@ describe("artistService", () => {
     });
 
     it("returns the en list when lang_code is 'en'", async () => {
-      mockAdapter.onGet("/api/v1/archive/artists").reply(200, MOCK_RESPONSE);
+      mockAdapter.onGet("/api/v1/archive/artists/").reply(200, MOCK_RESPONSE);
 
       const result = await getArtists("en");
 
@@ -41,7 +41,7 @@ describe("artistService", () => {
     });
 
     it("throws when the request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/artists").reply(500);
+      mockAdapter.onGet("/api/v1/archive/artists/").reply(500);
 
       await expect(getArtists("nl")).rejects.toThrow();
     });

--- a/frontend/tests/unit/blogService.test.ts
+++ b/frontend/tests/unit/blogService.test.ts
@@ -67,8 +67,8 @@ describe("blogService", () => {
 
     const apiClient = createApiClient();
     mockAdapter = new AxiosMockAdapter(apiClient);
-    mockAdapter.onGet("/api/v1/archive/blogs/1").reply(200, mockBlog1);
-    mockAdapter.onGet("/api/v1/archive/blogs/2").reply(200, mockBlog2);
+    mockAdapter.onGet("/api/v1/archive/blogs/1/").reply(200, mockBlog1);
+    mockAdapter.onGet("/api/v1/archive/blogs/2/").reply(200, mockBlog2);
     vi.spyOn(axios, "create").mockReturnValue(apiClient);
   });
 
@@ -84,7 +84,7 @@ describe("blogService", () => {
         pagination: pagination,
       };
 
-      mockAdapter.onGet("/api/v1/archive/blogs").reply(200, mockBlogList);
+      mockAdapter.onGet("/api/v1/archive/blogs/").reply(200, mockBlogList);
       const result = await getBlogsPaginated();
 
       expect(result.blogs).toHaveLength(2);
@@ -108,7 +108,7 @@ describe("blogService", () => {
     });
 
     it("returns a single blog by url on success", async () => {
-      const result = await getBlogByUrl("/api/v1/archive/blogs/1");
+      const result = await getBlogByUrl("/api/v1/archive/blogs/1/");
 
       expect(result).toBeDefined();
 
@@ -125,7 +125,7 @@ describe("blogService", () => {
   describe("createBlog", () => {
     it("creates a new blog and returns it", async () => {
       const blog_content: BlogContent = {
-        blog_id_url: "/api/v1/archive/blogs/3",
+        blog_id_url: "/api/v1/archive/blogs/3/",
         language: "en",
         title: "title3",
         content: "content3",
@@ -136,20 +136,20 @@ describe("blogService", () => {
       };
 
       const mockResponse: Blog = {
-        id_url: "/api/v1/archive/blogs/3",
+        id_url: "/api/v1/archive/blogs/3/",
         blog_contents: [blog_content],
         production_id_urls: [],
       };
 
-      mockAdapter.onPost("/api/v1/archive/blogs").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/blogs/").reply(201, mockResponse);
       const result = await createBlog(blogData);
       expect(result).toEqual(mockResponse);
-      expect(result.id_url).toBe("/api/v1/archive/blogs/3");
+      expect(result.id_url).toBe("/api/v1/archive/blogs/3/");
     });
 
     it("throws when create request fails", async () => {
       const blog_content: BlogContent = {
-        blog_id_url: "/api/v1/archive/blogs/3",
+        blog_id_url: "/api/v1/archive/blogs/3/",
         language: "en",
         title: "title3",
         content: "content3",
@@ -159,7 +159,7 @@ describe("blogService", () => {
         production_id_urls: [],
       };
 
-      mockAdapter.onPost("/api/v1/archive/blogs").reply(400);
+      mockAdapter.onPost("/api/v1/archive/blogs/").reply(400);
 
       await expect(createBlog(blogData)).rejects.toThrow();
     });
@@ -168,16 +168,16 @@ describe("blogService", () => {
     it("updates a blog and returns updated data", async () => {
       const blogUpdate: BlogUpdate = {
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_id_urls: ["/api/v1/archive/productions/3"],
+        production_id_urls: ["/api/v1/archive/productions/3/"],
       };
 
       const mockBlog2_updated: Blog = {
-        id_url: "/api/v1/archive/blogs/2",
+        id_url: "/api/v1/archive/blogs/2/",
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_id_urls: ["/api/v1/archive/productions/3"],
+        production_id_urls: ["/api/v1/archive/productions/3/"],
       };
 
-      mockAdapter.onPatch("/api/v1/archive/blogs/2").reply(200, mockBlog2_updated);
+      mockAdapter.onPatch("/api/v1/archive/blogs/2/").reply(200, mockBlog2_updated);
 
       const result = await updateBlog(2, blogUpdate);
 
@@ -187,18 +187,18 @@ describe("blogService", () => {
     it("updates a blog and returns updated data by url", async () => {
       const blogUpdate: BlogUpdate = {
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_id_urls: ["/api/v1/archive/productions/3"],
+        production_id_urls: ["/api/v1/archive/productions/3/"],
       };
 
       const mockBlog2_updated: Blog = {
-        id_url: "/api/v1/archive/blogs/2",
+        id_url: "/api/v1/archive/blogs/2/",
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_id_urls: ["/api/v1/archive/productions/3"],
+        production_id_urls: ["/api/v1/archive/productions/3/"],
       };
 
-      mockAdapter.onPatch("/api/v1/archive/blogs/2").reply(200, mockBlog2_updated);
+      mockAdapter.onPatch("/api/v1/archive/blogs/2/").reply(200, mockBlog2_updated);
 
-      const result = await updateBlogByUrl("/api/v1/archive/blogs/2", blogUpdate);
+      const result = await updateBlogByUrl("/api/v1/archive/blogs/2/", blogUpdate);
 
       expect(result).toEqual(mockBlog2_updated);
     });
@@ -209,19 +209,19 @@ describe("blogService", () => {
         production_id_urls: [],
       };
 
-      mockAdapter.onPatch("/api/v1/archive/blogs/2").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/blogs/2/").reply(400);
       await expect(updateBlog(1, blogUpdate)).rejects.toThrow();
     });
   });
   describe("deleteBlog", () => {
     it("deletes a blog successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/blogs/1").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/blogs/1/").reply(204);
 
       await expect(deleteBlog(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/blogs/1").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/blogs/1/").reply(404);
 
       await expect(deleteBlog(1)).rejects.toThrow();
     });

--- a/frontend/tests/unit/eventService.test.ts
+++ b/frontend/tests/unit/eventService.test.ts
@@ -44,7 +44,7 @@ describe("eventService", () => {
         updated_at: "2026-03-20T10:00:00",
       };
 
-      mockAdapter.onGet("/api/v1/archive/events/1").reply(200, mockEvent);
+      mockAdapter.onGet("/api/v1/archive/events/1/").reply(200, mockEvent);
 
       const result = await getEvent(1);
 
@@ -54,7 +54,7 @@ describe("eventService", () => {
     });
 
     it("throws when event is not found", async () => {
-      mockAdapter.onGet("/api/v1/archive/events/999").reply(404);
+      mockAdapter.onGet("/api/v1/archive/events/999/").reply(404);
 
       await expect(getEvent(999)).rejects.toThrow();
     });
@@ -78,7 +78,7 @@ describe("eventService", () => {
         updated_at: "2026-03-20T10:00:00",
       };
 
-      mockAdapter.onPost("/api/v1/archive/events").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/events/").reply(201, mockResponse);
 
       const result = await createEvent(eventData);
 
@@ -92,7 +92,7 @@ describe("eventService", () => {
         hall_id_url: "hall1",
       };
 
-      mockAdapter.onPost("/api/v1/archive/events").reply(400);
+      mockAdapter.onPost("/api/v1/archive/events/").reply(400);
 
       await expect(createEvent(eventData)).rejects.toThrow();
     });
@@ -114,7 +114,7 @@ describe("eventService", () => {
         updated_at: "2026-03-21T10:00:00",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/events/1").reply(200, mockResponse);
+      mockAdapter.onPatch("/api/v1/archive/events/1/").reply(200, mockResponse);
 
       const result = await updateEvent(1, eventData);
 
@@ -127,7 +127,7 @@ describe("eventService", () => {
         starts_at: "2026-03-21T19:00:00",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/events/1").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/events/1/").reply(400);
 
       await expect(updateEvent(1, eventData)).rejects.toThrow();
     });
@@ -135,13 +135,13 @@ describe("eventService", () => {
 
   describe("deleteEvent", () => {
     it("deletes an event successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/events/1").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/events/1/").reply(204);
 
       await expect(deleteEvent(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/events/1").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/events/1/").reply(404);
 
       await expect(deleteEvent(1)).rejects.toThrow();
     });
@@ -168,7 +168,7 @@ describe("eventService", () => {
         },
       ];
 
-      mockAdapter.onGet("/api/v1/archive/events/1/prices").reply(200, mockPrices);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices/").reply(200, mockPrices);
 
       const result = await getEventPrices(1);
 
@@ -177,7 +177,7 @@ describe("eventService", () => {
     });
 
     it("throws when get prices request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/events/1/prices").reply(500);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices/").reply(500);
 
       await expect(getEventPrices(1)).rejects.toThrow();
     });
@@ -194,7 +194,7 @@ describe("eventService", () => {
         updated_at: "2026-03-20T10:00:00",
       };
 
-      mockAdapter.onGet("/api/v1/archive/events/1/prices/1").reply(200, mockPrice);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices/1/").reply(200, mockPrice);
 
       const result = await getEventPrice(1, 1);
 
@@ -204,7 +204,7 @@ describe("eventService", () => {
     });
 
     it("throws when price is not found", async () => {
-      mockAdapter.onGet("/api/v1/archive/events/1/prices/999").reply(404);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices/999/").reply(404);
 
       await expect(getEventPrice(1, 999)).rejects.toThrow();
     });

--- a/frontend/tests/unit/hallService.test.ts
+++ b/frontend/tests/unit/hallService.test.ts
@@ -33,7 +33,7 @@ describe("hallService", () => {
         { id_url: "2", name: "Hall B", address: "Street 2" },
       ];
 
-      mockAdapter.onGet("/api/v1/archive/halls").reply(200, mockHalls);
+      mockAdapter.onGet("/api/v1/archive/halls/").reply(200, mockHalls);
 
       const result = await getAllHalls();
 
@@ -42,7 +42,7 @@ describe("hallService", () => {
     });
 
     it("throws when get request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/halls").reply(500);
+      mockAdapter.onGet("/api/v1/archive/halls/").reply(500);
 
       await expect(getAllHalls()).rejects.toThrow();
     });
@@ -56,7 +56,7 @@ describe("hallService", () => {
         address: "Street 1",
       };
 
-      mockAdapter.onGet("/api/v1/archive/halls/1").reply(200, mockHall);
+      mockAdapter.onGet("/api/v1/archive/halls/1/").reply(200, mockHall);
 
       const result = await getHall(1);
 
@@ -66,7 +66,7 @@ describe("hallService", () => {
     });
 
     it("throws when hall is not found", async () => {
-      mockAdapter.onGet("/api/v1/archive/halls/999").reply(404);
+      mockAdapter.onGet("/api/v1/archive/halls/999/").reply(404);
 
       await expect(getHall(999)).rejects.toThrow();
     });
@@ -78,7 +78,7 @@ describe("hallService", () => {
         { id_url: "1", name: "Hall A", address: "Street 1" },
         { id_url: "2", name: "Hall B", address: "Street 2" },
       ];
-      mockAdapter.onGet("/api/v1/archive/halls").reply(200, mockHalls);
+      mockAdapter.onGet("/api/v1/archive/halls/").reply(200, mockHalls);
 
       const result = await getHallByName("hall A");
       expect(result).toEqual(mockHalls[0]);
@@ -97,7 +97,7 @@ describe("hallService", () => {
         ...hallData,
       };
 
-      mockAdapter.onPost("/api/v1/archive/halls").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/halls/").reply(201, mockResponse);
 
       const result = await createHall(hallData);
 
@@ -112,7 +112,7 @@ describe("hallService", () => {
         address: "New Street 1",
       };
 
-      mockAdapter.onPost("/api/v1/archive/halls").reply(400);
+      mockAdapter.onPost("/api/v1/archive/halls/").reply(400);
 
       await expect(createHall(hallData)).rejects.toThrow();
     });
@@ -131,7 +131,7 @@ describe("hallService", () => {
         address: "Updated Street 1",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/halls/1").reply(200, mockResponse);
+      mockAdapter.onPatch("/api/v1/archive/halls/1/").reply(200, mockResponse);
 
       const result = await updateHall(1, hallData);
 
@@ -146,7 +146,7 @@ describe("hallService", () => {
         address: "Updated Street 1",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/halls/1").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/halls/1/").reply(400);
 
       await expect(updateHall(1, hallData)).rejects.toThrow();
     });
@@ -154,13 +154,13 @@ describe("hallService", () => {
 
   describe("deleteHall", () => {
     it("deletes a hall successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/halls/1").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/halls/1/").reply(204);
 
       await expect(deleteHall(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/halls/1").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/halls/1/").reply(404);
 
       await expect(deleteHall(1)).rejects.toThrow();
     });

--- a/frontend/tests/unit/historyService.test.ts
+++ b/frontend/tests/unit/historyService.test.ts
@@ -53,7 +53,7 @@ describe("historyService", () => {
 
   describe("getHistoryEntries", () => {
     it("returns a list of history entries from the API", async () => {
-      mockAdapter.onGet("/api/v1/archive/history").reply(200, MOCK_HISTORY_LIST);
+      mockAdapter.onGet("/api/v1/archive/history/").reply(200, MOCK_HISTORY_LIST);
 
       const result = await getHistoryEntries();
 
@@ -62,7 +62,7 @@ describe("historyService", () => {
     });
 
     it("returns an empty list when no entries exist", async () => {
-      mockAdapter.onGet("/api/v1/archive/history").reply(200, []);
+      mockAdapter.onGet("/api/v1/archive/history/").reply(200, []);
 
       const result = await getHistoryEntries();
 
@@ -70,7 +70,7 @@ describe("historyService", () => {
     });
 
     it("throws when the request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/history").reply(500);
+      mockAdapter.onGet("/api/v1/archive/history/").reply(500);
 
       await expect(getHistoryEntries()).rejects.toThrow();
     });
@@ -85,7 +85,7 @@ describe("historyService", () => {
         content: "This is a test history entry",
       };
 
-      mockAdapter.onPost("/api/v1/archive/history").reply(201, MOCK_HISTORY_ENTRY);
+      mockAdapter.onPost("/api/v1/archive/history/").reply(201, MOCK_HISTORY_ENTRY);
 
       const result = await createHistoryEntry(request);
 
@@ -102,7 +102,7 @@ describe("historyService", () => {
         content: "Duplicate entry",
       };
 
-      mockAdapter.onPost("/api/v1/archive/history").reply(400, {
+      mockAdapter.onPost("/api/v1/archive/history/").reply(400, {
         detail: "History entry for year 2024 and language 'nl' already exists",
       });
 
@@ -127,7 +127,7 @@ describe("historyService", () => {
         content: "Updated content",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/history/2024/nl").reply(200, updatedEntry);
+      mockAdapter.onPatch("/api/v1/archive/history/2024/nl/").reply(200, updatedEntry);
 
       const result = await updateHistoryEntry(year, language, request);
 
@@ -144,13 +144,13 @@ describe("historyService", () => {
       };
 
       mockAdapter
-        .onPatch("/api/v1/archive/history/1999/en")
+        .onPatch("/api/v1/archive/history/1999/en/")
         .reply(200, MOCK_HISTORY_ENTRY);
 
       await updateHistoryEntry(year, language, request);
 
       expect(mockAdapter.history.patch).toHaveLength(1);
-      expect(mockAdapter.history.patch[0].url).toBe("/api/v1/archive/history/1999/en");
+      expect(mockAdapter.history.patch[0].url).toBe("/api/v1/archive/history/1999/en/");
     });
 
     it("rejects when the entry does not exist", async () => {
@@ -158,7 +158,7 @@ describe("historyService", () => {
       const language = "nl";
       const request: HistoryEntryUpdateRequest = { title: "Updated" };
 
-      mockAdapter.onPatch("/api/v1/archive/history/999/nl").reply(404, {
+      mockAdapter.onPatch("/api/v1/archive/history/999/nl/").reply(404, {
         detail: "History entry not found",
       });
 
@@ -173,7 +173,7 @@ describe("historyService", () => {
       const year = 2024;
       const language = "nl";
 
-      mockAdapter.onDelete("/api/v1/archive/history/2024/nl").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/history/2024/nl/").reply(204);
 
       await expect(deleteHistoryEntry(year, language)).resolves.toBeUndefined();
       expect(mockAdapter.history.delete).toHaveLength(1);
@@ -183,19 +183,21 @@ describe("historyService", () => {
       const year = 1999;
       const language = "en";
 
-      mockAdapter.onDelete("/api/v1/archive/history/1999/en").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/history/1999/en/").reply(204);
 
       await deleteHistoryEntry(year, language);
 
       expect(mockAdapter.history.delete).toHaveLength(1);
-      expect(mockAdapter.history.delete[0].url).toBe("/api/v1/archive/history/1999/en");
+      expect(mockAdapter.history.delete[0].url).toBe(
+        "/api/v1/archive/history/1999/en/"
+      );
     });
 
     it("rejects when the entry does not exist", async () => {
       const year = 999;
       const language = "nl";
 
-      mockAdapter.onDelete("/api/v1/archive/history/999/nl").reply(404, {
+      mockAdapter.onDelete("/api/v1/archive/history/999/nl/").reply(404, {
         detail: "History entry not found",
       });
 

--- a/frontend/tests/unit/mediaService.test.ts
+++ b/frontend/tests/unit/mediaService.test.ts
@@ -116,13 +116,13 @@ describe("mediaService", () => {
 
   describe("deleteMedia", () => {
     it("deletes a media item successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1/media/1").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/productions/1/media/1/").reply(204);
 
       await expect(deleteMedia(1, 1)).resolves.toBeUndefined();
     });
 
     it("throws when media item is not found", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1/media/99").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/productions/1/media/99/").reply(404);
 
       await expect(deleteMedia(1, 99)).rejects.toThrow();
     });

--- a/frontend/tests/unit/productionService.test.ts
+++ b/frontend/tests/unit/productionService.test.ts
@@ -95,8 +95,8 @@ describe("productionService", () => {
 
     const apiClient = createApiClient();
     mockAdapter = new AxiosMockAdapter(apiClient);
-    mockAdapter.onGet("/api/v1/archive/productions/1").reply(200, mockProduction1);
-    mockAdapter.onGet("/api/v1/archive/productions/2").reply(200, mockProduction2);
+    mockAdapter.onGet("/api/v1/archive/productions/1/").reply(200, mockProduction1);
+    mockAdapter.onGet("/api/v1/archive/productions/2/").reply(200, mockProduction2);
     vi.spyOn(axios, "create").mockReturnValue(apiClient);
   });
 
@@ -112,7 +112,7 @@ describe("productionService", () => {
         pagination: pagination,
       };
 
-      mockAdapter.onGet("/api/v1/archive/productions").reply(200, mockProductionList);
+      mockAdapter.onGet("/api/v1/archive/productions/").reply(200, mockProductionList);
       const result = await getProductionsPaginated();
 
       expect(result.productions).toHaveLength(2);
@@ -146,7 +146,7 @@ describe("productionService", () => {
   describe("createProduction", () => {
     it("creates a new production and returns it", async () => {
       const production_info: ProductionInfo = {
-        production_id_url: "/api/v1/archive/productions/3",
+        production_id_url: "/api/v1/archive/productions/3/",
         language: "en",
         title: "Rocking the Suburbs!",
         artist: "William Shatner",
@@ -159,21 +159,21 @@ describe("productionService", () => {
       };
 
       const mockResponse: Production = {
-        id_url: "/api/v1/archive/productions/3",
+        id_url: "/api/v1/archive/productions/3/",
         production_infos: [production_info],
         event_id_urls: [],
         tags: [tag1],
       };
 
-      mockAdapter.onPost("/api/v1/archive/productions").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/productions/").reply(201, mockResponse);
       const result = await createProduction(productionData);
       expect(result).toEqual(mockResponse);
-      expect(result.id_url).toBe("/api/v1/archive/productions/3");
+      expect(result.id_url).toBe("/api/v1/archive/productions/3/");
     });
 
     it("throws when create request fails", async () => {
       const production_info: ProductionInfo = {
-        production_id_url: "/api/v1/archive/productions/3",
+        production_id_url: "/api/v1/archive/productions/3/",
         language: "en",
         title: "Rocking the Suburbs!",
         artist: "William Shatner",
@@ -185,7 +185,7 @@ describe("productionService", () => {
         tag_id_urls: ["1", "2"],
       };
 
-      mockAdapter.onPost("/api/v1/archive/productions").reply(400);
+      mockAdapter.onPost("/api/v1/archive/productions/").reply(400);
 
       await expect(createProduction(productionData)).rejects.toThrow();
     });
@@ -209,7 +209,7 @@ describe("productionService", () => {
       };
 
       mockAdapter
-        .onPatch("/api/v1/archive/productions/2")
+        .onPatch("/api/v1/archive/productions/2/")
         .reply(200, mockProduction2_updated);
 
       const result = await updateProduction(2, productionUpdate);
@@ -224,19 +224,19 @@ describe("productionService", () => {
         attendance_mode: "online",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/productions/2").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/productions/2/").reply(400);
       await expect(updateProduction(1, productionUpdate)).rejects.toThrow();
     });
   });
   describe("deleteProduction", () => {
     it("deletes a production successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/productions/1/").reply(204);
 
       await expect(deleteProduction(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/productions/1/").reply(404);
 
       await expect(deleteProduction(1)).rejects.toThrow();
     });

--- a/frontend/tests/unit/resourceService.test.ts
+++ b/frontend/tests/unit/resourceService.test.ts
@@ -39,7 +39,7 @@ describe("resourceService", () => {
   it("getResourceList returns a list of data", async () => {
     const mockResources: IResource[] = [{ id: 1, someData: "testData" }];
     mockAdapter
-      .onGet("/api/v1/archive/resource", { params: { limit: 10 } })
+      .onGet("/api/v1/archive/resource/", { params: { limit: 10 } })
       .reply(200, mockResources);
 
     const result = await getResourceList(10);
@@ -48,7 +48,7 @@ describe("resourceService", () => {
 
   it("getResourceById returns data of specific resource", async () => {
     mockAdapter
-      .onGet("/api/v1/archive/resource/1")
+      .onGet("/api/v1/archive/resource/1/")
       .reply(200, { id: 1, someData: "testData" });
 
     const result = await getResourceById(1);
@@ -58,7 +58,7 @@ describe("resourceService", () => {
   it("createResource posts data", async () => {
     const request: ICreateResource = { someData: "testData" };
     mockAdapter
-      .onPost("/api/v1/archive/resource", request)
+      .onPost("/api/v1/archive/resource/", request)
       .reply(201, { id: 1, someData: request.someData });
 
     const result = await createResource(request);
@@ -68,7 +68,7 @@ describe("resourceService", () => {
   it("editResource edits data", async () => {
     const request: IUpdateResource = { someData: "testData" };
     mockAdapter
-      .onPatch("/api/v1/archive/resource/1", request)
+      .onPatch("/api/v1/archive/resource/1/", request)
       .reply(201, { id: 1, someData: request.someData });
 
     const result = await editResource(1, request);
@@ -77,19 +77,19 @@ describe("resourceService", () => {
 
   it("editResource throws when trying to patch non-existent data", async () => {
     const request: IUpdateResource = { someData: "testData" };
-    mockAdapter.onPatch("/api/v1/archive/resource/999", request).reply(404);
+    mockAdapter.onPatch("/api/v1/archive/resource/999/", request).reply(404);
 
     await expect(editResource(999, request)).rejects.toThrow("404");
   });
 
   it("deleteResource deletes data", async () => {
-    mockAdapter.onDelete("/api/v1/archive/resource/1").reply(204);
+    mockAdapter.onDelete("/api/v1/archive/resource/1/").reply(204);
     const result = await deleteResource(1);
     expect(result).toBeUndefined();
   });
 
   it("deleteResource throws when trying to delete non-existent data", async () => {
-    mockAdapter.onDelete("/api/v1/archive/resource/999").reply(404);
+    mockAdapter.onDelete("/api/v1/archive/resource/999/").reply(404);
 
     await expect(deleteResource(999)).rejects.toThrow("404");
   });

--- a/frontend/tests/unit/tagService.test.ts
+++ b/frontend/tests/unit/tagService.test.ts
@@ -51,7 +51,7 @@ describe("tagService", () => {
 
   describe("getAllTags", () => {
     it("returns a list of tags on success", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
+      mockAdapter.onGet("/api/v1/archive/tags/").reply(200, [mockTag1, mockTag2]);
 
       const result = await getAllTags();
       expect(result).toEqual([mockTag1, mockTag2]);
@@ -60,7 +60,7 @@ describe("tagService", () => {
 
   describe("getTagById", () => {
     it("returns a tag object on success", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags/1").reply(200, mockTag1);
+      mockAdapter.onGet("/api/v1/archive/tags/1/").reply(200, mockTag1);
 
       const result = await getTagById(1);
       expect(result).toEqual(mockTag1);
@@ -69,14 +69,14 @@ describe("tagService", () => {
 
   describe("getTagByName", () => {
     it("returns a tag object on success (nl)", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
+      mockAdapter.onGet("/api/v1/archive/tags/").reply(200, [mockTag1, mockTag2]);
 
       const result = await getTagByName("tag naam");
       expect(result).toEqual(mockTag1);
     });
 
     it("returns a tag object on success (en)", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
+      mockAdapter.onGet("/api/v1/archive/tags/").reply(200, [mockTag1, mockTag2]);
 
       const result = await getTagByName("tag name");
       expect(result).toEqual(mockTag1);
@@ -86,7 +86,7 @@ describe("tagService", () => {
   describe("createTag", () => {
     it("creates a tag object and returns it on success", async () => {
       // Upon calling post, return the request with an added id field
-      mockAdapter.onPost("/api/v1/archive/tags").reply((config) => {
+      mockAdapter.onPost("/api/v1/archive/tags/").reply((config) => {
         const data = {
           id_url: mockTag1.id_url,
           ...JSON.parse(config.data),
@@ -101,7 +101,7 @@ describe("tagService", () => {
 
   describe("editTag", () => {
     it("edits a tag by id and returns the updated object", async () => {
-      mockAdapter.onPatch("/api/v1/archive/tags/1").reply((config) => {
+      mockAdapter.onPatch("/api/v1/archive/tags/1/").reply((config) => {
         const data = {
           id_url: "http://localhost/api/v1/archive/tags/1",
           ...JSON.parse(config.data),
@@ -116,7 +116,7 @@ describe("tagService", () => {
 
   describe("deleteTag", () => {
     it("deletes a tag", async () => {
-      mockAdapter.onDelete("/api/v1/archive/tags/1").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/tags/1/").reply(204);
       await deleteTag(1);
     });
   });


### PR DESCRIPTION
### Beschrijving
Alle gets in de frontend triggerden een 307 redirect van `url` naar `url/`. Nu wordt van de eerste keer `url/` gebruikt


### Aangepaste delen
`sharedService.ts`: trailing `/` toevoeg functie
`blogService.ts` en `productionService.ts`: een `/` toegevoegd bij de `getXXXPaginated`
`testen`: de gecallde urls moesten nu ook een `/` verwachten


### Testen
Veel testen geupdated


- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
