### PR TITLE
[TWEAK] Verbeter blog tests/service/schema

### DIFF
--- a/backend/src/schemas/blogs.py
+++ b/backend/src/schemas/blogs.py
@@ -15,7 +15,7 @@ class BlogContentResponse(StrictModel):
 # The response for a blog
 class BlogResponse(StrictModel):
     id_url: str
-    production_group_id_url: str
+    production_group_id_url: Optional[str]
     blog_contents: list[BlogContentResponse] = Field(default_factory=list)
 
 

--- a/frontend/app/features/blogs/services/blogService.ts
+++ b/frontend/app/features/blogs/services/blogService.ts
@@ -54,8 +54,8 @@ export async function deleteBlog(blogId: number): Promise<void> {
 
 export async function getBlogsForProduction(productionUrl: string): Promise<Blog[]> {
   try {
-    const productionId = productionUrl.split("/").pop();
-    if (!productionId) {
+    const productionId = productionUrl.split("/").pop()?.trim();
+    if (!productionId || isNaN(+productionId)) {
       return [];
     }
 
@@ -80,6 +80,8 @@ interface ProductionGroup {
 export async function getProductionsForBlog(blog: Blog): Promise<Production[]> {
   try {
     const productionGroupIdUrl = blog.production_group_id_url;
+    if (!productionGroupIdUrl) return [];
+
     const apiClient = createApiClient();
     const response = await apiClient.get<ProductionGroup>(productionGroupIdUrl);
     const productionIdUrls = response.data.production_id_urls;

--- a/frontend/app/features/blogs/types/blogTypes.ts
+++ b/frontend/app/features/blogs/types/blogTypes.ts
@@ -3,15 +3,14 @@ import type { JsonPaginationResponse } from "~/features/archive/types/pagination
 export interface BlogContent {
   blog_id_url: string;
   language: string;
-
   title: string;
   content: string;
 }
 
 export interface Blog {
   id_url: string;
+  production_group_id_url?: string;
   blog_contents: BlogContent[];
-  production_group_id_url: string;
 }
 
 export interface BlogList {
@@ -21,25 +20,23 @@ export interface BlogList {
 
 export interface BlogContentCreate {
   language: string;
-
   title: string;
   content: string;
 }
 
 export interface BlogCreate {
   blog_content: BlogContentCreate;
-  production_group_id_url: string;
+  production_group_id_url?: string;
 }
 
 export interface BlogContentUpdate {
   language: string;
-
-  title: string;
-  content: string;
+  title?: string;
+  content?: string;
 }
 
 export interface BlogUpdate {
   blog_contents: BlogContentUpdate[];
-  production_group_id_url: string;
+  production_group_id_url?: string;
   remove_languages?: string[];
 }

--- a/frontend/tests/unit/blogService.test.ts
+++ b/frontend/tests/unit/blogService.test.ts
@@ -18,6 +18,7 @@ import {
   getBlogByUrl,
   getBlogsForProduction,
   getBlogsPaginated,
+  getProductionsForBlog,
   updateBlog,
   updateBlogByUrl,
 } from "~/features/blogs/services/blogService";
@@ -250,9 +251,11 @@ describe("blogService", () => {
     });
 
     it("returns empty array when production URL is invalid", async () => {
-      const result = await getBlogsForProduction("invalid-url");
+      const result1 = await getBlogsForProduction("invalid-url");
+      expect(result1).toEqual([]);
 
-      expect(result).toEqual([]);
+      const result2 = await getBlogsForProduction("");
+      expect(result2).toEqual([]);
     });
 
     it("correctly extracts production ID from URL", async () => {
@@ -266,6 +269,62 @@ describe("blogService", () => {
       const result = await getBlogsForProduction("/api/v1/archive/productions/42");
 
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("getProductionsForBlog", () => {
+    it("returns productions for a blog", async () => {
+      const blog: Blog = {
+        id_url: "",
+        blog_contents: [],
+        production_group_id_url: "/api/v1/archive/production-groups/1",
+      };
+
+      mockAdapter.onGet("/api/v1/archive/production-groups/1").reply(200, {
+        production_id_urls: [
+          "/api/v1/archive/productions/1",
+          "/api/v1/archive/productions/2",
+        ],
+      });
+      const mockProd1 = {
+        id_url: "/api/v1/archive/productions/1",
+        production_infos: [],
+        event_id_urls: [],
+        tags: [],
+      };
+      const mockProd2 = {
+        id_url: "/api/v1/archive/productions/2",
+        production_infos: [],
+        event_id_urls: [],
+        tags: [],
+      };
+      mockAdapter.onGet("/api/v1/archive/productions/1").reply(200, mockProd1);
+      mockAdapter.onGet("/api/v1/archive/productions/2").reply(200, mockProd2);
+
+      const result = await getProductionsForBlog(blog);
+      expect(result).toHaveLength(2);
+      expect(result[0].id_url).toBe(mockProd1.id_url);
+      expect(result[1].id_url).toBe(mockProd2.id_url);
+    });
+
+    it("returns empty list when blog has no productions", async () => {
+      const blog: Blog = {
+        id_url: "",
+        blog_contents: [],
+      };
+      const result = await getProductionsForBlog(blog);
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns empty list upon error", async () => {
+      const blog: Blog = {
+        id_url: "",
+        blog_contents: [],
+        production_group_id_url: "/api/v1/archive/production-groups/1",
+      };
+      mockAdapter.onGet("/api/v1/archive/production-groups/1").reply(404, {});
+      const result = await getProductionsForBlog(blog);
+      expect(result).toHaveLength(0);
     });
   });
 });

--- a/frontend/tests/unit/components/Blogcard.test.tsx
+++ b/frontend/tests/unit/components/Blogcard.test.tsx
@@ -135,6 +135,16 @@ describe("BlogCard", () => {
     expect(blogCardText?.querySelectorAll("p")).toHaveLength(2);
   });
 
+  it("renders blog without content", () => {
+    const emptyBlog: Blog = {
+      ...mockBlog,
+      blog_contents: [],
+    };
+
+    renderBlogCard({ blog: emptyBlog });
+    expect(screen.getByText("Untitled blog")).toBeInTheDocument();
+  });
+
   it("renders the no-production fallback text", () => {
     vi.mocked(blogService.getProductionsForBlog).mockResolvedValue([]);
     renderBlogCard({ blog: mockBlogNoProductions });

--- a/frontend/tests/unit/components/Blogcard.test.tsx
+++ b/frontend/tests/unit/components/Blogcard.test.tsx
@@ -215,13 +215,9 @@ describe("BlogCardList", () => {
     };
 
     render(
-      <div>
-        {[mockBlog, blog2].map((blog) => (
-          <MemoryRouter>
-            <BlogCard key={blog.id_url} blog={blog} preferredLanguage="en" />
-          </MemoryRouter>
-        ))}
-      </div>
+      <MemoryRouter>
+        <BlogCardList blogs={[mockBlog, blog2]} prefferedLanguage="en" />
+      </MemoryRouter>
     );
 
     expect(screen.getByText("A Blog Post Title")).toBeInTheDocument();


### PR DESCRIPTION
### Beschrijving
Ik begon met frontend testen te schrijven, beginnend bij BlogCard, en daarbij vond ik wel wat dingetjes die beter konden.

De schema's voor blogs waren niet consistent met de nieuwe production-groups, dit is opgelost. Ook ontbreekten er testen voor de `getProductionsForBlog()` functie in `blogService.ts`. Na wat werk had ik deze PR die rond blogs hier en daar wat verbetert.


### Aangepaste delen
Blogs, maar dan enkel zo het API verkeer daarover.


### Testen
BlogCard is nu niet 100% gecovered, maar voldoende imo. De blogService is wel 100% covered nu.


- [X] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
