### PR TITLE
[TEST] Unit test - text editor, DeleteInfoButton

### DIFF
--- a/frontend/app/features/archive/components/DeleteInfoButton.tsx
+++ b/frontend/app/features/archive/components/DeleteInfoButton.tsx
@@ -6,10 +6,10 @@ import { updateProductionByUrl } from "../services/productionService";
 async function handleInfoDelete(
   production_id_url: string,
   language: string,
-  confirmeMessage: string,
+  confirmMessage: string,
   errorMessage: string
 ) {
-  const confirmed = window.confirm(confirmeMessage);
+  const confirmed = window.confirm(confirmMessage);
   if (!confirmed) return;
   try {
     await updateProductionByUrl(production_id_url, {

--- a/frontend/tests/unit/archive-rich-text.client.test.ts
+++ b/frontend/tests/unit/archive-rich-text.client.test.ts
@@ -27,7 +27,7 @@ describe("htmlToDelta", () => {
   });
 });
 
-// Tests for deltaToHtml not derictly covered because very annoying to create
+// Tests for deltaToHtml not directly covered because very annoying to create
 // a Delta object
 
 describe("round-trip conversions", () => {

--- a/frontend/tests/unit/archive-rich-text.client.test.ts
+++ b/frontend/tests/unit/archive-rich-text.client.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { deltaToHtml, htmlToDelta } from "~/archive-rich-text.client";
+
+describe("htmlToDelta", () => {
+  it("converts plain text html to delta", async () => {
+    const delta = await htmlToDelta("<p>Hello world</p>");
+
+    expect(delta.ops).toEqual([{ insert: "Hello world\n" }]);
+  });
+
+  it("converts bold text", async () => {
+    const delta = await htmlToDelta("<p><strong>Hello</strong></p>");
+
+    expect(delta.ops).toEqual([
+      {
+        insert: "Hello",
+        attributes: { bold: true },
+      },
+      { insert: "\n" },
+    ]);
+  });
+
+  it("handles empty html", async () => {
+    const delta = await htmlToDelta("");
+
+    expect(delta.ops).toEqual([{ insert: "\n" }]);
+  });
+});
+
+// Tests for deltaToHtml not derictly covered because very annoying to create
+// a Delta object
+
+describe("round-trip conversions", () => {
+  it("preserves content through html -> delta -> html", async () => {
+    const input = "<p>Hello <strong>world</strong></p>";
+
+    const delta = await htmlToDelta(input);
+    const html = await deltaToHtml(delta);
+
+    expect(html).toContain("Hello");
+    expect(html).toContain("<strong>world</strong>");
+  });
+});

--- a/frontend/tests/unit/components/DeleteInfoButton.test.tsx
+++ b/frontend/tests/unit/components/DeleteInfoButton.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthSessionProvider } from "~/features/auth";
+import * as loginServiceModule from "~/features/auth/services/loginService";
+import * as productionServiceModule from "~/features/archive/services/productionService";
+
+import DeleteInfoButton from "~/features/archive/components/DeleteInfoButton";
+
+const baseUser = {
+  id: 1,
+  username: "editor",
+  isSuperUser: false,
+  roles: ["editor"],
+  permissions: ["archive:update"],
+  createdAt: "2026-03-30T10:00:00",
+  lastLoginAt: null,
+};
+
+function renderButton(user = baseUser) {
+  vi.spyOn(loginServiceModule, "restoreSession").mockResolvedValue(user);
+
+  return render(
+    <AuthSessionProvider>
+      <DeleteInfoButton production_id_url="/archive/productions/123" language="nl" />
+    </AuthSessionProvider>
+  );
+}
+
+describe("DeleteInfoButton", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+  });
+
+  it("renders delete button for authorized users", async () => {
+    renderButton();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+    });
+  });
+
+  it("does not render delete button without permission", async () => {
+    renderButton({
+      ...baseUser,
+      permissions: [],
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("calls updateProductionByUrl when confirmed", async () => {
+    const user = userEvent.setup();
+
+    const updateSpy = vi
+      .spyOn(productionServiceModule, "updateProductionByUrl")
+      .mockResolvedValue({} as never);
+
+    vi.stubGlobal("location", {
+      ...window.location,
+      reload: vi.fn(),
+    });
+
+    renderButton();
+
+    const button = await screen.findByRole("button", {
+      name: /delete/i,
+    });
+
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith("/archive/productions/123", {
+        remove_languages: ["nl"],
+      });
+    });
+  });
+
+  it("does not call service when confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const updateSpy = vi.spyOn(productionServiceModule, "updateProductionByUrl");
+
+    renderButton();
+
+    const button = await screen.findByRole("button", {
+      name: /delete/i,
+    });
+
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows alert when delete fails", async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(productionServiceModule, "updateProductionByUrl").mockRejectedValue(
+      new Error("Failed")
+    );
+
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    renderButton();
+
+    const button = await screen.findByRole("button", {
+      name: /delete/i,
+    });
+
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Beschrijving
Deze PR voegt twee test bestanden toe. Waarom zo maar twee en waarom niet in 2 PR's? Tja, om de PR niet te groot en niet te klein te maken zekers?

De testen voor DeleteInfoButton hebben hun mosterd gehaald van bij de HistoryEntry. 


### Aangepaste delen
Extra testen en typo fix, allemaal in de frontend.


### Testen
De toegevoegde testen brengen coverage voor deze twee delen naar 100%.

Wist je dat we al aan 420 frontend testen zaten?

- [X] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
