### PR TITLE
[BUGFIX] remove trailing slashes

### DIFF
--- a/backend/src/api/v1/archive/artists.py
+++ b/backend/src/api/v1/archive/artists.py
@@ -8,7 +8,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=ArtistsResponse,
     summary="Get all artists",
     description="Returns lists of the artists, filtered by language",

--- a/backend/src/api/v1/archive/blog_media.py
+++ b/backend/src/api/v1/archive/blog_media.py
@@ -33,7 +33,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/{blog_id}/media/",
+    "/{blog_id}/media",
     response_model=MediaListResponse,
     summary="Get media for blog",
     description="Returns paginated media linked to a blog.",
@@ -50,7 +50,7 @@ async def get_media_for_blog(
 
 
 @router.post(
-    "/{blog_id}/media/",
+    "/{blog_id}/media",
     response_model=MediaResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Upload media for blog",

--- a/backend/src/api/v1/archive/blogs.py
+++ b/backend/src/api/v1/archive/blogs.py
@@ -24,7 +24,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=BlogListResponse,
     summary="Get Blogs",
     description="Get all blogs of the database, using pagination",
@@ -57,7 +57,7 @@ async def get_blog(
 
 
 @router.post(
-    "/",
+    "",
     response_model=BlogResponse,
     status_code=201,
     summary="Create blog",

--- a/backend/src/api/v1/archive/events.py
+++ b/backend/src/api/v1/archive/events.py
@@ -35,7 +35,7 @@ def delete_event(
     delete_event_by_id(db, event_id)
 
 
-@router.post("/", response_model=EventResponse, status_code=201)
+@router.post("", response_model=EventResponse, status_code=201)
 def post_event(
     event_in: EventCreate,
     request: Request,

--- a/backend/src/api/v1/archive/halls.py
+++ b/backend/src/api/v1/archive/halls.py
@@ -19,7 +19,7 @@ from src.services.hall_service import (
 router = APIRouter()
 
 
-@router.get("/", response_model=List[HallResponse])
+@router.get("", response_model=List[HallResponse])
 def get_halls(request: Request, db: Session = Depends(get_db)):
     base_url = get_base_url(str(request.url))
     return get_all_halls(db, base_url)
@@ -31,7 +31,7 @@ def get_hall(hall_id: int, request: Request, db: Session = Depends(get_db)):
     return get_hall_by_id(db, hall_id, base_url)
 
 
-@router.post("/", response_model=HallCreate, status_code=201)
+@router.post("", response_model=HallCreate, status_code=201)
 def post_hall(
     hall_in: HallCreate,
     request: Request,

--- a/backend/src/api/v1/archive/history.py
+++ b/backend/src/api/v1/archive/history.py
@@ -22,7 +22,7 @@ from src.services.history import (
 router = APIRouter()
 
 
-@router.get("/", response_model=List[HistoryResponse])
+@router.get("", response_model=List[HistoryResponse])
 def get_history(
     request: Request,
     db: Session = Depends(get_db),
@@ -47,7 +47,7 @@ def get_history_entry(
     return get_history_entry_by_key(db, year, language, base_url)
 
 
-@router.post("/", response_model=HistoryResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=HistoryResponse, status_code=status.HTTP_201_CREATED)
 def post_history(
     history_in: HistoryCreate,
     request: Request,

--- a/backend/src/api/v1/archive/prod_media.py
+++ b/backend/src/api/v1/archive/prod_media.py
@@ -33,7 +33,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/{production_id}/media/",
+    "/{production_id}/media",
     response_model=MediaListResponse,
     summary="Get media for production",
     description="Returns paginated media linked to a production.",
@@ -50,7 +50,7 @@ async def get_media_for_production(
 
 
 @router.post(
-    "/{production_id}/media/",
+    "/{production_id}/media",
     response_model=MediaResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Upload media for production",

--- a/backend/src/api/v1/archive/production_groups.py
+++ b/backend/src/api/v1/archive/production_groups.py
@@ -25,7 +25,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=List[ProductionGroupResponse],
     summary="Get production groups",
     description="Returns production groups, optionally including hidden groups.",
@@ -54,7 +54,7 @@ async def get_production_group(
 
 
 @router.post(
-    "/",
+    "",
     response_model=ProductionGroupResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a production group",

--- a/backend/src/api/v1/archive/productions.py
+++ b/backend/src/api/v1/archive/productions.py
@@ -29,7 +29,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=ProductionListResponse,
     summary="Get productions",
     description="Gets all productions of the database, using pagination.",
@@ -84,7 +84,7 @@ async def get_productions(
 
 
 @router.post(
-    "/",
+    "",
     response_model=ProductionResponse,
     status_code=201,
     summary="Create production",
@@ -158,7 +158,7 @@ async def delete_production(
 
 
 @router.get(
-    "/{production_id}/blogs/",
+    "/{production_id}/blogs",
     response_model=BlogListResponse,
     summary="Get blogs by production id",
     description="Get all blogs linked to a specific production",

--- a/backend/src/api/v1/archive/statistics.py
+++ b/backend/src/api/v1/archive/statistics.py
@@ -10,7 +10,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=StatisticsResponse,
     summary="Get archive statistics",
     description="Returns archive counts and all unique tags.",

--- a/backend/src/api/v1/archive/tags.py
+++ b/backend/src/api/v1/archive/tags.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=List[TagResponse],
     summary="Get all tags",
     description="Returns a list of tags.",
@@ -53,7 +53,7 @@ def get_tag(
 
 
 @router.post(
-    "/",
+    "",
     response_model=TagResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a new tag",

--- a/backend/src/api/v1/auth/permissions.py
+++ b/backend/src/api/v1/auth/permissions.py
@@ -9,7 +9,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=List[PermissionResponse],
     summary="List all possible permissions",
     description="Returns all permissions defined in the application. Requires users:read permission.",

--- a/backend/src/api/v1/auth/roles.py
+++ b/backend/src/api/v1/auth/roles.py
@@ -14,7 +14,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/",
+    "",
     response_model=List[RoleResponse],
     summary="List all roles",
     description="Returns all roles with their permissions.",
@@ -29,7 +29,7 @@ def list_roles(
 
 
 @router.post(
-    "/",
+    "",
     response_model=RoleResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a role",

--- a/backend/src/api/v1/auth/users.py
+++ b/backend/src/api/v1/auth/users.py
@@ -29,7 +29,7 @@ def get_current_user_profile(
 
 
 @router.get(
-    "/",
+    "",
     response_model=List[UserResponse],
     summary="List all users",
     description="Returns all users with their roles and permissions.",
@@ -44,7 +44,7 @@ def list_users(
 
 
 @router.post(
-    "/",
+    "",
     response_model=UserResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create a user",

--- a/backend/src/services/archive.py
+++ b/backend/src/services/archive.py
@@ -6,9 +6,9 @@ def get_base_url(url: str, remove_last_segments: int = 1) -> str:
     Returns the base URL by removing a specified number of path segments from the end.
 
     Examples:
-        >>> get_base_url("https://example.com/api/v1/users/", 1)
+        >>> get_base_url("https://example.com/api/v1/users", 1)
         'https://example.com/api/v1'
-        >>> get_base_url("https://example.com/api/v1/users/", 2)
+        >>> get_base_url("https://example.com/api/v1/users", 2)
         'https://example.com/api'
         >>> get_base_url("https://example.com/api/v1/archive/productions/?cursor=1&limit=20", 1)
         'https://example.com/api/v1/archive'

--- a/backend/tests/integration/test_artists_endpoints.py
+++ b/backend/tests/integration/test_artists_endpoints.py
@@ -11,7 +11,7 @@ MOCK_ROWS = [
     (3, "nl", "Artiest C"),
 ]
 
-BASE_URL = "/api/v1/archive/artists/"
+BASE_URL = "/api/v1/archive/artists"
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_auth_endpoints.py
+++ b/backend/tests/integration/test_auth_endpoints.py
@@ -15,7 +15,7 @@ def test_login_integration(client: TestClient, db_session: Session):
     db_session.commit()
 
     response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "login_int_user", "password": password},
     )
     assert response.status_code == 200
@@ -29,7 +29,7 @@ def test_login_integration(client: TestClient, db_session: Session):
 
 def test_login_integration_fail(client: TestClient):
     response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "non_existent", "password": "password"},
     )
     assert response.status_code == 401
@@ -43,7 +43,7 @@ def test_get_me_integration(client: TestClient, db_session: Session):
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "me_int_user", "password": password},
     )
     token = login_response.json()["access_token"]
@@ -65,7 +65,7 @@ def test_refresh_token_integration(client: TestClient, db_session: Session):
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "refresh_int_user", "password": password},
     )
     refresh_token = login_response.json()["refresh_token"]
@@ -90,7 +90,7 @@ def test_tokens_invalidated_after_password_change_integration(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "invalidate_int_user", "password": password},
     )
     access_token = login_response.json()["access_token"]
@@ -121,7 +121,7 @@ def test_refresh_token_rejected_as_access_token_integration(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "exploit_int_user", "password": password},
     )
     refresh_token = login_response.json()["refresh_token"]

--- a/backend/tests/integration/test_blog_endpoint.py
+++ b/backend/tests/integration/test_blog_endpoint.py
@@ -40,7 +40,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]
@@ -282,7 +282,7 @@ def test_delete_blog_failure(client: TestClient, db_session: Session, blogs_limi
 def test_get_blogs_by_production_success(
     client: TestClient, db_session: Session, blogs_limited
 ):
-    response = client.get(f"{BASE_PROD_URL}/1/blogs/")
+    response = client.get(f"{BASE_PROD_URL}/1/blogs")
     assert response.status_code == 200
 
     data = response.json()
@@ -297,7 +297,7 @@ def test_get_blogs_by_production_with_language(
     client: TestClient, db_session: Session, blogs_limited
 ):
     response = client.get(
-        f"{BASE_PROD_URL}/1/blogs/",
+        f"{BASE_PROD_URL}/1/blogs",
         headers={"Accept-Language": Languages.ENGLISH},
     )
     assert response.status_code == 200
@@ -313,7 +313,7 @@ def test_get_blogs_by_production_with_language(
 def test_get_blogs_by_production_empty(
     client: TestClient, db_session: Session, blogs_limited
 ):
-    response = client.get(f"{BASE_PROD_URL}/999/blogs/")
+    response = client.get(f"{BASE_PROD_URL}/999/blogs")
     assert response.status_code == 200
 
     data = response.json()

--- a/backend/tests/integration/test_blog_media_endpoint.py
+++ b/backend/tests/integration/test_blog_media_endpoint.py
@@ -38,7 +38,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
     token = login_response.json()["access_token"]
     if language is not None:
@@ -60,7 +60,7 @@ def test_upload_media_success(
     test_file = ("test.jpg", io.BytesIO(b"fake image data"), content_type)
 
     response = client.post(
-        f"{BASE_URL}/{blog_with_no_media.id}/media/",
+        f"{BASE_URL}/{blog_with_no_media.id}/media",
         files={"file": test_file},
         headers=headers,
     )
@@ -76,7 +76,7 @@ def test_upload_media_success(
 
     # Verify blog relationship
     assert f"blogs/{blog_with_no_media.id}" in data["blog_id_url"]
-    assert f"blogs/{blog_with_no_media.id}/media/" in data["id_url"]
+    assert f"blogs/{blog_with_no_media.id}/media" in data["id_url"]
 
 
 def test_upload_media_unsupported_type(
@@ -89,7 +89,7 @@ def test_upload_media_unsupported_type(
     test_file = ("test.pdf", io.BytesIO(b"fake pdf"), "application/pdf")
 
     response = client.post(
-        f"{BASE_URL}/{blog_with_no_media.id}/media/",
+        f"{BASE_URL}/{blog_with_no_media.id}/media",
         files={"file": test_file},
         headers=headers,
     )
@@ -105,7 +105,7 @@ def test_upload_media_no_permission(
     test_file = ("test.jpg", io.BytesIO(b"fake"), "image/jpeg")
 
     response = client.post(
-        f"{BASE_URL}/{blog_with_no_media.id}/media/",
+        f"{BASE_URL}/{blog_with_no_media.id}/media",
         files={"file": test_file},
         headers=headers,
     )
@@ -114,7 +114,7 @@ def test_upload_media_no_permission(
 
 def test_list_media(client: TestClient, media_items_for_blog):
     blog_id = media_items_for_blog[0].blog_id
-    response = client.get(f"{BASE_URL}/{blog_id}/media/")
+    response = client.get(f"{BASE_URL}/{blog_id}/media")
     assert response.status_code == 200
     data = response.json()
 

--- a/backend/tests/integration/test_events_endpoint.py
+++ b/backend/tests/integration/test_events_endpoint.py
@@ -37,7 +37,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]

--- a/backend/tests/integration/test_halls_endpoint.py
+++ b/backend/tests/integration/test_halls_endpoint.py
@@ -39,7 +39,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]

--- a/backend/tests/integration/test_history_endpoint.py
+++ b/backend/tests/integration/test_history_endpoint.py
@@ -37,7 +37,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]

--- a/backend/tests/integration/test_prod_media_endpoint.py
+++ b/backend/tests/integration/test_prod_media_endpoint.py
@@ -38,7 +38,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
     token = login_response.json()["access_token"]
     if language is not None:
@@ -60,7 +60,7 @@ def test_upload_media_success(
     test_file = ("test.jpg", io.BytesIO(b"fake image data"), content_type)
 
     response = client.post(
-        f"{BASE_URL}/{production_with_no_media.id}/media/",
+        f"{BASE_URL}/{production_with_no_media.id}/media",
         files={"file": test_file},
         headers=headers,
     )
@@ -76,7 +76,7 @@ def test_upload_media_success(
 
     # Verify production relationship
     assert f"productions/{production_with_no_media.id}" in data["production_id_url"]
-    assert f"productions/{production_with_no_media.id}/media/" in data["id_url"]
+    assert f"productions/{production_with_no_media.id}/media" in data["id_url"]
 
 
 def test_upload_media_unsupported_type(
@@ -89,7 +89,7 @@ def test_upload_media_unsupported_type(
     test_file = ("test.pdf", io.BytesIO(b"fake pdf"), "application/pdf")
 
     response = client.post(
-        f"{BASE_URL}/{production_with_no_media.id}/media/",
+        f"{BASE_URL}/{production_with_no_media.id}/media",
         files={"file": test_file},
         headers=headers,
     )
@@ -105,7 +105,7 @@ def test_upload_media_no_permission(
     test_file = ("test.jpg", io.BytesIO(b"fake"), "image/jpeg")
 
     response = client.post(
-        f"{BASE_URL}/{production_with_no_media.id}/media/",
+        f"{BASE_URL}/{production_with_no_media.id}/media",
         files={"file": test_file},
         headers=headers,
     )
@@ -114,7 +114,7 @@ def test_upload_media_no_permission(
 
 def test_list_media(client: TestClient, media_items_for_production):
     prod_id = media_items_for_production[0].production_id
-    response = client.get(f"{BASE_URL}/{prod_id}/media/")
+    response = client.get(f"{BASE_URL}/{prod_id}/media")
     assert response.status_code == 200
     data = response.json()
 

--- a/backend/tests/integration/test_production_endpoint.py
+++ b/backend/tests/integration/test_production_endpoint.py
@@ -39,7 +39,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]

--- a/backend/tests/integration/test_production_groups_endpoints.py
+++ b/backend/tests/integration/test_production_groups_endpoints.py
@@ -38,7 +38,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
     token = login_response.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}

--- a/backend/tests/integration/test_roles_permissions_endpoints.py
+++ b/backend/tests/integration/test_roles_permissions_endpoints.py
@@ -31,7 +31,7 @@ def create_user_with_permissions(
 
 def get_token(client: TestClient, username: str) -> str:
     response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": "pw"}
+        "/api/v1/auth/login", json={"username": username, "password": "pw"}
     )
     return response.json()["access_token"]
 
@@ -42,7 +42,7 @@ def test_permissions_endpoint_requires_users_read(
     create_user_with_permissions(db_session, "perm_user", [Permissions.USERS_READ])
     token = get_token(client, "perm_user")
     response = client.get(
-        "/api/v1/auth/permissions/", headers={"Authorization": f"Bearer {token}"}
+        "/api/v1/auth/permissions", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 200
     perms = response.json()
@@ -53,7 +53,7 @@ def test_permissions_endpoint_forbidden(client: TestClient, db_session: Session)
     create_user_with_permissions(db_session, "noperm_user", [])
     token = get_token(client, "noperm_user")
     response = client.get(
-        "/api/v1/auth/permissions/", headers={"Authorization": f"Bearer {token}"}
+        "/api/v1/auth/permissions", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 403
 
@@ -64,7 +64,7 @@ def test_permissions_endpoint_lists_all_defined_permissions(
     create_user_with_permissions(db_session, "perm_user_all", [Permissions.USERS_READ])
     token = get_token(client, "perm_user_all")
     response = client.get(
-        "/api/v1/auth/permissions/", headers={"Authorization": f"Bearer {token}"}
+        "/api/v1/auth/permissions", headers={"Authorization": f"Bearer {token}"}
     )
     assert response.status_code == 200
     perms = {p["name"] for p in response.json()}
@@ -87,7 +87,7 @@ def test_roles_crud(client: TestClient, db_session: Session):
     headers = {"Authorization": f"Bearer {token}"}
 
     response = client.post(
-        "/api/v1/auth/roles/",
+        "/api/v1/auth/roles",
         json={"name": "testrole", "permissions": [Permissions.USERS_READ]},
         headers=headers,
     )
@@ -107,7 +107,7 @@ def test_roles_crud(client: TestClient, db_session: Session):
     assert response.status_code == 200
     assert response.json()["name"] == "updatedrole"
 
-    response = client.get("/api/v1/auth/roles/", headers=headers)
+    response = client.get("/api/v1/auth/roles", headers=headers)
     assert response.status_code == 200
     assert any(r["name"] == "updatedrole" for r in response.json())
 
@@ -121,7 +121,7 @@ def test_roles_permission_enforcement(client: TestClient, db_session: Session):
     headers = {"Authorization": f"Bearer {token}"}
 
     response = client.post(
-        "/api/v1/auth/roles/",
+        "/api/v1/auth/roles",
         json={"name": "failrole", "permissions": []},
         headers=headers,
     )

--- a/backend/tests/integration/test_statistics_endpoint.py
+++ b/backend/tests/integration/test_statistics_endpoint.py
@@ -3,7 +3,7 @@ import pytest
 from src.models import Event, ProdInfo, Production, Tag, TagName
 from src.services.language import Languages
 
-STATISTICS_URL = "/api/v1/archive/statistics/"
+STATISTICS_URL = "/api/v1/archive/statistics"
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_tags_endpoints.py
+++ b/backend/tests/integration/test_tags_endpoints.py
@@ -47,7 +47,7 @@ def create_user_and_login(
     db_session.commit()
 
     login_response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": password}
+        "/api/v1/auth/login", json={"username": username, "password": password}
     )
 
     token = login_response.json()["access_token"]

--- a/backend/tests/integration/test_users_endpoints.py
+++ b/backend/tests/integration/test_users_endpoints.py
@@ -47,7 +47,7 @@ def create_user_with_permissions(
 
 def get_token(client: TestClient, username: str) -> str:
     response = client.post(
-        "/api/v1/auth/login/", json={"username": username, "password": "pw"}
+        "/api/v1/auth/login", json={"username": username, "password": "pw"}
     )
     return response.json()["access_token"]
 
@@ -67,7 +67,7 @@ def test_users_crud_endpoints(client: TestClient, db_session: Session):
     headers = {"Authorization": f"Bearer {get_token(client, 'admin')}"}
 
     response = client.post(
-        "/api/v1/auth/users/",
+        "/api/v1/auth/users",
         json={"username": "bob", "password": "secret", "roles": ["viewer"]},
         headers=headers,
     )
@@ -96,7 +96,7 @@ def test_users_crud_endpoints(client: TestClient, db_session: Session):
     assert patched["permissions"] == [Permissions.USERS_READ]
 
     response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "bobby", "password": "secret"},
     )
     assert response.status_code == 200
@@ -113,12 +113,12 @@ def test_users_crud_endpoints(client: TestClient, db_session: Session):
     assert updated["permissions"] == []
 
     response = client.post(
-        "/api/v1/auth/login/",
+        "/api/v1/auth/login",
         json={"username": "robert", "password": "new-secret"},
     )
     assert response.status_code == 200
 
-    response = client.get("/api/v1/auth/users/", headers=headers)
+    response = client.get("/api/v1/auth/users", headers=headers)
     assert response.status_code == 200
     assert any(user["username"] == "robert" for user in response.json())
 
@@ -143,14 +143,14 @@ def test_users_permissions_are_enforced(client: TestClient, db_session: Session)
 
     headers = {"Authorization": f"Bearer {get_token(client, readonly.username)}"}
 
-    response = client.get("/api/v1/auth/users/", headers=headers)
+    response = client.get("/api/v1/auth/users", headers=headers)
     assert response.status_code == 200
 
     response = client.get(f"/api/v1/auth/users/{target.id}", headers=headers)
     assert response.status_code == 200
 
     response = client.post(
-        "/api/v1/auth/users/",
+        "/api/v1/auth/users",
         json={"username": "new-user", "password": "secret", "roles": ["viewer"]},
         headers=headers,
     )
@@ -183,7 +183,7 @@ def test_create_user_rejects_unknown_role(client: TestClient, db_session: Sessio
     headers = {"Authorization": f"Bearer {get_token(client, 'admin')}"}
 
     response = client.post(
-        "/api/v1/auth/users/",
+        "/api/v1/auth/users",
         json={"username": "bob", "password": "secret", "roles": ["missing"]},
         headers=headers,
     )

--- a/backend/tests/unit/test_archive_service.py
+++ b/backend/tests/unit/test_archive_service.py
@@ -2,7 +2,7 @@ from src.services.archive import get_base_url
 
 
 def test_basic():
-    url = "https://example.com/api/v1/users/"
+    url = "https://example.com/api/v1/users"
     assert get_base_url(url, 1) == "https://example.com/api/v1"
     assert get_base_url(url, 2) == "https://example.com/api"
 
@@ -13,7 +13,7 @@ def test_no_trailing_slash():
 
 
 def test_root_url():
-    url = "https://example.com/"
+    url = "https://example.com"
     assert get_base_url(url, 1) == "https://example.com"
 
 

--- a/backend/tests/unit/test_event_service.py
+++ b/backend/tests/unit/test_event_service.py
@@ -103,7 +103,7 @@ def test_create_event_invalid_prod_hall_error(db_session, hall):
     with pytest.raises(ValidationError):
         create_event(db_session, event, BASE_URL)
 
-    event = EventCreate(production_id_url="", hall_id_url="lls/")
+    event = EventCreate(production_id_url="", hall_id_url="lls")
 
     with pytest.raises(ValidationError):
         create_event(db_session, event, BASE_URL)

--- a/backend/tests/unit/test_hall_service.py
+++ b/backend/tests/unit/test_hall_service.py
@@ -22,7 +22,7 @@ def test_create_hall(db_session):
     assert hall.names[0].language == "en"
     assert hall.names[0].name == "Main Hall"
     assert hall.address == "Street 1"
-    assert hall.id_url.startswith("BASE/halls/")
+    assert hall.id_url.startswith("BASE/halls")
 
 
 def test_get_hall_by_id_success(db_session):
@@ -37,7 +37,7 @@ def test_get_hall_by_id_success(db_session):
     assert len(result.names) == 1
     assert result.names[0].name == "Hall A"
     assert result.address == "Street A"
-    assert result.id_url.startswith("BASE/halls/")
+    assert result.id_url.startswith("BASE/halls")
 
 
 def test_get_hall_by_id_not_found(db_session):
@@ -61,7 +61,7 @@ def test_get_all_halls(db_session):
     assert len(halls[1].names) == 1
     assert halls[0].names[0].name == "Hall A"
     assert halls[1].names[0].name == "Hall B"
-    assert all(hall.id_url.startswith("BASE/halls/") for hall in halls)
+    assert all(hall.id_url.startswith("BASE/halls") for hall in halls)
 
 
 def test_update_hall_success(db_session):
@@ -87,7 +87,7 @@ def test_update_hall_success(db_session):
     assert updated.names[1].language == "nl"
     assert updated.names[1].name == "Nieuwe Hal"
     assert updated.address == "New Street"
-    assert updated.id_url.startswith("BASE/halls/")
+    assert updated.id_url.startswith("BASE/halls")
 
 
 def test_update_hall_not_found(db_session):

--- a/backend/tests/unit/test_history_service.py
+++ b/backend/tests/unit/test_history_service.py
@@ -26,7 +26,7 @@ def test_create_history_success(db_session):
 
     result = create_history(db_session, history_in, BASE_URL)
 
-    assert result.id_url.startswith(f"{BASE_URL}/history/")
+    assert result.id_url.startswith(f"{BASE_URL}/history")
     assert result.year == 2024
     assert result.language == "nl"
     assert result.title == "Titel"

--- a/backend/tests/unit/test_tag_service.py
+++ b/backend/tests/unit/test_tag_service.py
@@ -80,7 +80,7 @@ def test_create_tag(db_session):
 
     result = create_tag(db_session, tag_in, BASE_URL)
 
-    assert result.id_url.startswith(f"{BASE_URL}/tags/")
+    assert result.id_url.startswith(f"{BASE_URL}/tags")
     assert len(result.names) == 2
 
     names = {n.language: n.name for n in result.names}

--- a/frontend/app/features/archive/services/mediaService.ts
+++ b/frontend/app/features/archive/services/mediaService.ts
@@ -11,7 +11,7 @@ export async function getMediaForProduction(
 ): Promise<MediaList> {
   const apiClient = createApiClient();
   const response = await apiClient.get<MediaList>(
-    `${ARCHIVE_PATH}/productions/${productionId}/media/`,
+    `${ARCHIVE_PATH}/productions/${productionId}/media`,
     { params }
   );
   return response.data;
@@ -25,7 +25,7 @@ export async function uploadMedia(
   const formData = new FormData();
   formData.append("file", file);
   const response = await apiClient.post<MediaItem>(
-    `${ARCHIVE_PATH}/productions/${productionId}/media/`,
+    `${ARCHIVE_PATH}/productions/${productionId}/media`,
     formData
   );
   return response.data;

--- a/frontend/app/features/archive/services/productionService.ts
+++ b/frontend/app/features/archive/services/productionService.ts
@@ -29,7 +29,7 @@ export async function getProductionsPaginated(
 ): Promise<ProductionList> {
   const apiClient = createApiClient();
 
-  const response = await apiClient.get<ProductionList>(`${ARCHIVE_PATH}/productions/`, {
+  const response = await apiClient.get<ProductionList>(`${ARCHIVE_PATH}/productions`, {
     params: {
       ...params,
       tag_ids: params?.tag_ids?.join(","),

--- a/frontend/app/features/blogs/services/blogService.ts
+++ b/frontend/app/features/blogs/services/blogService.ts
@@ -18,7 +18,7 @@ export async function getBlogsPaginated(
 ): Promise<BlogList> {
   const apiClient = createApiClient();
 
-  const response = await apiClient.get<BlogList>(`${ARCHIVE_PATH}/blogs/`, {
+  const response = await apiClient.get<BlogList>(`${ARCHIVE_PATH}/blogs`, {
     params: { ...params },
   });
 

--- a/frontend/app/features/blogs/services/blogService.ts
+++ b/frontend/app/features/blogs/services/blogService.ts
@@ -61,7 +61,7 @@ export async function getBlogsForProduction(productionUrl: string): Promise<Blog
 
     const apiClient = createApiClient();
     const response = await apiClient.get<BlogList>(
-      `${ARCHIVE_PATH}/productions/${productionId}/blogs/`
+      `${ARCHIVE_PATH}/productions/${productionId}/blogs`
     );
 
     return response.data.blogs;

--- a/frontend/app/shared/services/sharedService.ts
+++ b/frontend/app/shared/services/sharedService.ts
@@ -3,26 +3,21 @@ import { createApiClient } from "./apiClient";
 
 const ARCHIVE_PATH: string = "/api/v1/archive";
 
-function ensureTrailingSlash(url: string): string {
-  const [path, ...rest] = url.split(/(?=[?#])/);
-  return path.endsWith("/") ? url : `${path}/${rest.join("")}`;
-}
-
 function normalizeRequestUrl(url: string): string {
   const trimmedUrl = url.trim();
   if (trimmedUrl.startsWith("http://") || trimmedUrl.startsWith("https://")) {
     try {
       const parsedUrl = new URL(trimmedUrl);
-      return ensureTrailingSlash(`${parsedUrl.pathname}${parsedUrl.search}`);
+      return `${parsedUrl.pathname}${parsedUrl.search}`;
     } catch {
-      return ensureTrailingSlash(trimmedUrl);
+      return trimmedUrl;
     }
   }
-  return ensureTrailingSlash(trimmedUrl);
+  return trimmedUrl;
 }
 
 function archivePath(url: string): string {
-  return ensureTrailingSlash(`${ARCHIVE_PATH}${url}`);
+  return `${ARCHIVE_PATH}${url}`;
 }
 
 export async function getByUrl<T>(url: string, lang?: string): Promise<T> {

--- a/frontend/tests/unit/apiClient.test.ts
+++ b/frontend/tests/unit/apiClient.test.ts
@@ -130,7 +130,7 @@ describe("getByUrl", () => {
   });
 
   it("returns response data", async () => {
-    mockAdapter.onGet("/test/").reply(200, { foo: "bar" });
+    mockAdapter.onGet("/test").reply(200, { foo: "bar" });
 
     const result = await getByUrl("/test");
     expect(result).toEqual({ foo: "bar" });

--- a/frontend/tests/unit/artistService.test.ts
+++ b/frontend/tests/unit/artistService.test.ts
@@ -25,7 +25,7 @@ describe("artistService", () => {
 
   describe("getArtists", () => {
     it("returns the nl list when lang_code is 'nl'", async () => {
-      mockAdapter.onGet("/api/v1/archive/artists/").reply(200, MOCK_RESPONSE);
+      mockAdapter.onGet("/api/v1/archive/artists").reply(200, MOCK_RESPONSE);
 
       const result = await getArtists("nl");
 
@@ -33,7 +33,7 @@ describe("artistService", () => {
     });
 
     it("returns the en list when lang_code is 'en'", async () => {
-      mockAdapter.onGet("/api/v1/archive/artists/").reply(200, MOCK_RESPONSE);
+      mockAdapter.onGet("/api/v1/archive/artists").reply(200, MOCK_RESPONSE);
 
       const result = await getArtists("en");
 
@@ -41,7 +41,7 @@ describe("artistService", () => {
     });
 
     it("throws when the request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/artists/").reply(500);
+      mockAdapter.onGet("/api/v1/archive/artists").reply(500);
 
       await expect(getArtists("nl")).rejects.toThrow();
     });

--- a/frontend/tests/unit/blogService.test.ts
+++ b/frontend/tests/unit/blogService.test.ts
@@ -65,8 +65,8 @@ describe("blogService", () => {
 
     const apiClient = createApiClient();
     mockAdapter = new AxiosMockAdapter(apiClient);
-    mockAdapter.onGet("/api/v1/archive/blogs/1/").reply(200, mockBlog1);
-    mockAdapter.onGet("/api/v1/archive/blogs/2/").reply(200, mockBlog2);
+    mockAdapter.onGet("/api/v1/archive/blogs/1").reply(200, mockBlog1);
+    mockAdapter.onGet("/api/v1/archive/blogs/2").reply(200, mockBlog2);
     vi.spyOn(axios, "create").mockReturnValue(apiClient);
   });
 
@@ -82,7 +82,7 @@ describe("blogService", () => {
         pagination: pagination,
       };
 
-      mockAdapter.onGet("/api/v1/archive/blogs/").reply(200, mockBlogList);
+      mockAdapter.onGet("/api/v1/archive/blogs").reply(200, mockBlogList);
       const result = await getBlogsPaginated();
 
       expect(result.blogs).toHaveLength(2);
@@ -106,7 +106,7 @@ describe("blogService", () => {
     });
 
     it("returns a single blog by url on success", async () => {
-      const result = await getBlogByUrl("/api/v1/archive/blogs/1/");
+      const result = await getBlogByUrl("/api/v1/archive/blogs/1");
 
       expect(result).toBeDefined();
 
@@ -139,7 +139,7 @@ describe("blogService", () => {
         production_group_id_url: "/api/v1/archive/production-groups/3/",
       };
 
-      mockAdapter.onPost("/api/v1/archive/blogs/").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/blogs").reply(201, mockResponse);
       const result = await createBlog(blogData);
       expect(result).toEqual(mockResponse);
       expect(result.id_url).toBe("/api/v1/archive/blogs/3/");
@@ -157,7 +157,7 @@ describe("blogService", () => {
         production_group_id_url: "",
       };
 
-      mockAdapter.onPost("/api/v1/archive/blogs/").reply(400);
+      mockAdapter.onPost("/api/v1/archive/blogs").reply(400);
 
       await expect(createBlog(blogData)).rejects.toThrow();
     });
@@ -166,16 +166,16 @@ describe("blogService", () => {
     it("updates a blog and returns updated data", async () => {
       const blogUpdate: BlogUpdate = {
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_group_id_url: "/api/v1/archive/production-groups/3/",
+        production_group_id_url: "/api/v1/archive/production-groups/3",
       };
 
       const mockBlog2_updated: Blog = {
         id_url: "/api/v1/archive/blogs/2/",
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_group_id_url: "/api/v1/archive/production-groups/3/",
+        production_group_id_url: "/api/v1/archive/production-groups/3",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/blogs/2/").reply(200, mockBlog2_updated);
+      mockAdapter.onPatch("/api/v1/archive/blogs/2").reply(200, mockBlog2_updated);
 
       const result = await updateBlog(2, blogUpdate);
 
@@ -185,18 +185,18 @@ describe("blogService", () => {
     it("updates a blog and returns updated data by url", async () => {
       const blogUpdate: BlogUpdate = {
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_group_id_url: "/api/v1/archive/production-groups/3/",
+        production_group_id_url: "/api/v1/archive/production-groups/3",
       };
 
       const mockBlog2_updated: Blog = {
         id_url: "/api/v1/archive/blogs/2/",
         blog_contents: [mockBlogContent2EN, mockBlogContent2NL],
-        production_group_id_url: "/api/v1/archive/production-groups/3/",
+        production_group_id_url: "/api/v1/archive/production-groups/3",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/blogs/2/").reply(200, mockBlog2_updated);
+      mockAdapter.onPatch("/api/v1/archive/blogs/2").reply(200, mockBlog2_updated);
 
-      const result = await updateBlogByUrl("/api/v1/archive/blogs/2/", blogUpdate);
+      const result = await updateBlogByUrl("/api/v1/archive/blogs/2", blogUpdate);
 
       expect(result).toEqual(mockBlog2_updated);
     });
@@ -207,19 +207,19 @@ describe("blogService", () => {
         production_group_id_url: "",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/blogs/2/").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/blogs/2").reply(400);
       await expect(updateBlog(1, blogUpdate)).rejects.toThrow();
     });
   });
   describe("deleteBlog", () => {
     it("deletes a blog successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/blogs/1/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/blogs/1").reply(204);
 
       await expect(deleteBlog(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/blogs/1/").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/blogs/1").reply(404);
 
       await expect(deleteBlog(1)).rejects.toThrow();
     });
@@ -232,7 +232,7 @@ describe("blogService", () => {
         pagination: { has_more: false, total_count: 2 },
       };
 
-      mockAdapter.onGet("/api/v1/archive/productions/1/blogs/").reply(200, blogList);
+      mockAdapter.onGet("/api/v1/archive/productions/1/blogs").reply(200, blogList);
 
       const result = await getBlogsForProduction("/api/v1/archive/productions/1");
 
@@ -242,7 +242,7 @@ describe("blogService", () => {
     });
 
     it("returns empty array when request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/productions/1/blogs/").reply(500);
+      mockAdapter.onGet("/api/v1/archive/productions/1/blogs").reply(500);
 
       const result = await getBlogsForProduction("/api/v1/archive/productions/1");
 
@@ -261,7 +261,7 @@ describe("blogService", () => {
         pagination: { has_more: false, total_count: 1 },
       };
 
-      mockAdapter.onGet("/api/v1/archive/productions/42/blogs/").reply(200, blogList);
+      mockAdapter.onGet("/api/v1/archive/productions/42/blogs").reply(200, blogList);
 
       const result = await getBlogsForProduction("/api/v1/archive/productions/42");
 

--- a/frontend/tests/unit/eventService.test.ts
+++ b/frontend/tests/unit/eventService.test.ts
@@ -44,7 +44,7 @@ describe("eventService", () => {
         updated_at: "2026-03-20T10:00:00",
       };
 
-      mockAdapter.onGet("/api/v1/archive/events/1/").reply(200, mockEvent);
+      mockAdapter.onGet("/api/v1/archive/events/1").reply(200, mockEvent);
 
       const result = await getEvent(1);
 
@@ -54,7 +54,7 @@ describe("eventService", () => {
     });
 
     it("throws when event is not found", async () => {
-      mockAdapter.onGet("/api/v1/archive/events/999/").reply(404);
+      mockAdapter.onGet("/api/v1/archive/events/999").reply(404);
 
       await expect(getEvent(999)).rejects.toThrow();
     });
@@ -78,7 +78,7 @@ describe("eventService", () => {
         updated_at: "2026-03-20T10:00:00",
       };
 
-      mockAdapter.onPost("/api/v1/archive/events/").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/events").reply(201, mockResponse);
 
       const result = await createEvent(eventData);
 
@@ -92,7 +92,7 @@ describe("eventService", () => {
         hall_id_url: "hall1",
       };
 
-      mockAdapter.onPost("/api/v1/archive/events/").reply(400);
+      mockAdapter.onPost("/api/v1/archive/events").reply(400);
 
       await expect(createEvent(eventData)).rejects.toThrow();
     });
@@ -114,7 +114,7 @@ describe("eventService", () => {
         updated_at: "2026-03-21T10:00:00",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/events/1/").reply(200, mockResponse);
+      mockAdapter.onPatch("/api/v1/archive/events/1").reply(200, mockResponse);
 
       const result = await updateEvent(1, eventData);
 
@@ -127,7 +127,7 @@ describe("eventService", () => {
         starts_at: "2026-03-21T19:00:00",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/events/1/").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/events/1").reply(400);
 
       await expect(updateEvent(1, eventData)).rejects.toThrow();
     });
@@ -135,13 +135,13 @@ describe("eventService", () => {
 
   describe("deleteEvent", () => {
     it("deletes an event successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/events/1/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/events/1").reply(204);
 
       await expect(deleteEvent(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/events/1/").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/events/1").reply(404);
 
       await expect(deleteEvent(1)).rejects.toThrow();
     });
@@ -168,7 +168,7 @@ describe("eventService", () => {
         },
       ];
 
-      mockAdapter.onGet("/api/v1/archive/events/1/prices/").reply(200, mockPrices);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices").reply(200, mockPrices);
 
       const result = await getEventPrices(1);
 
@@ -177,7 +177,7 @@ describe("eventService", () => {
     });
 
     it("throws when get prices request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/events/1/prices/").reply(500);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices").reply(500);
 
       await expect(getEventPrices(1)).rejects.toThrow();
     });
@@ -194,7 +194,7 @@ describe("eventService", () => {
         updated_at: "2026-03-20T10:00:00",
       };
 
-      mockAdapter.onGet("/api/v1/archive/events/1/prices/1/").reply(200, mockPrice);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices/1").reply(200, mockPrice);
 
       const result = await getEventPrice(1, 1);
 
@@ -204,7 +204,7 @@ describe("eventService", () => {
     });
 
     it("throws when price is not found", async () => {
-      mockAdapter.onGet("/api/v1/archive/events/1/prices/999/").reply(404);
+      mockAdapter.onGet("/api/v1/archive/events/1/prices/999").reply(404);
 
       await expect(getEventPrice(1, 999)).rejects.toThrow();
     });

--- a/frontend/tests/unit/hallService.test.ts
+++ b/frontend/tests/unit/hallService.test.ts
@@ -41,7 +41,7 @@ describe("hallService", () => {
         },
       ];
 
-      mockAdapter.onGet("/api/v1/archive/halls/").reply(200, mockHalls);
+      mockAdapter.onGet("/api/v1/archive/halls").reply(200, mockHalls);
 
       const result = await getAllHalls();
 
@@ -50,7 +50,7 @@ describe("hallService", () => {
     });
 
     it("throws when get request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/halls/").reply(500);
+      mockAdapter.onGet("/api/v1/archive/halls").reply(500);
 
       await expect(getAllHalls()).rejects.toThrow();
     });
@@ -64,7 +64,7 @@ describe("hallService", () => {
         address: "Street 1",
       };
 
-      mockAdapter.onGet("/api/v1/archive/halls/1/").reply(200, mockHall);
+      mockAdapter.onGet("/api/v1/archive/halls/1").reply(200, mockHall);
 
       const result = await getHall(1);
 
@@ -75,7 +75,7 @@ describe("hallService", () => {
     });
 
     it("throws when hall is not found", async () => {
-      mockAdapter.onGet("/api/v1/archive/halls/999/").reply(404);
+      mockAdapter.onGet("/api/v1/archive/halls/999").reply(404);
 
       await expect(getHall(999)).rejects.toThrow();
     });
@@ -95,7 +95,7 @@ describe("hallService", () => {
           address: "Street 2",
         },
       ];
-      mockAdapter.onGet("/api/v1/archive/halls/").reply(200, mockHalls);
+      mockAdapter.onGet("/api/v1/archive/halls").reply(200, mockHalls);
 
       const result = await getHallByName("hall A");
       expect(result).toEqual(mockHalls[0]);
@@ -114,7 +114,7 @@ describe("hallService", () => {
         ...hallData,
       };
 
-      mockAdapter.onPost("/api/v1/archive/halls/").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/halls").reply(201, mockResponse);
 
       const result = await createHall(hallData);
 
@@ -130,7 +130,7 @@ describe("hallService", () => {
         address: "New Street 1",
       };
 
-      mockAdapter.onPost("/api/v1/archive/halls/").reply(400);
+      mockAdapter.onPost("/api/v1/archive/halls").reply(400);
 
       await expect(createHall(hallData)).rejects.toThrow();
     });
@@ -149,7 +149,7 @@ describe("hallService", () => {
         address: "Updated Street 1",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/halls/1/").reply(200, mockResponse);
+      mockAdapter.onPatch("/api/v1/archive/halls/1").reply(200, mockResponse);
 
       const result = await updateHall(1, hallData);
 
@@ -165,7 +165,7 @@ describe("hallService", () => {
         address: "Updated Street 1",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/halls/1/").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/halls/1").reply(400);
 
       await expect(updateHall(1, hallData)).rejects.toThrow();
     });
@@ -173,13 +173,13 @@ describe("hallService", () => {
 
   describe("deleteHall", () => {
     it("deletes a hall successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/halls/1/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/halls/1").reply(204);
 
       await expect(deleteHall(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/halls/1/").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/halls/1").reply(404);
 
       await expect(deleteHall(1)).rejects.toThrow();
     });

--- a/frontend/tests/unit/historyService.test.ts
+++ b/frontend/tests/unit/historyService.test.ts
@@ -53,7 +53,7 @@ describe("historyService", () => {
 
   describe("getHistoryEntries", () => {
     it("returns a list of history entries from the API", async () => {
-      mockAdapter.onGet("/api/v1/archive/history/").reply(200, MOCK_HISTORY_LIST);
+      mockAdapter.onGet("/api/v1/archive/history").reply(200, MOCK_HISTORY_LIST);
 
       const result = await getHistoryEntries();
 
@@ -62,7 +62,7 @@ describe("historyService", () => {
     });
 
     it("returns an empty list when no entries exist", async () => {
-      mockAdapter.onGet("/api/v1/archive/history/").reply(200, []);
+      mockAdapter.onGet("/api/v1/archive/history").reply(200, []);
 
       const result = await getHistoryEntries();
 
@@ -70,7 +70,7 @@ describe("historyService", () => {
     });
 
     it("throws when the request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/history/").reply(500);
+      mockAdapter.onGet("/api/v1/archive/history").reply(500);
 
       await expect(getHistoryEntries()).rejects.toThrow();
     });
@@ -85,7 +85,7 @@ describe("historyService", () => {
         content: "This is a test history entry",
       };
 
-      mockAdapter.onPost("/api/v1/archive/history/").reply(201, MOCK_HISTORY_ENTRY);
+      mockAdapter.onPost("/api/v1/archive/history").reply(201, MOCK_HISTORY_ENTRY);
 
       const result = await createHistoryEntry(request);
 
@@ -102,7 +102,7 @@ describe("historyService", () => {
         content: "Duplicate entry",
       };
 
-      mockAdapter.onPost("/api/v1/archive/history/").reply(400, {
+      mockAdapter.onPost("/api/v1/archive/history").reply(400, {
         detail: "History entry for year 2024 and language 'nl' already exists",
       });
 
@@ -127,7 +127,7 @@ describe("historyService", () => {
         content: "Updated content",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/history/2024/nl/").reply(200, updatedEntry);
+      mockAdapter.onPatch("/api/v1/archive/history/2024/nl").reply(200, updatedEntry);
 
       const result = await updateHistoryEntry(year, language, request);
 
@@ -144,13 +144,13 @@ describe("historyService", () => {
       };
 
       mockAdapter
-        .onPatch("/api/v1/archive/history/1999/en/")
+        .onPatch("/api/v1/archive/history/1999/en")
         .reply(200, MOCK_HISTORY_ENTRY);
 
       await updateHistoryEntry(year, language, request);
 
       expect(mockAdapter.history.patch).toHaveLength(1);
-      expect(mockAdapter.history.patch[0].url).toBe("/api/v1/archive/history/1999/en/");
+      expect(mockAdapter.history.patch[0].url).toBe("/api/v1/archive/history/1999/en");
     });
 
     it("rejects when the entry does not exist", async () => {
@@ -158,7 +158,7 @@ describe("historyService", () => {
       const language = "nl";
       const request: HistoryEntryUpdateRequest = { title: "Updated" };
 
-      mockAdapter.onPatch("/api/v1/archive/history/999/nl/").reply(404, {
+      mockAdapter.onPatch("/api/v1/archive/history/999/nl").reply(404, {
         detail: "History entry not found",
       });
 
@@ -173,7 +173,7 @@ describe("historyService", () => {
       const year = 2024;
       const language = "nl";
 
-      mockAdapter.onDelete("/api/v1/archive/history/2024/nl/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/history/2024/nl").reply(204);
 
       await expect(deleteHistoryEntry(year, language)).resolves.toBeUndefined();
       expect(mockAdapter.history.delete).toHaveLength(1);
@@ -183,21 +183,19 @@ describe("historyService", () => {
       const year = 1999;
       const language = "en";
 
-      mockAdapter.onDelete("/api/v1/archive/history/1999/en/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/history/1999/en").reply(204);
 
       await deleteHistoryEntry(year, language);
 
       expect(mockAdapter.history.delete).toHaveLength(1);
-      expect(mockAdapter.history.delete[0].url).toBe(
-        "/api/v1/archive/history/1999/en/"
-      );
+      expect(mockAdapter.history.delete[0].url).toBe("/api/v1/archive/history/1999/en");
     });
 
     it("rejects when the entry does not exist", async () => {
       const year = 999;
       const language = "nl";
 
-      mockAdapter.onDelete("/api/v1/archive/history/999/nl/").reply(404, {
+      mockAdapter.onDelete("/api/v1/archive/history/999/nl").reply(404, {
         detail: "History entry not found",
       });
 

--- a/frontend/tests/unit/mediaService.test.ts
+++ b/frontend/tests/unit/mediaService.test.ts
@@ -55,7 +55,7 @@ describe("mediaService", () => {
       };
 
       mockAdapter
-        .onGet("/api/v1/archive/productions/1/media/")
+        .onGet("/api/v1/archive/productions/1/media")
         .reply(200, mockMediaList);
 
       const result = await getMediaForProduction(1);
@@ -71,7 +71,7 @@ describe("mediaService", () => {
       };
 
       mockAdapter
-        .onGet("/api/v1/archive/productions/1/media/")
+        .onGet("/api/v1/archive/productions/1/media")
         .reply(200, mockMediaList);
 
       const result = await getMediaForProduction(1);
@@ -80,7 +80,7 @@ describe("mediaService", () => {
     });
 
     it("throws when request fails", async () => {
-      mockAdapter.onGet("/api/v1/archive/productions/1/media/").reply(404);
+      mockAdapter.onGet("/api/v1/archive/productions/1/media").reply(404);
 
       await expect(getMediaForProduction(1)).rejects.toThrow();
     });
@@ -89,7 +89,7 @@ describe("mediaService", () => {
   describe("uploadMedia", () => {
     it("uploads a file and returns the created media item", async () => {
       mockAdapter
-        .onPost("/api/v1/archive/productions/1/media/")
+        .onPost("/api/v1/archive/productions/1/media")
         .reply(201, mockMediaItem1);
 
       const file = new File(["dummy content"], "poster.jpg", {
@@ -104,7 +104,7 @@ describe("mediaService", () => {
     });
 
     it("throws when upload fails", async () => {
-      mockAdapter.onPost("/api/v1/archive/productions/1/media/").reply(415);
+      mockAdapter.onPost("/api/v1/archive/productions/1/media").reply(415);
 
       const file = new File(["dummy content"], "doc.pdf", {
         type: "application/pdf",
@@ -116,13 +116,13 @@ describe("mediaService", () => {
 
   describe("deleteMedia", () => {
     it("deletes a media item successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1/media/1/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/productions/1/media/1").reply(204);
 
       await expect(deleteMedia(1, 1)).resolves.toBeUndefined();
     });
 
     it("throws when media item is not found", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1/media/99/").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/productions/1/media/99").reply(404);
 
       await expect(deleteMedia(1, 99)).rejects.toThrow();
     });

--- a/frontend/tests/unit/productionService.test.ts
+++ b/frontend/tests/unit/productionService.test.ts
@@ -95,8 +95,8 @@ describe("productionService", () => {
 
     const apiClient = createApiClient();
     mockAdapter = new AxiosMockAdapter(apiClient);
-    mockAdapter.onGet("/api/v1/archive/productions/1/").reply(200, mockProduction1);
-    mockAdapter.onGet("/api/v1/archive/productions/2/").reply(200, mockProduction2);
+    mockAdapter.onGet("/api/v1/archive/productions/1").reply(200, mockProduction1);
+    mockAdapter.onGet("/api/v1/archive/productions/2").reply(200, mockProduction2);
     vi.spyOn(axios, "create").mockReturnValue(apiClient);
   });
 
@@ -112,7 +112,7 @@ describe("productionService", () => {
         pagination: pagination,
       };
 
-      mockAdapter.onGet("/api/v1/archive/productions/").reply(200, mockProductionList);
+      mockAdapter.onGet("/api/v1/archive/productions").reply(200, mockProductionList);
       const result = await getProductionsPaginated();
 
       expect(result.productions).toHaveLength(2);
@@ -146,7 +146,7 @@ describe("productionService", () => {
   describe("createProduction", () => {
     it("creates a new production and returns it", async () => {
       const production_info: ProductionInfo = {
-        production_id_url: "/api/v1/archive/productions/3/",
+        production_id_url: "/api/v1/archive/productions/3",
         language: "en",
         title: "Rocking the Suburbs!",
         artist: "William Shatner",
@@ -159,21 +159,21 @@ describe("productionService", () => {
       };
 
       const mockResponse: Production = {
-        id_url: "/api/v1/archive/productions/3/",
+        id_url: "/api/v1/archive/productions/3",
         production_infos: [production_info],
         event_id_urls: [],
         tags: [tag1],
       };
 
-      mockAdapter.onPost("/api/v1/archive/productions/").reply(201, mockResponse);
+      mockAdapter.onPost("/api/v1/archive/productions").reply(201, mockResponse);
       const result = await createProduction(productionData);
       expect(result).toEqual(mockResponse);
-      expect(result.id_url).toBe("/api/v1/archive/productions/3/");
+      expect(result.id_url).toBe("/api/v1/archive/productions/3");
     });
 
     it("throws when create request fails", async () => {
       const production_info: ProductionInfo = {
-        production_id_url: "/api/v1/archive/productions/3/",
+        production_id_url: "/api/v1/archive/productions/3",
         language: "en",
         title: "Rocking the Suburbs!",
         artist: "William Shatner",
@@ -185,7 +185,7 @@ describe("productionService", () => {
         tag_id_urls: ["1", "2"],
       };
 
-      mockAdapter.onPost("/api/v1/archive/productions/").reply(400);
+      mockAdapter.onPost("/api/v1/archive/productions").reply(400);
 
       await expect(createProduction(productionData)).rejects.toThrow();
     });
@@ -209,7 +209,7 @@ describe("productionService", () => {
       };
 
       mockAdapter
-        .onPatch("/api/v1/archive/productions/2/")
+        .onPatch("/api/v1/archive/productions/2")
         .reply(200, mockProduction2_updated);
 
       const result = await updateProduction(2, productionUpdate);
@@ -224,19 +224,19 @@ describe("productionService", () => {
         attendance_mode: "online",
       };
 
-      mockAdapter.onPatch("/api/v1/archive/productions/2/").reply(400);
+      mockAdapter.onPatch("/api/v1/archive/productions/2").reply(400);
       await expect(updateProduction(1, productionUpdate)).rejects.toThrow();
     });
   });
   describe("deleteProduction", () => {
     it("deletes a production successfully", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/productions/1").reply(204);
 
       await expect(deleteProduction(1)).resolves.toBeUndefined();
     });
 
     it("throws when delete request fails", async () => {
-      mockAdapter.onDelete("/api/v1/archive/productions/1/").reply(404);
+      mockAdapter.onDelete("/api/v1/archive/productions/1").reply(404);
 
       await expect(deleteProduction(1)).rejects.toThrow();
     });

--- a/frontend/tests/unit/resourceService.test.ts
+++ b/frontend/tests/unit/resourceService.test.ts
@@ -39,7 +39,7 @@ describe("resourceService", () => {
   it("getResourceList returns a list of data", async () => {
     const mockResources: IResource[] = [{ id: 1, someData: "testData" }];
     mockAdapter
-      .onGet("/api/v1/archive/resource/", { params: { limit: 10 } })
+      .onGet("/api/v1/archive/resource", { params: { limit: 10 } })
       .reply(200, mockResources);
 
     const result = await getResourceList(10);
@@ -48,7 +48,7 @@ describe("resourceService", () => {
 
   it("getResourceById returns data of specific resource", async () => {
     mockAdapter
-      .onGet("/api/v1/archive/resource/1/")
+      .onGet("/api/v1/archive/resource/1")
       .reply(200, { id: 1, someData: "testData" });
 
     const result = await getResourceById(1);
@@ -58,7 +58,7 @@ describe("resourceService", () => {
   it("createResource posts data", async () => {
     const request: ICreateResource = { someData: "testData" };
     mockAdapter
-      .onPost("/api/v1/archive/resource/", request)
+      .onPost("/api/v1/archive/resource", request)
       .reply(201, { id: 1, someData: request.someData });
 
     const result = await createResource(request);
@@ -68,7 +68,7 @@ describe("resourceService", () => {
   it("editResource edits data", async () => {
     const request: IUpdateResource = { someData: "testData" };
     mockAdapter
-      .onPatch("/api/v1/archive/resource/1/", request)
+      .onPatch("/api/v1/archive/resource/1", request)
       .reply(201, { id: 1, someData: request.someData });
 
     const result = await editResource(1, request);
@@ -77,19 +77,19 @@ describe("resourceService", () => {
 
   it("editResource throws when trying to patch non-existent data", async () => {
     const request: IUpdateResource = { someData: "testData" };
-    mockAdapter.onPatch("/api/v1/archive/resource/999/", request).reply(404);
+    mockAdapter.onPatch("/api/v1/archive/resource/999", request).reply(404);
 
     await expect(editResource(999, request)).rejects.toThrow("404");
   });
 
   it("deleteResource deletes data", async () => {
-    mockAdapter.onDelete("/api/v1/archive/resource/1/").reply(204);
+    mockAdapter.onDelete("/api/v1/archive/resource/1").reply(204);
     const result = await deleteResource(1);
     expect(result).toBeUndefined();
   });
 
   it("deleteResource throws when trying to delete non-existent data", async () => {
-    mockAdapter.onDelete("/api/v1/archive/resource/999/").reply(404);
+    mockAdapter.onDelete("/api/v1/archive/resource/999").reply(404);
 
     await expect(deleteResource(999)).rejects.toThrow("404");
   });

--- a/frontend/tests/unit/tagService.test.ts
+++ b/frontend/tests/unit/tagService.test.ts
@@ -51,7 +51,7 @@ describe("tagService", () => {
 
   describe("getAllTags", () => {
     it("returns a list of tags on success", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags/").reply(200, [mockTag1, mockTag2]);
+      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
 
       const result = await getAllTags();
       expect(result).toEqual([mockTag1, mockTag2]);
@@ -60,7 +60,7 @@ describe("tagService", () => {
 
   describe("getTagById", () => {
     it("returns a tag object on success", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags/1/").reply(200, mockTag1);
+      mockAdapter.onGet("/api/v1/archive/tags/1").reply(200, mockTag1);
 
       const result = await getTagById(1);
       expect(result).toEqual(mockTag1);
@@ -69,14 +69,14 @@ describe("tagService", () => {
 
   describe("getTagByName", () => {
     it("returns a tag object on success (nl)", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags/").reply(200, [mockTag1, mockTag2]);
+      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
 
       const result = await getTagByName("tag naam");
       expect(result).toEqual(mockTag1);
     });
 
     it("returns a tag object on success (en)", async () => {
-      mockAdapter.onGet("/api/v1/archive/tags/").reply(200, [mockTag1, mockTag2]);
+      mockAdapter.onGet("/api/v1/archive/tags").reply(200, [mockTag1, mockTag2]);
 
       const result = await getTagByName("tag name");
       expect(result).toEqual(mockTag1);
@@ -86,7 +86,7 @@ describe("tagService", () => {
   describe("createTag", () => {
     it("creates a tag object and returns it on success", async () => {
       // Upon calling post, return the request with an added id field
-      mockAdapter.onPost("/api/v1/archive/tags/").reply((config) => {
+      mockAdapter.onPost("/api/v1/archive/tags").reply((config) => {
         const data = {
           id_url: mockTag1.id_url,
           ...JSON.parse(config.data),
@@ -101,7 +101,7 @@ describe("tagService", () => {
 
   describe("editTag", () => {
     it("edits a tag by id and returns the updated object", async () => {
-      mockAdapter.onPatch("/api/v1/archive/tags/1/").reply((config) => {
+      mockAdapter.onPatch("/api/v1/archive/tags/1").reply((config) => {
         const data = {
           id_url: "http://localhost/api/v1/archive/tags/1",
           ...JSON.parse(config.data),
@@ -116,7 +116,7 @@ describe("tagService", () => {
 
   describe("deleteTag", () => {
     it("deletes a tag", async () => {
-      mockAdapter.onDelete("/api/v1/archive/tags/1/").reply(204);
+      mockAdapter.onDelete("/api/v1/archive/tags/1").reply(204);
       await deleteTag(1);
     });
   });


### PR DESCRIPTION
### Beschrijving
Er werden trailing slashes gezet achter enkele endpoints. Deze zijn nu allemaal verwijderd om de backend uniform te houden zonder dat er redirects nodig zijn.
Voorbeeld voor -> na:
<img width="456" height="68" alt="image" src="https://github.com/user-attachments/assets/94c182e2-6323-4218-a0ca-f0f22d94378e" />
<img width="456" height="68" alt="image" src="https://github.com/user-attachments/assets/0560639e-cd00-4f09-9f8f-272deefd6a08" />


### Aangepaste delen
backend: endpoints aangepast
frontend: de services plaatsten een extra trailing slash door een eerdere poging om de redirects te minderen, dit is nu terug gebracht


Closes #426 

- [ ] Auteur wil zelf mergen.
