### PR TITLE
RichTextField is clickable everywhere

### DIFF
--- a/frontend/app/shared/components/ArchiveRichTextField.tsx
+++ b/frontend/app/shared/components/ArchiveRichTextField.tsx
@@ -38,10 +38,13 @@ const archiveRichTextFieldSx: SxProps<Theme> = {
     fontSize: "0.875rem",
     color: "var(--archive-ink)",
     minHeight: "150px",
+    cursor: "text",
   },
 
   "& .ql-editor": {
     padding: "0.75rem",
+    minHeight: "150px",
+    cursor: "text",
   },
 
   "& .ql-toolbar button": {

--- a/frontend/app/shared/components/ArchiveRichTextField.tsx
+++ b/frontend/app/shared/components/ArchiveRichTextField.tsx
@@ -170,7 +170,7 @@ export function ArchiveRichTextField({
   }, [canEdit]);
 
   return (
-    <Box sx={toSxArray(sx)}>
+    <Box sx={toSxArray(sx)} onClick={() => quillRef.current?.focus()}>
       <div ref={containerRef} />
     </Box>
   );


### PR DESCRIPTION
### Beschrijving
Deze kleine PR lost het probleem op dat je in de editor enkel kon typen als je bovenaan op de editor klikte. Nu is de hele editor clickable. 


### Aangepaste delen
ArchiveRichTextField

### Speciale opmerkingen
Ik vraag me af of dit component niet cursed is op gsm mode. Het is alleszins nog goed als ik mijn window verklein.


### Afhankelijkheden
None.


### Testen
None


Closes None

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
