### PR TITLE
[FIX] Scraper faalt niet meer na 1e keer

### DIFF
--- a/backend/src/worker/converters/genres.py
+++ b/backend/src/worker/converters/genres.py
@@ -12,7 +12,6 @@ def api_genre_to_model_tag(json_genre: dict) -> tuple[Tag, list[TagName]]:
     genre = Tag(viernulvier_id=genre_id)
 
     names = json_genre.get("name")
-    genre_names = []
     if names:
         for lang_code in names.keys():
             lang = get_accepted_language(lang_code)
@@ -21,13 +20,10 @@ def api_genre_to_model_tag(json_genre: dict) -> tuple[Tag, list[TagName]]:
                 continue
 
             genre_name = names[lang_code]
-            genre_name_object = TagName(language=lang, name=genre_name)
-
-            genre_names.append(genre_name_object)
+            genre.names.append(TagName(language=lang, name=genre_name))
     else:
         name = json_genre.get("vendor_id")
         if name:
-            genre_name_object = TagName(language=Languages.DUTCH, name=name)
-            genre_names.append(genre_name_object)
+            genre.names.append(TagName(language=Languages.DUTCH, name=name))
 
-    return genre, genre_names
+    return genre

--- a/backend/src/worker/sync/store/event.py
+++ b/backend/src/worker/sync/store/event.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select
+from src.models.event import Event
 from src.models.hall import Hall
 from src.models.production import Production
 from src.worker.converters.event import api_event_to_model_event
@@ -27,6 +28,8 @@ def store_new_events(db_session: Session, events: list[dict]):
         for (hall_id, hall_viernulvier_id) in existing_halls
     }
 
+    existing_vnv_ids = set(db_session.execute(select(Event.viernulvier_id)))
+
     orphans = 0
 
     for json_event in events:
@@ -34,6 +37,11 @@ def store_new_events(db_session: Session, events: list[dict]):
             event, viernulvier_prod_id, viernulvier_hall_id = api_event_to_model_event(
                 json_event
             )
+
+            if event.viernulvier_id in existing_vnv_ids:
+                continue
+            else:
+                existing_vnv_ids.add(event.viernulvier_id)
 
             # Check if the event is tied to a valid production, else we would get a
             # ForeignKey violation

--- a/backend/src/worker/sync/store/event.py
+++ b/backend/src/worker/sync/store/event.py
@@ -28,7 +28,7 @@ def store_new_events(db_session: Session, events: list[dict]):
         for (hall_id, hall_viernulvier_id) in existing_halls
     }
 
-    existing_vnv_ids = set(db_session.execute(select(Event.viernulvier_id)))
+    existing_vnv_ids = set(db_session.scalars(select(Event.viernulvier_id)))
 
     orphans = 0
 
@@ -40,8 +40,7 @@ def store_new_events(db_session: Session, events: list[dict]):
 
             if event.viernulvier_id in existing_vnv_ids:
                 continue
-            else:
-                existing_vnv_ids.add(event.viernulvier_id)
+            existing_vnv_ids.add(event.viernulvier_id)
 
             # Check if the event is tied to a valid production, else we would get a
             # ForeignKey violation

--- a/backend/src/worker/sync/store/eventprice.py
+++ b/backend/src/worker/sync/store/eventprice.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def store_new_eventprices(db_session: Session, eventprices: list[dict]):
     newest_timestamp = None
 
