### PR TITLE
[TASK] Verwijder history van translation

### DIFF
--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -168,41 +168,7 @@
         "title": "Give a short title for this moment",
         "content": "Tell the story of this moment in history"
       }
-    },
-    "entries": [
-      {
-        "title": "1910: The construction of Vooruit 'Festivities Hall'",
-        "description": "In 1910 Vooruit bought a big residence and two adjacent houses in the Sint-Pietersnieuwstraat. This was to become the location for a new festivities hall. With this new cultural temple the socialists wanted to prove that they were no philistines, and that they cared about the intellectual development of the workers.The cooperative commissioned Ferdinand Dierkens to be the architect and he gave the workers a colossal “House of the People”."
-      },
-      {
-        "title": "1946: The return of the bustle",
-        "description": "The Vooruit cooperative regained the Festivities Hall in 1946. After the war, the Multatulikring, Harmonie Vooruit, and the Rode Valken, once more transformed the Festivities Hall into a true beehive. A few new associations were also added to the mix: The Anseele Vrienden, the Studiekring Edward Anseele, a women's league 'De Samenwerkster', a women’s league, the Leesclub Boekuil, ..."
-      },
-      {
-        "title": "1970: The decline of the building & the exodus of the associations",
-        "description": "Because there was less and less money to upkeep the building, more and more spaces were abandoned. There were water leaks, the fire security was lacking and many associations started leaving the building. In the 1970s, the café was one of the few spaces in the building that still had visitors, but its lively days were long gone. The seniors’ weekly dance on Sundays was as exciting as it got."
-      },
-      {
-        "title": "1980: Clean-up of the building",
-        "description": "Everywhere in Belgium ‘Houses of the People’ were suffering the same faith and as cooperatives had a hard time staying afloat, neglect and dilapidation followed. Some ‘Houses of the People’ were repurposed, others were torn down. In 1982 a group of enthusiastic young people created the non-profit Socio-cultureel Centrum Vooruit (Vooruit Socio-Cultural Center) who planned to rehabilitate the entire building and use it as a progressive artistic meeting center. En 1982, quelques jeunes très motivés fondèrent le Centre socio-culturel Vooruit, chargé de rénover le bâtiment dans son ensemble et de l’exploiter comme centre artistique progressif ouvert au public. The promoters of the initiative wanted to get rid of the building’s “Red” label and considered the de-pillarization of the Festivities Hall to be a priority."
-      },
-      {
-        "title": "1988: Kunstencentrum Vooruit",
-        "description": "In 1988 Socio-Cultureel Centrum Vooruit (Vooruit Socio-Cultural Center) was renamed Kunstencentrum Vooruit (Vooruit Arts Center). From now on its own activities were to fit a specific profile and its artistic policy had to become the number one priority, with a focus on innovative work from various artistic disciplines. The building became a place where local and foreign artists could come together to work on productions."
-      },
-      {
-        "title": "2013: 100 years of Vooruit",
-        "description": "Today, with a staff of about 100 people and roughly 2,000 activities and 350,000 visitors each year, Vooruit Arts Center has become a major cultural institution. While it started out at the periphery of the Flemish performance landscape it has now become part of its core. Just like its predecessor, the Vooruit Festivities Hall, Vooruit Arts Center is a place of encounters, culture and social involvement. After more than one century above the Theaterzaal stage, the phrase ‘Kunst veredelt’ (Art ennobles), despite its pompousness, can today still be the motto of this cultural temple."
-      },
-      {
-        "title": "2017: A Flemish arts institution",
-        "description": "On January 1, 2017, the arts center became officially a Flemish arts institution. This translates into a renewed mission, with six central pillars: support, experiment, connect, engage, reflect and celebrate. You can find the complete mission here."
-      },
-      {
-        "title": "2022: A new name",
-        "description": "In 2022 Kunstencentrum Vooruit changes its name to Kunstencentrum VIERNULVIER, after the Flemish socialist party chose the new name 'Vooruit' in 2021. The building itself will continue to be known as De Vooruit. Only the organization will carry the new name."
-      }
-    ]
+    }
   },
 
   "blogs": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -168,41 +168,7 @@
         "title": "Geef een korte titel voor dit moment",
         "content": "Vertel het verhaal van dit moment in de geschiedenis"
       }
