### PR TITLE
fix annoying quill bugs

### DIFF
--- a/frontend/app/archive-rich-text.client.ts
+++ b/frontend/app/archive-rich-text.client.ts
@@ -13,5 +13,7 @@ export async function deltaToHtml(delta: Delta): Promise<string> {
   const container = document.createElement("div");
   const quill = new Quill(container);
   quill.setContents(delta);
-  return quill.getSemanticHTML();
+  
+  const html = quill.getSemanticHTML();
+  return html.replace(/&nbsp;/g, " ");
 }

--- a/frontend/app/archive-rich-text.client.ts
+++ b/frontend/app/archive-rich-text.client.ts
@@ -13,7 +13,7 @@ export async function deltaToHtml(delta: Delta): Promise<string> {
   const container = document.createElement("div");
   const quill = new Quill(container);
   quill.setContents(delta);
-  
+
   const html = quill.getSemanticHTML();
   return html.replace(/&nbsp;/g, " ");
 }

--- a/frontend/app/features/archive/components/ProductionInfoSection.tsx
+++ b/frontend/app/features/archive/components/ProductionInfoSection.tsx
@@ -9,6 +9,7 @@ type ProductionInfoSectionProps = {
   infoHtml: string | undefined;
   isEditing: boolean;
   onSave: (field: string, html: string) => void;
+  onQuillDirtyChange: (isDirty: boolean) => void;
 };
 
 export function ProductionInfoSection({
@@ -18,6 +19,7 @@ export function ProductionInfoSection({
   infoHtml,
   isEditing: globalIsEditing,
   onSave,
+  onQuillDirtyChange,
 }: ProductionInfoSectionProps) {
   const { t } = useTranslation();
   const [editing, setEditing] = useState<string | null>(null);
@@ -47,6 +49,7 @@ export function ProductionInfoSection({
         onCancel={() => setEditing(null)}
         fallback={<p className="opacity-75">{t("productionPage.fallback.noTeaser")}</p>}
         canEdit={globalIsEditing}
+        onDirtyChange={onQuillDirtyChange}
       />
 
       <ComplexEditableField
@@ -61,6 +64,7 @@ export function ProductionInfoSection({
           <p className="opacity-75">{t("productionPage.fallback.noDescription")}</p>
         }
         canEdit={globalIsEditing}
+        onDirtyChange={onQuillDirtyChange}
       />
 
       <ComplexEditableField
@@ -73,6 +77,7 @@ export function ProductionInfoSection({
         onCancel={() => setEditing(null)}
         fallback={<p className="opacity-75">{t("productionPage.fallback.noInfo")}</p>}
         canEdit={globalIsEditing}
+        onDirtyChange={onQuillDirtyChange}
       />
     </>
   );

--- a/frontend/app/features/archive/components/ProductionInfoSection.tsx
+++ b/frontend/app/features/archive/components/ProductionInfoSection.tsx
@@ -36,7 +36,7 @@ export function ProductionInfoSection({
   }
 
   return (
-    <>
+    <div className="flex min-w-0 flex-col gap-6">
       {tagline && <p id="tagline">{tagline}</p>}
 
       <ComplexEditableField
@@ -79,6 +79,6 @@ export function ProductionInfoSection({
         canEdit={globalIsEditing}
         onDirtyChange={onQuillDirtyChange}
       />
-    </>
+    </div>
   );
 }

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -325,17 +325,26 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   // Prevent moving away from page when edit is modified (browser aways)
   // Browser does not show warning when saving.
   const skipUnloadWarning = useRef(false);
+  const isEditingRef = useRef(false);
+  const isModifiedRef = useRef(false);
+  const isQuillDirtyRef = useRef(false);
   const [skipWarning, setSkipWarning] = useState(false);
   const [isQuillDirty, setIsQuillDirty] = useState(false);
 
+  isEditingRef.current = isEditing;
+  isModifiedRef.current = isModified;
+  isQuillDirtyRef.current = isQuillDirty;
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
       if (skipUnloadWarning.current) return;
-      if (isEditing && (isModified || isQuillDirty)) e.preventDefault();
+      if (isEditingRef.current && (isModifiedRef.current || isQuillDirtyRef.current)) {
+        e.preventDefault();
+      }
     };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
-  }, [isEditing, isModified, isQuillDirty]);
+  }, []);
+
 
   // And the same but for React links
   useUnsavedChangesBlocker(isEditing && (isModified || isQuillDirty) && !skipWarning);
@@ -495,7 +504,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
         <Tags performer_type={production.performer_type} tags={tags} />
 
         <section id="production-events" className="mt-8">
-          <article className="space-y-6 text-[1.06rem] leading-[1.62] opacity-92">
+          <article className="w-full min-w-0 space-y-6 text-[1.06rem] leading-[1.62] opacity-92">
             <ProductionInfoSection
               tagline={tagline}
               teaserHtml={teaserHtml}

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -168,9 +168,14 @@ function useUnsavedChangesBlocker(when: boolean) {
     blockerRef.current = blocker;
   });
 
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  });
+
   useEffect(() => {
     if (blockerRef.current.state === "blocked") {
-      const confirmLeave = window.confirm(t("notSaveChanges"));
+      const confirmLeave = window.confirm(tRef.current("notSaveChanges"));
       if (confirmLeave) {
         blockerRef.current.proceed();
       } else {

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -1,6 +1,6 @@
 import { Link, useBlocker, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import DOMPurify from "dompurify";
 
 import type {
@@ -161,15 +161,19 @@ async function handleInfoSave(
 
 function useUnsavedChangesBlocker(when: boolean) {
   const blocker = useBlocker(when);
+  const blockerRef = useRef(blocker);
 
   useEffect(() => {
-    if (blocker.state === "blocked") {
-      const confirmLeave = window.confirm("You have unsaved changes. Leave anyway?");
+    blockerRef.current = blocker;
+  });
 
+  useEffect(() => {
+    if (blockerRef.current.state === "blocked") {
+      const confirmLeave = window.confirm("You have unsaved changes. Leave anyway?");
       if (confirmLeave) {
-        blocker.proceed();
+        blockerRef.current.proceed();
       } else {
-        blocker.reset();
+        blockerRef.current.reset();
       }
     }
   }, [blocker.state]);
@@ -498,7 +502,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
                   prev ? { ...prev, [field]: isEmpty ? null : html } : prev
                 );
               }}
-              onQuillDirtyChange={setIsQuillDirty}
+              onQuillDirtyChange={useCallback((isDirty: boolean) => setIsQuillDirty(isDirty), [])}
             />
 
             <section className="bg-archive-surface-strong mt-8 max-w-3xl rounded-[1.75rem] p-6">

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -508,7 +508,10 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
                   prev ? { ...prev, [field]: isEmpty ? null : html } : prev
                 );
               }}
-              onQuillDirtyChange={useCallback((isDirty: boolean) => setIsQuillDirty(isDirty), [])}
+              onQuillDirtyChange={useCallback(
+                (isDirty: boolean) => setIsQuillDirty(isDirty),
+                []
+              )}
             />
 
             <section className="bg-archive-surface-strong mt-8 max-w-3xl rounded-[1.75rem] p-6">

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -322,8 +322,6 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       .catch(() => {});
   }, [production.id_url]);
 
-  // Prevent moving away from page when edit is modified (browser aways)
-  // Browser does not show warning when saving.
   const skipUnloadWarning = useRef(false);
   const isEditingRef = useRef(false);
   const isModifiedRef = useRef(false);
@@ -331,9 +329,12 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   const [skipWarning, setSkipWarning] = useState(false);
   const [isQuillDirty, setIsQuillDirty] = useState(false);
 
-  isEditingRef.current = isEditing;
-  isModifiedRef.current = isModified;
-  isQuillDirtyRef.current = isQuillDirty;
+  useEffect(() => {
+    isEditingRef.current = isEditing;
+    isModifiedRef.current = isModified;
+    isQuillDirtyRef.current = isQuillDirty;
+  }, [isEditing, isModified, isQuillDirty]);
+
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
       if (skipUnloadWarning.current) return;
@@ -345,7 +346,6 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
     return () => window.removeEventListener("beforeunload", handler);
   }, []);
 