-    existing_vnv_ids = set(db_session.execute(select(EventPrice.viernulvier_id)))
+    existing_vnv_ids = set(db_session.scalars(select(EventPrice.viernulvier_id)))
 
     existing_events = db_session.execute(select(Event.id, Event.viernulvier_id))
     event_map: dict[int, int] = {
@@ -30,8 +30,7 @@ def store_new_eventprices(db_session: Session, eventprices: list[dict]):
 
             if eventprice.viernulvier_id in existing_vnv_ids:
                 continue
-            else:
-                existing_vnv_ids.add(eventprice.viernulvier_id)
+            existing_vnv_ids.add(eventprice.viernulvier_id)
 
             # Check if the eventprice is tied to a valid event, else we would get a
             # ForeignKey violation

--- a/backend/src/worker/sync/store/eventprice.py
+++ b/backend/src/worker/sync/store/eventprice.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select
-from src.models.event import Event
+from src.models.event import Event, EventPrice
 from src.worker.converters.eventprice import api_eventprice_to_model_eventprice
 
 logger = logging.getLogger(__name__)
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 def store_new_eventprices(db_session: Session, eventprices: list[dict]):
     newest_timestamp = None
+
+    existing_vnv_ids = set(db_session.execute(select(EventPrice.viernulvier_id)))
 
     existing_events = db_session.execute(select(Event.id, Event.viernulvier_id))
     event_map: dict[int, int] = {
@@ -25,6 +27,11 @@ def store_new_eventprices(db_session: Session, eventprices: list[dict]):
             eventprice, viernulvier_event_id = api_eventprice_to_model_eventprice(
                 json_price
             )
+
+            if eventprice.viernulvier_id in existing_vnv_ids:
+                continue
+            else:
+                existing_vnv_ids.add(eventprice.viernulvier_id)
 
             # Check if the eventprice is tied to a valid event, else we would get a
             # ForeignKey violation

--- a/backend/src/worker/sync/store/genre.py
+++ b/backend/src/worker/sync/store/genre.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def store_new_genres(db_session: Session, genres: list[dict]):
     newest_timestamp = None
 
-    existing_vnv_ids = set(db_session.execute(select(Tag.viernulvier_id)))
+    existing_vnv_ids = set(db_session.scalars(select(Tag.viernulvier_id)))
 
     for json_genre in genres:
         try:
@@ -20,8 +20,7 @@ def store_new_genres(db_session: Session, genres: list[dict]):
 
             if tag.viernulvier_id in existing_vnv_ids:
                 continue
-            else:
-                existing_vnv_ids.add(tag.viernulvier_id)
+            existing_vnv_ids.add(tag.viernulvier_id)
 
             db_session.add(tag)
 

--- a/backend/src/worker/sync/store/genre.py
+++ b/backend/src/worker/sync/store/genre.py
@@ -12,15 +12,9 @@ def store_new_genres(db_session: Session, genres: list[dict]):
 
     for json_genre in genres:
         try:
-            tag, tag_names = api_genre_to_model_tag(json_genre)
+            tag = api_genre_to_model_tag(json_genre)
+
             db_session.add(tag)
-            db_session.flush()
-
-            for tag_name in tag_names:
-                tag_name.tag_id = tag.id
-                db_session.add(tag_name)
-
-            db_session.flush()
 
             created_at = datetime.fromisoformat(json_genre["created_at"])
             if newest_timestamp is None or created_at > newest_timestamp:

--- a/backend/src/worker/sync/store/genre.py
+++ b/backend/src/worker/sync/store/genre.py
@@ -2,6 +2,8 @@ import logging
 
 from datetime import datetime
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import select
+from src.models.tag import Tag
 from src.worker.converters.genres import api_genre_to_model_tag
 
 logger = logging.getLogger(__name__)
@@ -10,9 +12,16 @@ logger = logging.getLogger(__name__)
 def store_new_genres(db_session: Session, genres: list[dict]):
     newest_timestamp = None
 
+    existing_vnv_ids = set(db_session.execute(select(Tag.viernulvier_id)))
+
     for json_genre in genres:
         try:
             tag = api_genre_to_model_tag(json_genre)
+
+            if tag.viernulvier_id in existing_vnv_ids:
+                continue
+            else:
+                existing_vnv_ids.add(tag.viernulvier_id)
 
             db_session.add(tag)
 

--- a/backend/src/worker/sync/store/hall.py
+++ b/backend/src/worker/sync/store/hall.py
@@ -21,7 +21,7 @@ def store_new_halls(db_session: Session, json_locations: list[dict]):
             # Valid production id, so store this event
             for hall in halls:
                 if hall.viernulvier_id not in existing_vnv_ids:
-                    db_session.add(halls)
+                    db_session.add(hall)
                     existing_vnv_ids.add(hall.viernulvier_id)
 
             created_at_str = json_location.get("created_at")

--- a/backend/src/worker/sync/store/hall.py
+++ b/backend/src/worker/sync/store/hall.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def store_new_halls(db_session: Session, json_locations: list[dict]):
     newest_timestamp = None
 
-    existing_vnv_ids = set(db_session.execute(select(Hall.viernulvier_id)))
+    existing_vnv_ids = set(db_session.scalars(select(Hall.viernulvier_id)))
 
     for json_location in json_locations:
         try:

--- a/backend/src/worker/sync/store/hall.py
+++ b/backend/src/worker/sync/store/hall.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime
 
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import select
+from src.models.hall import Hall
 from src.worker.converters.hall import api_location_to_model_halls
 
 logger = logging.getLogger(__name__)
@@ -10,12 +12,17 @@ logger = logging.getLogger(__name__)
 def store_new_halls(db_session: Session, json_locations: list[dict]):
     newest_timestamp = None
 
+    existing_vnv_ids = set(db_session.execute(select(Hall.viernulvier_id)))
+
     for json_location in json_locations:
         try:
             halls = api_location_to_model_halls(json_location)
 
             # Valid production id, so store this event
-            db_session.add_all(halls)
+            for hall in halls:
+                if hall.viernulvier_id not in existing_vnv_ids:
+                    db_session.add(halls)
+                    existing_vnv_ids.add(hall.viernulvier_id)
 
             created_at_str = json_location.get("created_at")
             if created_at_str:

--- a/backend/src/worker/sync/store/production.py
+++ b/backend/src/worker/sync/store/production.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select
 from src.models.tag import Tag
+from src.models.production import Production
 from src.worker.converters.production import api_prod_to_model_prod
 
 logger = logging.getLogger(__name__)
@@ -11,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 def store_new_productions(db_session: Session, productions: list[dict]):
     newest_timestamp = None
+
+    existing_vnv_ids = set(db_session.execute(select(Production.viernulvier_id)))
 
     existing_tags = db_session.execute(select(Tag))
     tag_map: dict[int, Tag] = {tag.viernulvier_id: tag for (tag,) in existing_tags}
@@ -21,8 +24,10 @@ def store_new_productions(db_session: Session, productions: list[dict]):
             # sqlalchemy should automatically create all the required objects.
             prod, vnv_tag_ids = api_prod_to_model_prod(json_prod)
 
-            # Attach 'prod' to sql-alchemy session
-            prod = db_session.merge(prod)
+            if prod.viernulvier_id in existing_vnv_ids:
+                continue
+            else:
+                existing_vnv_ids.add(prod.viernulvier_id)
 
             tags = []
             for tag in vnv_tag_ids:
@@ -36,6 +41,8 @@ def store_new_productions(db_session: Session, productions: list[dict]):
                     tags.append(internal_tag_id)
 
             prod.tags.extend(tags)
+
+            db_session.add(prod)
 
             created_at = datetime.fromisoformat(json_prod["created_at"])
             if newest_timestamp is None or created_at > newest_timestamp:

--- a/backend/src/worker/sync/store/production.py
+++ b/backend/src/worker/sync/store/production.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def store_new_productions(db_session: Session, productions: list[dict]):
     newest_timestamp = None
 
-    existing_vnv_ids = set(db_session.execute(select(Production.viernulvier_id)))
+    existing_vnv_ids = set(db_session.scalars(select(Production.viernulvier_id)))
 
     existing_tags = db_session.execute(select(Tag))
     tag_map: dict[int, Tag] = {tag.viernulvier_id: tag for (tag,) in existing_tags}
@@ -26,8 +26,7 @@ def store_new_productions(db_session: Session, productions: list[dict]):
 
             if prod.viernulvier_id in existing_vnv_ids:
                 continue
-            else:
-                existing_vnv_ids.add(prod.viernulvier_id)
+            existing_vnv_ids.add(prod.viernulvier_id)
 
             tags = []
             for tag in vnv_tag_ids:

--- a/backend/tests/unit/worker/test_api_converters.py
+++ b/backend/tests/unit/worker/test_api_converters.py
@@ -237,13 +237,13 @@ def test_api_genre_to_model_tag():
         "slug": {"nl": "Met voeltoer"},
     }
 
-    tag, tag_names = api_genre_to_model_tag(test_input)
+    tag = api_genre_to_model_tag(test_input)
 
     assert tag.viernulvier_id == 100
-    assert len(tag_names) == 2
+    assert len(tag.names) == 2
 
-    tagname_nl = [tn for tn in tag_names if tn.language == Languages.DUTCH][0]
-    tagname_en = [tn for tn in tag_names if tn.language == Languages.ENGLISH][0]
+    tagname_nl = [tn for tn in tag.names if tn.language == Languages.DUTCH][0]
+    tagname_en = [tn for tn in tag.names if tn.language == Languages.ENGLISH][0]
 
     assert tagname_nl.name == "Met voeltoer"
     assert tagname_en.name == "With feeling tour"
@@ -263,12 +263,12 @@ def test_api_genre_to_model_tag_fallback():
         "vendor_id": "cabaret",
     }
 
