### PR TITLE
Feat/ctrl click prodcard

### DIFF
--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -518,11 +518,9 @@ export function ProductionCard({
         </Stack>
 
         <Stack direction="row" alignItems="center" justifyContent="flex-end">
-          <Link
+          <div
             className="production-card-text"
-            component="span"
-            underline="none"
-            sx={{
+            style={{
               color: colorWithOpacity(CARD_COLORS.accent, 0.98),
               fontWeight: "var(--weight-archive-bold)",
               textTransform: "uppercase",
@@ -535,7 +533,7 @@ export function ProductionCard({
             }}
           >
             Details <ArrowRightAlt />
-          </Link>
+          </div>
         </Stack>
       </CardContent>
     </Card>

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -190,7 +190,6 @@ export function ProductionCard({
   const tagNames = getTagNamesByLanguage(production, preferredLanguage);
 
   const productionId = getProductionNumericIdFromUrl(production.id_url);
-  if (!productionId) return null;
 
   const handleToggleSelected = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
@@ -210,6 +209,8 @@ export function ProductionCard({
         // keep default
       });
   }, [productionId]);
+
+  if (!productionId) return null;
 
   const imageUrl = firstImageUrl ?? defaultCardValues.imageUrl;
 

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router";
+import { useParams } from "react-router";
 import { useEffect, useState } from "react";
 import type { Production, ProductionInfo } from "../types/productionTypes";
 import { useLocalizedPath } from "~/shared/hooks/useLocalizedPath";
@@ -162,7 +162,6 @@ export function ProductionCard({
   onToggleSelected,
 }: ProductionCardProps) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const lp = useLocalizedPath();
   const { lang } = useParams();
   if (!preferredLanguage) preferredLanguage = lang || "nl";
@@ -191,7 +190,7 @@ export function ProductionCard({
   const tagNames = getTagNamesByLanguage(production, preferredLanguage);
 
   const productionId = getProductionNumericIdFromUrl(production.id_url);
-  if (!productionId) return undefined;
+  if (!productionId) return null;
 
   const handleToggleSelected = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
@@ -526,7 +525,6 @@ export function ProductionCard({
               textTransform: "uppercase",
               letterSpacing: "var(--tracking-archive-label)",
               fontSize: "var(--text-archive-meta)",
-              cursor: "pointer",
               display: "flex",
               alignItems: "center",
               gap: 0.5,

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -1,12 +1,12 @@
 import ArrowRightAlt from "@mui/icons-material/ArrowRightAlt";
 import Check from "@mui/icons-material/Check";
+import { Link } from "react-router";
 import {
   Box,
   Card,
   CardContent,
   CardMedia,
   Chip,
-  Link,
   Divider,
   Stack,
   Typography,
@@ -191,6 +191,7 @@ export function ProductionCard({
   const tagNames = getTagNamesByLanguage(production, preferredLanguage);
 
   const productionId = getProductionNumericIdFromUrl(production.id_url);
+  if (!productionId) return undefined;
 
   const handleToggleSelected = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation();
@@ -213,28 +214,11 @@ export function ProductionCard({
 
   const imageUrl = firstImageUrl ?? defaultCardValues.imageUrl;
 
-  const handleOpenDetails = () => {
-    if (!productionId) {
-      return;
-    }
-
-    navigate(lp(`/archive/productions/${productionId}`));
-  };
-
   return (
     <Card
-      onClick={handleOpenDetails}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          handleOpenDetails();
-        }
-      }}
-      role="button"
-      tabIndex={0}
-      aria-label={`Open details for ${title}`}
       className={className}
       sx={{
+        "position": "relative",
         "height": "100%",
         "display": "flex",
         "flexDirection": "column",
@@ -270,8 +254,12 @@ export function ProductionCard({
           color: "var(--color-archive-paper) !important",
         },
       }}
-      elevation={0}
     >
+      <Link
+        to={lp(`/archive/productions/${productionId}`)}
+        aria-label={`Open details for ${title}`}
+        style={{ position: "absolute", inset: 0, zIndex: 1 }}
+      />
       <Box sx={{ position: "relative", overflow: "hidden" }}>
         <CardMedia
           className="production-card-image"

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -254,6 +254,7 @@ export function ProductionCard({
           color: "var(--color-archive-paper) !important",
         },
       }}
+      elevation={0}
     >
       <Link
         to={lp(`/archive/productions/${productionId}`)}
@@ -521,14 +522,14 @@ export function ProductionCard({
           <div
             className="production-card-text"
             style={{
-              color: colorWithOpacity(CARD_COLORS.accent, 0.98),
-              fontWeight: "var(--weight-archive-bold)",
-              textTransform: "uppercase",
-              letterSpacing: "var(--tracking-archive-label)",
-              fontSize: "var(--text-archive-meta)",
-              display: "flex",
               alignItems: "center",
+              color: colorWithOpacity(CARD_COLORS.accent, 0.98),
+              display: "flex",
+              fontSize: "var(--text-archive-meta)",
+              fontWeight: "var(--weight-archive-bold)",
               gap: 0.5,
+              letterSpacing: "var(--tracking-archive-label)",
+              textTransform: "uppercase",
             }}
           >
             Details <ArrowRightAlt />

--- a/frontend/app/features/blogs/components/BlogCard.tsx
+++ b/frontend/app/features/blogs/components/BlogCard.tsx
@@ -205,6 +205,7 @@ export function BlogCard({
 
   return (
     <Card
+      id={`blog-card-${blogId}`}
       className={className}
       sx={{
         "position": "relative",

--- a/frontend/app/features/blogs/components/BlogCard.tsx
+++ b/frontend/app/features/blogs/components/BlogCard.tsx
@@ -1,4 +1,5 @@
 import ArrowRightAlt from "@mui/icons-material/ArrowRightAlt";
+import { Link } from "react-router";
 import {
   Box,
   Card,
@@ -6,12 +7,11 @@ import {
   CardMedia,
   Chip,
   Divider,
-  Link,
   Stack,
   Typography,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router";
+import { useParams } from "react-router";
 import { useLocalizedPath } from "~/shared/hooks/useLocalizedPath";
 import type { Blog, BlogContent } from "../types/blogTypes";
 import { getProductionByUrl } from "~/features/archive/services/productionService";
@@ -179,7 +179,6 @@ export function BlogCard({
   const [productionTitles, setProductionTitles] = useState<string[]>([]);
 
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const lp = useLocalizedPath();
 
   const { lang } = useParams();
@@ -202,23 +201,13 @@ export function BlogCard({
   }, [blog, language]);
 
   const blogId = getBlogNumericIdFromUrl(blog.id_url);
-
-  const handleOpenDetails = () => {
-    if (!blogId) {
-      return;
-    }
-
-    navigate(lp(`/blogs/${blogId}`));
-  };
+  if (!blogId) return null;
 
   return (
     <Card
-      onClick={handleOpenDetails}
-      role="button"
-      tabIndex={0}
-      aria-label={`Open details for ${title}`}
       className={className}
       sx={{
+        "position": "relative",
         "width": "100%",
         "height": compact
           ? { xs: "100px", sm: "110px", md: "120px" }
@@ -256,6 +245,11 @@ export function BlogCard({
       }}
       elevation={0}
     >
+      <Link
+        to={lp(`/blogs/${blogId}`)}
+        aria-label={`Open details for ${title}`}
+        style={{ position: "absolute", inset: 0, zIndex: 1 }}
+      />
       <Box
         sx={{
           position: "relative",
@@ -362,25 +356,22 @@ export function BlogCard({
             >
               <ProductionTitles productionTitles={productionTitles} />
 
-              <Link
+              <div
                 className="blog-card-text"
-                component="span"
-                underline="none"
-                sx={{
-                  display: "flex",
+                style={{
                   alignItems: "center",
-                  gap: 0.25,
                   color: colorWithOpacity(CARD_COLORS.accent, 0.98),
-                  fontWeight: "var(--weight-archive-bold)",
-                  textTransform: "uppercase",
-                  letterSpacing: "var(--tracking-archive-label)",
-                  fontSize: "var(--text-archive-meta)",
-                  cursor: "pointer",
+                  display: "flex",
                   flexShrink: 0,
+                  fontSize: "var(--text-archive-meta)",
+                  fontWeight: "var(--weight-archive-bold)",
+                  gap: 0.25,
+                  letterSpacing: "var(--tracking-archive-label)",
+                  textTransform: "uppercase",
                 }}
               >
                 {t("blogs.card.details")} <ArrowRightAlt sx={{ fontSize: "1.1em" }} />
-              </Link>
+              </div>
             </Stack>
           </>
         )}

--- a/frontend/app/features/blogs/pages/BlogContentPage.tsx
+++ b/frontend/app/features/blogs/pages/BlogContentPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import DOMPurify from "dompurify";
@@ -78,7 +78,6 @@ type ProductionLinkCardProps = {
 function ProductionLinkCard({ production }: ProductionLinkCardProps) {
   const { t } = useTranslation();
   const { lang } = useParams();
-  const navigate = useNavigate();
   const lp = useLocalizedPath();
 
   const primaryInfo = getProductionInfoByLanguage(
@@ -90,22 +89,18 @@ function ProductionLinkCard({ production }: ProductionLinkCardProps) {
   const artist = primaryInfo?.artist ?? "";
 
   const id = production.id_url.match(/\/productions\/(\d+)(?:[/?#]|$)/)?.[1];
-
-  const handleOpenDetails = () => {
-    if (!id) return;
-    navigate(lp(`/archive/productions/${id}`));
-  };
+  if (!id) return null;
 
   return (
-    <div
-      onClick={handleOpenDetails}
+    <Link
+      to={lp(`/archive/productions/${id}`)}
       className="p3 bg-archive-ink/5 bg-archive-ink-dark/5 border-archive-ink/5 border-archive-ink-dark/5 h-[60px] cursor-pointer rounded-lg border shadow-sm"
     >
       <div className="h-full rounded-lg p-3 transition">
         <h3 className="truncate text-sm font-semibold">{title}</h3>
         <p className="truncate text-xs">{artist}</p>
       </div>
-    </div>
+    </Link>
   );
 }
 


### PR DESCRIPTION
### Beschrijving
Deze PR zorgt dat je kan control-klikken op een ProductionCard door deze een `Link` te geven ipv via `onClick` te werken. Hierdoor gedraagt deze zich als een normale link met all browser shortcuts die automatisch werken.

### Aangepaste delen
`ProductionCard`


Closes #410 

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