-  // And the same but for React links
   useUnsavedChangesBlocker(isEditing && (isModified || isQuillDirty) && !skipWarning);
 
   const title = getTextOrDefault(

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -345,7 +345,6 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
     return () => window.removeEventListener("beforeunload", handler);
   }, []);
 
-
   // And the same but for React links
   useUnsavedChangesBlocker(isEditing && (isModified || isQuillDirty) && !skipWarning);
 

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -323,7 +323,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   }, [isEditing, isModified]);
 
   // And the same but for React links
-  useUnsavedChangesBlocker(isEditing && isModified && !skipUnloadWarning);
+  useUnsavedChangesBlocker(isEditing && isModified && !skipUnloadWarning.current);
 
   const title = getTextOrDefault(
     productionInfo?.title,

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -121,7 +121,8 @@ async function handleInfoSave(
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
   language: string,
-  skipUnloadWarning: React.MutableRefObject<boolean>
+  skipUnloadWarning: React.RefObject<boolean>,
+  setSkipWarning: React.Dispatch<React.SetStateAction<boolean>>
 ) {
   if (!draftInfo) return;
 
@@ -148,6 +149,7 @@ async function handleInfoSave(
     setIsEditing(false);
     if (!originalInfo) {
       skipUnloadWarning.current = true;
+      setSkipWarning(true);
       window.location.reload();
     }
   } catch (err) {
@@ -284,7 +286,8 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       setIsEditing,
       setIsSaving,
       language,
-      skipUnloadWarning
+      skipUnloadWarning,
+      setSkipWarning
     );
 
   // State when editing, keeps track if something has changed
@@ -312,6 +315,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   // Prevent moving away from page when edit is modified (browser aways)
   // Browser does not show warning when saving.
   const skipUnloadWarning = useRef(false);
+  const [skipWarning, setSkipWarning] = useState(false);
 
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
@@ -323,7 +327,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   }, [isEditing, isModified]);
 
   // And the same but for React links