-    tag, tag_names = api_genre_to_model_tag(test_input)
+    tag = api_genre_to_model_tag(test_input)
 
     assert tag.viernulvier_id == 1
-    assert len(tag_names) == 1
+    assert len(tag.names) == 1
 
-    tagname_nl = [tn for tn in tag_names if tn.language == Languages.DUTCH][0]
+    tagname_nl = [tn for tn in tag.names if tn.language == Languages.DUTCH][0]
 
     assert tagname_nl.name == "cabaret"
 
@@ -279,11 +279,11 @@ def test_api_genre_to_model_tag_fallback():
 def test_api_genre_to_none():
     test_input = {"@id": "/api/v1/genres/7"}
 
-    tag, tag_names = api_genre_to_model_tag(test_input)
+    tag = api_genre_to_model_tag(test_input)
 
     assert tag is not None
     assert tag.viernulvier_id == 7
-    assert len(tag_names) == 0
+    assert len(tag.names) == 0
 
 
 def test_get_address_from_location():

--- a/backend/tests/unit/worker/test_stores.py
+++ b/backend/tests/unit/worker/test_stores.py
@@ -351,7 +351,9 @@ def test_store_new_eventprices_with_orphans(db_session, caplog):
     # Test that duplicates won't be stored
     newest = store_new_eventprices(db_session, [eventprices[0]])
     assert newest is None
