### PR TITLE
use 2 columns instead of a row on mobile devices

### DIFF
--- a/frontend/app/features/home/pages/homePage.tsx
+++ b/frontend/app/features/home/pages/homePage.tsx
@@ -23,7 +23,7 @@ export default function HomePage() {
         <p className="mb-10 text-lg leading-relaxed font-light opacity-70 md:mb-16 md:text-2xl">
           {t("home.description")}
         </p>
-        <div className="border-archive-ink/5 mb-16 mx-auto grid max-w-sm grid-cols-2 items-center gap-y-10 border-y py-10 opacity-80 sm:max-w-none sm:flex sm:flex-wrap sm:justify-center sm:gap-x-16">
+        <div className="border-archive-ink/5 mx-auto mb-16 grid max-w-sm grid-cols-2 items-center gap-y-10 border-y py-10 opacity-80 sm:flex sm:max-w-none sm:flex-wrap sm:justify-center sm:gap-x-16">
           <HomeStatistic count={productionsCount} label={t("home.stats.productions")} />
           <HomeStatistic count={eventsCount} label={t("home.stats.events")} />
           <HomeStatistic count={artistsCount} label={t("home.stats.artists")} />

--- a/frontend/app/features/home/pages/homePage.tsx
+++ b/frontend/app/features/home/pages/homePage.tsx
@@ -23,7 +23,7 @@ export default function HomePage() {
         <p className="mb-10 text-lg leading-relaxed font-light opacity-70 md:mb-16 md:text-2xl">
           {t("home.description")}
         </p>
-        <div className="border-archive-ink/5 mb-16 flex flex-wrap items-center justify-center gap-x-12 gap-y-10 border-y py-10 opacity-80 sm:gap-x-16">
+        <div className="border-archive-ink/5 mb-16 mx-auto grid max-w-sm grid-cols-2 items-center gap-y-10 border-y py-10 opacity-80 sm:max-w-none sm:flex sm:flex-wrap sm:justify-center sm:gap-x-16">
           <HomeStatistic count={productionsCount} label={t("home.stats.productions")} />
           <HomeStatistic count={eventsCount} label={t("home.stats.events")} />
           <HomeStatistic count={artistsCount} label={t("home.stats.artists")} />


### PR DESCRIPTION
### Beschrijving
Fixes UI bug for homepage. De statistiscs werden niet mooi weergegeven, nu wel.

### Aangepaste delen
ipv ze allemaal op 1 rij te zetten zijn ze op een mobile device in 2x2 grid .

<img width="309" height="653" alt="image" src="https://github.com/user-attachments/assets/3814ee30-9eac-4e2e-88e2-a9a6d566c197" />

### Speciale opmerkingen
N/A


### Afhankelijkheden
N/A


### Testen
N/A


Closes #261 

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