-  useUnsavedChangesBlocker(isEditing && isModified && !skipUnloadWarning.current);
+  useUnsavedChangesBlocker(isEditing && isModified && !skipWarning);
 
   const title = getTextOrDefault(
     productionInfo?.title,

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -172,7 +172,7 @@ function useUnsavedChangesBlocker(when: boolean) {
         blocker.reset();
       }
     }
-  }, [blocker]);
+  }, [blocker.state]);
 }
 
 function BackToCollectionLink() {
@@ -316,18 +316,19 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   // Browser does not show warning when saving.
   const skipUnloadWarning = useRef(false);
   const [skipWarning, setSkipWarning] = useState(false);
+  const [isQuillDirty, setIsQuillDirty] = useState(false);
 
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
-      if (skipUnloadWarning.current) return; // skip bij reload na save
-      if (isEditing && isModified) e.preventDefault();
+      if (skipUnloadWarning.current) return;
+      if (isEditing && (isModified || isQuillDirty)) e.preventDefault();
     };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
-  }, [isEditing, isModified]);
+  }, [isEditing, isModified, isQuillDirty]);
 
   // And the same but for React links
-  useUnsavedChangesBlocker(isEditing && isModified && !skipWarning);
+  useUnsavedChangesBlocker(isEditing && (isModified || isQuillDirty) && !skipWarning);
 
   const title = getTextOrDefault(
     productionInfo?.title,
@@ -497,6 +498,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
                   prev ? { ...prev, [field]: isEmpty ? null : html } : prev
                 );
               }}