-    assert len(stored_eventprices) == len(db_session.scalars(select(EventPrice.id)).all())
+    assert len(stored_eventprices) == len(
+        db_session.scalars(select(EventPrice.id)).all()
+    )
 
 
 def test_store_new_genres_as_tags(db_session):

--- a/backend/tests/unit/worker/test_stores.py
+++ b/backend/tests/unit/worker/test_stores.py
@@ -81,6 +81,11 @@ def test_store_new_productions(db_session):
     # Assert newest timestamp returned
     assert newest == datetime.fromisoformat("2022-11-22T13:45:59+00:00")
 
+    # Test that duplicates won't be stored
+    newest = store_new_productions(db_session, [productions[0]])
+    assert newest is None
+    assert len(stored_prods) == len(db_session.scalars(select(Production.id)).all())
+
 
 # Quick sanity check that we get None when no production was received
 def test_store_new_productions_empty_list(db_session):
@@ -181,6 +186,11 @@ def test_store_new_events_with_orphans(db_session, caplog):
     assert "does not exist" in orphaned_warning_2
 
     assert "Skipped 3 events" in total_orphans_warning
+
+    # Test that duplicates won't be stored
+    newest = store_new_events(db_session, [events[0]])
+    assert newest is None
+    assert len(stored_events) == len(db_session.scalars(select(Event.id)).all())
 
 
 def test_store_new_events_hall(db_session, caplog):
@@ -310,9 +320,9 @@ def test_store_new_eventprices_with_orphans(db_session, caplog):
     db_session.commit()
 
     # Assert that only one eventprice was stored
-    stored_events = db_session.execute(select(EventPrice)).scalars().all()
-    assert len(stored_events) == 1
-    assert stored_events[0].viernulvier_id == 14085
+    stored_eventprices = db_session.execute(select(EventPrice)).scalars().all()
+    assert len(stored_eventprices) == 1
+    assert stored_eventprices[0].viernulvier_id == 14085
 
     # newest timestamp should be from the last created valid eventprice
     assert newest == datetime.fromisoformat("2023-01-20T10:26:50+00:00")
@@ -337,6 +347,11 @@ def test_store_new_eventprices_with_orphans(db_session, caplog):
     assert "does not exist" in orphaned_warning_2
 
     assert "Skipped 3 eventprices" in total_orphans_warning
+
+    # Test that duplicates won't be stored
+    newest = store_new_eventprices(db_session, [eventprices[0]])
+    assert newest is None
+    assert len(stored_eventprices) == len(db_session.scalars(select(EventPrice.id)).all())
 
 
 def test_store_new_genres_as_tags(db_session):
@@ -377,6 +392,11 @@ def test_store_new_genres_as_tags(db_session):
     assert len(stored_names) == 4
 
     assert newest == datetime.fromisoformat("2023-03-31T08:44:07+00:00")
+
+    # Test that duplicates won't be stored
+    newest = store_new_genres(db_session, [genres[0]])
+    assert newest is None
+    assert len(stored_tags) == len(db_session.scalars(select(Tag.id)).all())
 
 
 def test_store_production_with_tags(db_session):


### PR DESCRIPTION
### Beschrijving
Deze PR zorgt er voor dat de scraper niet meer zal falen met de error message dat er duplicate ID's gevonden waren. 

Ook paste ik kort nog een stukje logica aan van het opslaan van genres/tags, dat kon nog properder met de nieuwe syntax die ik later geleerd heb.


### Aangepaste delen
Sync-worker: sync/store/ directory


### Testen
Klein stukje testen toegevoegd die deze nieuwe functionaliteit coveren.

Ik zag in de coverage dat er een paar logger warnings nog niet gecovered werden, dit doe ik nog in een andere PR want die staan los van de inhoud van deze.


Closes #314 

- [X] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