-    },
-    "entries": [
-      {
-        "title": "1910: De bouw van 'Feestlokaal Vooruit'",
-        "description": "In 1910 kocht Vooruit een groot herenhuis en twee aangrenzende woningen in de Sint-Pietersnieuwstraat. Daar moest een nieuw feestlokaal komen. Met de nieuwe cultuurtempel wilden de socialisten bewijzen dat ze geen cultuurbarbaren waren, dat ze zich bekommerden om de geestelijke ontwikkeling van de arbeiders. De coöperatie stelde Ferdinand Dierkens aan als architect. De arbeiders kregen een reusachtig volkshuis."
-      },
-      {
-        "title": "1946: Reprise de l’activité",
-        "description": "De coöperatie Vooruit kreeg het Feestlokaal in 1946 terug in handen. De Multatulikring, Harmonie Vooruit, de Rode Valken, ... na de oorlog maakten ze van het Feestlokaal opnieuw een ware bijenkorf. Er kwamen ook enkele nieuwe verenigingen bij. De Anseele Vrienden, De Samenwerkster (een vrouwenbond), de Leesclub Boekuil, e.a."
-      },
-      {
-        "title": "1970: Het verval van feestlokaal Vooruit",
-        "description": "Omdat er steeds minder geld was om het gebouw te onderhouden, raakten meer en meer zalen in onbruik. Er sijpelde water binnen, de brandveiligheid liet te wensen over. Heel wat verenigingen verlieten het gebouw. In de jaren 1970 was het café een van de weinige plekken waar nog volk over de vloer kwam. Een levendige plek was het toen al lang niet meer."
-      },
-      {
-        "title": "1980: Opruimactie & restauratie",
-        "description": "Overal in België waren volkshuizen in hetzelfde bedje ziek. Coöperaties konden moeilijk het hoofd boven water houden. Dat leidde tot verwaarlozing en verkrotting. Sommige volkshuizen kregen een nieuwe bestemming, andere werden afgebroken. In 1982 richtten enkele jongeren de vzw Socio-cultureel Centrum Vooruit op. Die ging het hele gebouw restaureren en het als progressief artistiek ontmoetingscentrum uitbaten. De initiatiefnemers wilden wel graag af van het rode etiket en zagen de ontzuiling van het Feestlokaal als een prioriteit."
-      },
-      {
-        "title": "1988: Kunstencentrum Vooruit",
-        "description": "In 1988 werd Socio-Cultureel Centrum Vooruit omgedoopt tot Kunstencentrum Vooruit. De eigen activiteiten moesten een geprononceerder profiel krijgen, het artistieke beleid moest de grootste prioriteit worden. Daarbij stond vernieuwend werk uit verschillende kunstdisciplines centraal. Vooruit ging niet enkel producties van anderen brengen, maar ook zelf (co)produceren. Het gebouw werd een werkplaats waar kunstenaars uit binnen- en buitenland samen aan producties konden sleutelen."
-      },
-      {
-        "title": "2013: 100 jaar Vooruit",
-        "description": "Met een 100-tal personeelsleden, jaarlijks ongeveer 2000 activiteiten en 350 000 bezoekers - groeide Kunstencentrum Vooruit in de nillies uit tot een culturele instelling van formaat. Net als zijn voorganger - het Feestlokaal van Vooruit - was het Kunstencentrum een plaats van ontmoeting, cultuur en engagement. Het opschrift ‘Kunst veredelt’, dat al een eeuw boven het podium van de Theaterzaal te lezen is, mag dan wel behoorlijk hoogdravend klinken: het bleef het motto van Vooruit. In 2013 wordt het 100 jarig bestaan van het gebouw uitgebreid gevierd tijdens 'Vooruit 100'. "
-      },
-      {
-        "title": "2017: Een Vlaamse kunstinstelling",
-        "description": "Op 1 januari 2017 wordt het kunstencentrum officieel een Vlaamse kunstinstelling. Dat vertaalt zich in onder andere een hernieuwde missie, met daaraan gekoppeld zes centrale speerpunten: support, experiment, connect, engage, reflect en celebrate. Hier kan je de volledige missie vinden."
-      },
-      {
-        "title": "2022: Een nieuwe naam",
-        "description": "In 2022 verandert Kunstencentrum Vooruit haar naam naar Kunstencentrum VIERNULVIER, nadat de Vlaamse socialistische partij in 2021 voor de nieuwe naam ‘Vooruit’ koos. Het gebouw zelf blijft De Vooruit heten. Enkel de organisatie draagt dus een nieuwe naam."
-      }
-    ]
+    }
   },
 
   "blogs": {

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -58,40 +58,6 @@ const translationMap: Record<string, TranslationValue> = {
   "history.messages.updateFailed": "I18N_History_Message_UpdateFailed",
   "history.messages.deleteFailed": "I18N_History_Message_DeleteFailed",
   "edit.cancel": "edit.cancel",
-  "history.entries": [
-    {
-      title: "I18N_History_Entry1_Title",
-      description: "I18N_History_Entry1_Description",
-    },
-    {
-      title: "I18N_History_Entry2_Title",
-      description: "I18N_History_Entry2_Description",
-    },
-    {
-      title: "I18N_History_Entry3_Title",
-      description: "I18N_History_Entry3_Description",
-    },
-    {
-      title: "I18N_History_Entry4_Title",
-      description: "I18N_History_Entry4_Description",
-    },
-    {
-      title: "I18N_History_Entry5_Title",
-      description: "I18N_History_Entry5_Description",
-    },
-    {
-      title: "I18N_History_Entry6_Title",
-      description: "I18N_History_Entry6_Description",
-    },
-    {
-      title: "I18N_History_Entry7_Title",
-      description: "I18N_History_Entry7_Description",
-    },
-    {
-      title: "I18N_History_Entry8_Title",
-      description: "I18N_History_Entry8_Description",
-    },
-  ],
   "blogs.card.other_prods": "I18N_Blog_Many_Productions",
   "blogs.card.no_prods": "I18N_Blog_No_Productions",
   "blogs.card.details": "I18N_Blog_Details",


### PR DESCRIPTION
### Beschrijving
Nadat de history van translations naar database verhuisd waren, waren we vergeten deze uit de translation files te halen. Bij deze.


### Aangepaste delen
Translation files en test setup.

### Testen
Niets nieuws te testen.

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