+              onQuillDirtyChange={setIsQuillDirty}
             />
 
             <section className="bg-archive-surface-strong mt-8 max-w-3xl rounded-[1.75rem] p-6">

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -162,6 +162,7 @@ async function handleInfoSave(
 function useUnsavedChangesBlocker(when: boolean) {
   const blocker = useBlocker(when);
   const blockerRef = useRef(blocker);
+  const { t } = useTranslation();
 
   useEffect(() => {
     blockerRef.current = blocker;
@@ -169,7 +170,7 @@ function useUnsavedChangesBlocker(when: boolean) {
 
   useEffect(() => {
     if (blockerRef.current.state === "blocked") {
-      const confirmLeave = window.confirm("You have unsaved changes. Leave anyway?");
+      const confirmLeave = window.confirm(t("notSaveChanges"));
       if (confirmLeave) {
         blockerRef.current.proceed();
       } else {

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -1,4 +1,5 @@
 {
+  "notSaveChanges": "You have unsaved changes. Leave anyway?",
   "loading": "Loading...",
   "nav": {
     "home": "Home",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -45,7 +45,7 @@
     "unknownDate": "Unknown date",
     "card": {
       "defaults": {
-        "title": "Unknown production",
+        "title": "Unknown production title",
         "dateLabel": "Unknown date",
         "venueLabel": "Unknown"
       }

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -1,4 +1,5 @@
 {
+  "notSaveChanges": "Je hebt niet opgeslagen wijzigingen. Toch doorgaan?",
   "loading": "Laden...",
   "nav": {
     "home": "Home",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -45,7 +45,7 @@
     "unknownDate": "Onbekende datum",
     "card": {
       "defaults": {
-        "title": "Onbekende productie",
+        "title": "Onbekende productie titel",
         "dateLabel": "Onbekende datum",
         "venueLabel": "Onbekend"
       }

--- a/frontend/app/shared/components/ComplexEditableField.tsx
+++ b/frontend/app/shared/components/ComplexEditableField.tsx
@@ -132,7 +132,7 @@ export default function ComplexEditableField({
   return (
     <div
       id={id}
-      className={`rounded opacity-90 ${canEdit ? "className=flex hover:outline-archive-accent !cursor-pointer items-center gap-2 hover:outline hover:outline-1" : "!cursor-default"}`}
+      className={`flex-1 rounded opacity-90 min-w-0 w-full overflow-x-hidden ${canEdit ? "flex flex-col hover:outline-archive-accent !cursor-pointer hover:outline hover:outline-1" : "cursor-default"}`}
       onClick={onStartEdit}
     >
       {canEdit ? (
@@ -143,7 +143,10 @@ export default function ComplexEditableField({
       ) : null}
 
       {html ? (
-        <div className="prose" dangerouslySetInnerHTML={{ __html: html }} />
+        <div
+          className="prose max-w-none min-w-0 whitespace-normal break-words overflow-wrap-anywhere"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
       ) : (
         fallback
       )}

--- a/frontend/app/shared/components/ComplexEditableField.tsx
+++ b/frontend/app/shared/components/ComplexEditableField.tsx
@@ -92,7 +92,7 @@ export default function ComplexEditableField({
     } else {
       onDirtyChange?.(false);
     }
-  }, [isEditing, html]);
+  }, [isEditing, html, onDirtyChange]);
 
   if (isEditing) {
     return (

--- a/frontend/app/shared/components/ComplexEditableField.tsx
+++ b/frontend/app/shared/components/ComplexEditableField.tsx
@@ -46,6 +46,7 @@ type ComplexEditableFieldProps = {
   onSave: (html: string) => void;
   onCancel: () => void;
   canEdit: boolean;
+  onDirtyChange?: (isDirty: boolean) => void;
 };
 
 export default function ComplexEditableField({
@@ -58,9 +59,12 @@ export default function ComplexEditableField({
   onSave,
   onCancel,
   canEdit,
+  onDirtyChange,
 }: ComplexEditableFieldProps) {
   const { t } = useTranslation();
   const [delta, setDelta] = useState<Delta | null>(null);
+  const [originalDelta, setOriginalDelta] = useState<Delta | null>(null);
+
   const shared_css = `
     shadow-lg
     hover:bg-archive-control-hover
@@ -76,9 +80,17 @@ export default function ComplexEditableField({
 
   useEffect(() => {
     if (isEditing && html) {
-      htmlToDelta(html).then(setDelta);
+      htmlToDelta(html).then((d) => {
+        setDelta(d);
+        setOriginalDelta(d);
+      });
     } else if (isEditing) {
-      setTimeout(() => setDelta(null), 0);
+      setTimeout(() => {
+        setDelta(null);
+        setOriginalDelta(null);
+      }, 0);
+    } else {
+      onDirtyChange?.(false);
     }
   }, [isEditing, html]);
 
@@ -89,7 +101,11 @@ export default function ComplexEditableField({
           <ArchiveRichTextFieldWrapper
             label={field}
             value={delta}
-            onChange={setDelta}
+            onChange={(newDelta) => {
+              setDelta(newDelta);
+              const dirty = JSON.stringify(newDelta) !== JSON.stringify(originalDelta);
+              onDirtyChange?.(dirty);
+            }}
             canEdit={canEdit}
           />
           <div className="mt-2 flex gap-2">

--- a/frontend/app/shared/components/ComplexEditableField.tsx
+++ b/frontend/app/shared/components/ComplexEditableField.tsx
@@ -132,7 +132,7 @@ export default function ComplexEditableField({
   return (
     <div
       id={id}
-      className={`flex-1 rounded opacity-90 min-w-0 w-full overflow-x-hidden ${canEdit ? "flex flex-col hover:outline-archive-accent !cursor-pointer hover:outline hover:outline-1" : "cursor-default"}`}
+      className={`w-full min-w-0 flex-1 overflow-x-hidden rounded opacity-90 ${canEdit ? "hover:outline-archive-accent flex !cursor-pointer flex-col hover:outline hover:outline-1" : "cursor-default"}`}
       onClick={onStartEdit}
     >
       {canEdit ? (
@@ -144,7 +144,7 @@ export default function ComplexEditableField({
 
       {html ? (
         <div
-          className="prose max-w-none min-w-0 whitespace-normal break-words overflow-wrap-anywhere"
+          className="prose overflow-wrap-anywhere max-w-none min-w-0 break-words whitespace-normal"
           dangerouslySetInnerHTML={{ __html: html }}
         />
       ) : (


### PR DESCRIPTION
### Beschrijving
Iets misgelopen waardoor #378 al gemerged is, ondanks dat er nog een bug was. Als je in quillveldje iets hebt aangepast maar nog niet een 2e keer opgeslagen hebt, kan je naar andere tab gaan zonder waarschuwing. Nu lukt dit niet meer.

Nog 2 andere bugs zijn naar boven gekomen waarvan er eentje zeer ambetant doet.
- Andere website bezoeken bij unsaved changes gaf geen waarschuwing.
- Overlow bij quill. 

### Aangepaste delen
<Beschrijf hier welke delen van de app aangepast waren, frontend, backend, ...
welk deel ervan?>


### Speciale opmerkingen
Quill doet echt heel moeilijk met overflow. Verschillende pogingen zijn ondernomen geweest, vele hersencellen zijn hieraan gestorven en dit is het uiteindelijke resultaat.


### Afhankelijkheden
<Welke eventuele PR's moeten eerder gesloten worden voor dit kan gemerged worden>


### Testen
<Vermeld of er al testen zijn voor nieuwe functionaliteit en hoe de coverage is,
als er iets niet gecovered is, leg dit uit waarom dit niet nodig zou zijn.>


Closes <issue-nr>

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
