### PR TITLE
[HOTFIX] Snellere frontend testen

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -20,6 +20,6 @@ export default defineConfig({
     env: {
       NODE_OPTIONS: "--no-experimental-webstorage",
     },
-    fileParallelism: false,
+    fileParallelism: true,
   },
 });


### PR DESCRIPTION
### Beschrijving
In een eerdere PR was vitest fileParallelism per ongeluk uit gezet, deze PR zet deze weer aan.

Gevolg: frontend testen duren lokaal geen 60s meer, maar slechts 14s.


### Aangepaste delen
`frontend/vitest.config.ts`


### Testen
Die zijn dus sneller he


- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
