### PR TITLE
Feat/production page/create production part2

### DIFF
--- a/frontend/app/features/archive/components/ProductionHeader.tsx
+++ b/frontend/app/features/archive/components/ProductionHeader.tsx
@@ -2,14 +2,7 @@ import { useTranslation } from "react-i18next";
 import type { ProductionInfo } from "../types/productionTypes";
 import SimpleEditableField from "~/shared/components/SimpleEditableField";
 import { ARCHIVE_PERMISSIONS } from "../archive.constants";
-
-function getTextOrDefault(value: string | null | undefined, fallback: string): string {
-  if (typeof value !== "string") {
-    return fallback;
-  }
-  const trimmedValue = value.trim();
-  return trimmedValue.length > 0 ? trimmedValue : fallback;
-}
+import { getTextOrDefault } from "../utils/productionPageFunctions";
 
 function isFieldModified(
   original: string | undefined,

--- a/frontend/app/features/archive/components/ProductionInfoSection.tsx
+++ b/frontend/app/features/archive/components/ProductionInfoSection.tsx
@@ -4,14 +4,7 @@ import ComplexEditableField from "~/shared/components/ComplexEditableField";
 import SimpleEditableField from "~/shared/components/SimpleEditableField";
 import { ARCHIVE_PERMISSIONS } from "../archive.constants";
 
-function getTextOrDefault(value: string | null | undefined, fallback: string): string {
-  if (typeof value !== "string") {
-    return fallback;
-  }
-
-  const trimmedValue = value.trim();
-  return trimmedValue.length > 0 ? trimmedValue : fallback;
-}
+import { getTextOrDefault } from "../utils/productionPageFunctions";
 
 function isFieldModified(
   original: string | undefined,

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -3,7 +3,7 @@ import { ProductionHeader } from "../components/ProductionHeader";
 import { BackToCollectionLink } from "../components/BackToCollectionLink";
 import { useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import { useCallback, useEffect, useRef, useState, type SetStateAction } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProductionInfo } from "../types/productionTypes";
 import { EditButton } from "../components/EditButton";
 import { createProduction } from "../services/productionService";
@@ -12,7 +12,6 @@ import {
   useUnsavedChangesBlocker,
   isEmptyHtml,
 } from "../utils/productionPageFunctions";
-import type { Tag } from "../types/tagTypes";
 
 function isInfoModified(draftInfo: ProductionInfo | null): boolean {
   if (!draftInfo) return false;

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -1,10 +1,66 @@
 import { ProductionInfoSection } from "../components/ProductionInfoSection";
 import { ProductionHeader } from "../components/ProductionHeader";
 import { BackToCollectionLink } from "../components/BackToCollectionLink";
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProductionInfo } from "../types/productionTypes";
+import { EditButton } from "../components/EditButton";
+import { createProduction } from "../services/productionService";
+import { getSanitizedHtmlOrUndefined, useUnsavedChangesBlocker, isEmptyHtml } from "../utils/productionPageFunctions";
+
+function isInfoModified(draftInfo: ProductionInfo | null): boolean {
+  if (!draftInfo) return false;
+
+  return (
+    !!draftInfo.title ||
+    !!draftInfo.supertitle ||
+    !!draftInfo.artist ||
+    !!draftInfo.tagline ||
+    !!draftInfo.teaser ||
+    !!draftInfo.description ||
+    !!draftInfo.info
+  );
+}
+
+async function handleAddProduction(
+  language: string,
+  draftInfo: ProductionInfo | null,
+  setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
+  errorMessage: string,
+  skipWarning: React.RefObject<boolean>,
+  navigate: (path: string) => void,
+) {
+    if (!draftInfo) return;
+    setIsSaving(true);
+    
+    try {
+      const response = await createProduction({
+        production_info: {
+          language: language,
+          artist: draftInfo.artist,
+          title: draftInfo.title,
+          supertitle: draftInfo.supertitle,
+          tagline: draftInfo.tagline,
+          teaser: draftInfo.teaser,
+          description: draftInfo.description,
+          info: draftInfo.info, 
+        },
+        tag_id_urls: []
+      });
+      skipWarning.current = true;
+      
+      // Go to newly created production
+      const currentParts = window.location.pathname.split("/");
+      const responseParts = response["id_url"].split("/");
+      currentParts[currentParts.length - 1] = responseParts[responseParts.length - 1];
+      navigate(currentParts.join("/"));
+    } catch (e) {
+      window.alert(`${errorMessage}: ${e}`);
+    } finally {
+      setIsSaving(false);
+    }
+}
 
 export function CreateProductionPageAccessDenied() {
   const { t } = useTranslation();
@@ -29,6 +85,7 @@ export function CreateProductionPageAccessDenied() {
 
 export function CreateProductionPage() {
   const { lang } = useParams();
+  const language = lang ?? "nl";
   const { t } = useTranslation();
   const [draftInfo, setDraftInfo] = useState<ProductionInfo | null>({
     production_id_url: "",
@@ -41,12 +98,40 @@ export function CreateProductionPage() {
     description: "",
     info: "",
   });
-  const [, setIsQuillDirty] = useState(false);
+  const [isQuillDirty, setIsQuillDirty] = useState(false);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const skipWarning = useRef(false);
+  useUnsavedChangesBlocker(!skipWarning.current && (isInfoModified(draftInfo) || isQuillDirty));  const navigate = useNavigate();
 
+  const _handleAddProduction = () => handleAddProduction(language, draftInfo, setIsSaving, t("archive.create_error"), skipWarning, navigate);
   // TODO
   const fallbackImageUrl =
     "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
+
   const imageUrl = fallbackImageUrl;
+  const teaserHtml = getSanitizedHtmlOrUndefined(draftInfo?.teaser)
+  const descriptionHtml = getSanitizedHtmlOrUndefined(draftInfo?.description)
+  const infoHtml = getSanitizedHtmlOrUndefined(draftInfo?.info)
+
+  // warning if going to another url when edits are not saved.
+  const isModifiedRef = useRef(false);
+  const isQuillDirtyRef = useRef(false);
+
+  useEffect(() => {
+    isModifiedRef.current = isInfoModified(draftInfo);
+    isQuillDirtyRef.current = isQuillDirty;
+  }, [draftInfo, isQuillDirty]);
+
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (skipWarning.current) return;
+      if (isModifiedRef.current || isQuillDirtyRef.current) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, []);
 
   return (
     <div className="bg-archive-paper text-archive-ink min-h-screen">
@@ -68,14 +153,13 @@ export function CreateProductionPage() {
               isCreateInfo={true}
               tagline={draftInfo?.tagline ?? ""}
               originalTagline={undefined}
-              teaserHtml={undefined}
-              descriptionHtml={undefined}
-              infoHtml={undefined}
+              teaserHtml={teaserHtml}
+              descriptionHtml={descriptionHtml}
+              infoHtml={infoHtml}
               isEditing={true}
               onSave={(field, html) => {
-                const isEmpty = html === "<p><br></p>" || html === "";
                 setDraftInfo((prev) =>
-                  prev ? { ...prev, [field]: isEmpty ? null : html } : prev
+                  prev ? { ...prev, [field]: isEmptyHtml(html) ? null : html } : prev
                 );
               }}
               onQuillDirtyChange={useCallback(
@@ -85,6 +169,22 @@ export function CreateProductionPage() {
             />
           </article>
         </section>
+         <div className="fixed right-6 bottom-6 z-50 flex gap-3">
+            <EditButton
+              action={t("archive.create_production")}
+              isEditing={true}
+              setIsEditing={()=>{}}
+              originalInfo={null}
+              setDraftInfo={setDraftInfo}
+              originalEvents={[]}
+              setDraftEvents={()=>{}}
+              setNewEvents={()=>{}}
+              setDeletedEvents={()=>{}}
+              enable_save={isInfoModified(draftInfo) || isQuillDirty}
+              is_saving={isSaving}
+              _handleSave={_handleAddProduction}
+            />
+          </div>
       </main>
     </div>
   );

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -158,7 +158,9 @@ export function CreateProductionPage() {
       <title>{`${t("nav.create_production")} | VIERNULVIER`}</title>
       <main className="mx-auto flex w-full max-w-[1400px] flex-col gap-4 px-6 pt-10 pb-16 md:px-12">
         <BackToCollectionLink />
-        <h1 className="mb-2 font-serif text-3xl italic">{t("archive.create_production")}</h1>
+        <h1 className="mb-2 font-serif text-3xl italic">
+          {t("archive.create_production")}
+        </h1>
         <ProductionHeader
           production_info={null}
           image_url={imageUrl}

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -3,7 +3,7 @@ import { ProductionHeader } from "../components/ProductionHeader";
 import { BackToCollectionLink } from "../components/BackToCollectionLink";
 import { useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type SetStateAction } from "react";
 import type { ProductionInfo } from "../types/productionTypes";
 import { EditButton } from "../components/EditButton";
 import { createProduction } from "../services/productionService";
@@ -12,6 +12,7 @@ import {
   useUnsavedChangesBlocker,
   isEmptyHtml,
 } from "../utils/productionPageFunctions";
+import type { Tag } from "../types/tagTypes";
 
 function isInfoModified(draftInfo: ProductionInfo | null): boolean {
   if (!draftInfo) return false;
@@ -206,6 +207,8 @@ export function CreateProductionPage() {
             enable_save={isInfoModified(draftInfo) || isQuillDirty}
             is_saving={isSaving}
             _handleSave={_handleAddProduction}
+            originalTags={null}
+            setDraftTags={() => {}}
           />
         </div>
       </main>

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -33,6 +33,7 @@ async function handleAddProduction(
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
   errorMessage: string,
   skipWarning: React.RefObject<boolean>,
+  setSkipWarning: React.Dispatch<React.SetStateAction<boolean>>,
   navigate: (path: string) => void
 ) {
   if (!draftInfo) return;
@@ -53,6 +54,7 @@ async function handleAddProduction(
       tag_id_urls: [],
     });
     skipWarning.current = true;
+    setSkipWarning(true);
 
     // Go to newly created production
     const currentParts = window.location.pathname.split("/");
@@ -105,8 +107,10 @@ export function CreateProductionPage() {
   const [isQuillDirty, setIsQuillDirty] = useState(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const skipWarning = useRef(false);
+  const [skipWarningState, setSkipWarningState] = useState(false);
+
   useUnsavedChangesBlocker(
-    !skipWarning.current && (isInfoModified(draftInfo) || isQuillDirty)
+    !skipWarningState && !isSaving && (isInfoModified(draftInfo) || isQuillDirty)
   );
   const navigate = useNavigate();
 
@@ -117,6 +121,7 @@ export function CreateProductionPage() {
       setIsSaving,
       t("archive.create_error"),
       skipWarning,
+      setSkipWarningState,
       navigate
     );
   // TODO

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -158,6 +158,7 @@ export function CreateProductionPage() {
       <title>{`${t("nav.create_production")} | VIERNULVIER`}</title>
       <main className="mx-auto flex w-full max-w-[1400px] flex-col gap-4 px-6 pt-10 pb-16 md:px-12">
         <BackToCollectionLink />
+        <h1 className="mb-2 font-serif text-3xl italic">{t("archive.create_production")}</h1>
         <ProductionHeader
           production_info={null}
           image_url={imageUrl}

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -7,7 +7,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { ProductionInfo } from "../types/productionTypes";
 import { EditButton } from "../components/EditButton";
 import { createProduction } from "../services/productionService";
-import { getSanitizedHtmlOrUndefined, useUnsavedChangesBlocker, isEmptyHtml } from "../utils/productionPageFunctions";
+import {
+  getSanitizedHtmlOrUndefined,
+  useUnsavedChangesBlocker,
+  isEmptyHtml,
+} from "../utils/productionPageFunctions";
 
 function isInfoModified(draftInfo: ProductionInfo | null): boolean {
   if (!draftInfo) return false;
@@ -29,37 +33,37 @@ async function handleAddProduction(
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
   errorMessage: string,
   skipWarning: React.RefObject<boolean>,
-  navigate: (path: string) => void,
+  navigate: (path: string) => void
 ) {
-    if (!draftInfo) return;
-    setIsSaving(true);
-    
-    try {
-      const response = await createProduction({
-        production_info: {
-          language: language,
-          artist: draftInfo.artist,
-          title: draftInfo.title,
-          supertitle: draftInfo.supertitle,
-          tagline: draftInfo.tagline,
-          teaser: draftInfo.teaser,
-          description: draftInfo.description,
-          info: draftInfo.info, 
-        },
-        tag_id_urls: []
-      });
-      skipWarning.current = true;
-      
-      // Go to newly created production
-      const currentParts = window.location.pathname.split("/");
-      const responseParts = response["id_url"].split("/");
-      currentParts[currentParts.length - 1] = responseParts[responseParts.length - 1];
-      navigate(currentParts.join("/"));
-    } catch (e) {
-      window.alert(`${errorMessage}: ${e}`);
-    } finally {
-      setIsSaving(false);
-    }
+  if (!draftInfo) return;
+  setIsSaving(true);
+
+  try {
+    const response = await createProduction({
+      production_info: {
+        language: language,
+        artist: draftInfo.artist,
+        title: draftInfo.title,
+        supertitle: draftInfo.supertitle,
+        tagline: draftInfo.tagline,
+        teaser: draftInfo.teaser,
+        description: draftInfo.description,
+        info: draftInfo.info,
+      },
+      tag_id_urls: [],
+    });
+    skipWarning.current = true;
+
+    // Go to newly created production
+    const currentParts = window.location.pathname.split("/");
+    const responseParts = response["id_url"].split("/");
+    currentParts[currentParts.length - 1] = responseParts[responseParts.length - 1];
+    navigate(currentParts.join("/"));
+  } catch (e) {
+    window.alert(`${errorMessage}: ${e}`);
+  } finally {
+    setIsSaving(false);
+  }
 }
 
 export function CreateProductionPageAccessDenied() {
@@ -101,17 +105,28 @@ export function CreateProductionPage() {
   const [isQuillDirty, setIsQuillDirty] = useState(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const skipWarning = useRef(false);
-  useUnsavedChangesBlocker(!skipWarning.current && (isInfoModified(draftInfo) || isQuillDirty));  const navigate = useNavigate();
+  useUnsavedChangesBlocker(
+    !skipWarning.current && (isInfoModified(draftInfo) || isQuillDirty)
+  );
+  const navigate = useNavigate();
 
-  const _handleAddProduction = () => handleAddProduction(language, draftInfo, setIsSaving, t("archive.create_error"), skipWarning, navigate);
+  const _handleAddProduction = () =>
+    handleAddProduction(
+      language,
+      draftInfo,
+      setIsSaving,
+      t("archive.create_error"),
+      skipWarning,
+      navigate
+    );
   // TODO
   const fallbackImageUrl =
     "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
 
   const imageUrl = fallbackImageUrl;
-  const teaserHtml = getSanitizedHtmlOrUndefined(draftInfo?.teaser)
-  const descriptionHtml = getSanitizedHtmlOrUndefined(draftInfo?.description)
-  const infoHtml = getSanitizedHtmlOrUndefined(draftInfo?.info)
+  const teaserHtml = getSanitizedHtmlOrUndefined(draftInfo?.teaser);
+  const descriptionHtml = getSanitizedHtmlOrUndefined(draftInfo?.description);
+  const infoHtml = getSanitizedHtmlOrUndefined(draftInfo?.info);
 
   // warning if going to another url when edits are not saved.
   const isModifiedRef = useRef(false);
@@ -169,22 +184,22 @@ export function CreateProductionPage() {
             />
           </article>
         </section>
-         <div className="fixed right-6 bottom-6 z-50 flex gap-3">
-            <EditButton
-              action={t("archive.create_production")}
-              isEditing={true}
-              setIsEditing={()=>{}}
-              originalInfo={null}
-              setDraftInfo={setDraftInfo}
-              originalEvents={[]}
-              setDraftEvents={()=>{}}
-              setNewEvents={()=>{}}
-              setDeletedEvents={()=>{}}
-              enable_save={isInfoModified(draftInfo) || isQuillDirty}
-              is_saving={isSaving}
-              _handleSave={_handleAddProduction}
-            />
-          </div>
+        <div className="fixed right-6 bottom-6 z-50 flex gap-3">
+          <EditButton
+            action={t("archive.create_production")}
+            isEditing={true}
+            setIsEditing={() => {}}
+            originalInfo={null}
+            setDraftInfo={setDraftInfo}
+            originalEvents={[]}
+            setDraftEvents={() => {}}
+            setNewEvents={() => {}}
+            setDeletedEvents={() => {}}
+            enable_save={isInfoModified(draftInfo) || isQuillDirty}
+            is_saving={isSaving}
+            _handleSave={_handleAddProduction}
+          />
+        </div>
       </main>
     </div>
   );

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -2,7 +2,12 @@ import { useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import Add from "@mui/icons-material/Add";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getSanitizedHtmlOrUndefined, getTextOrDefault, useUnsavedChangesBlocker, isEmptyHtml } from "../utils/productionPageFunctions";
+import {
+  getSanitizedHtmlOrUndefined,
+  getTextOrDefault,
+  useUnsavedChangesBlocker,
+  isEmptyHtml,
+} from "../utils/productionPageFunctions";
 
 import type {
   Production,

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -134,7 +134,7 @@ async function handleInfoSave(
   skipUnloadWarning: React.RefObject<boolean>,
   setSkipWarning: React.Dispatch<React.SetStateAction<boolean>>
 ) {
-  if (!draftInfo || !originalInfo) return;
+  if (!draftInfo) return;
   setIsSaving(true);
   try {
     await updateProductionByUrl(production_id_url, {

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -2,7 +2,7 @@ import { useBlocker, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import Add from "@mui/icons-material/Add";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import DOMPurify from "dompurify";
+import { getSanitizedHtmlOrUndefined, getTextOrDefault } from "../utils/productionPageFunctions";
 
 import type {
   Production,
@@ -48,30 +48,6 @@ function getProductionInfoByLanguage(
     return languageMatch;
   }
   return null;
-}
-
-function getTextOrDefault(value: string | null | undefined, fallback: string): string {
-  if (typeof value !== "string") {
-    return fallback;
-  }
-
-  const trimmedValue = value.trim();
-  return trimmedValue.length > 0 ? trimmedValue : fallback;
-}
-
-function getSanitizedHtmlOrUndefined(
-  value: string | null | undefined
-): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const trimmedValue = value.trim();
-  if (trimmedValue.length === 0) {
-    return undefined;
-  }
-
-  return DOMPurify.sanitize(trimmedValue);
 }
 
 function getEventTimestamp(startsAt?: string): number {
@@ -675,7 +651,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
               infoHtml={infoHtml}
               isEditing={isEditing}
               onSave={(field, html) => {
-                const isEmpty = html === "<p><br></p>" || html === "";
+                const isEmpty = html === "<p><br></p>" || html === "" || html === "<p></p>";
                 setDraftInfo((prev) =>
                   prev ? { ...prev, [field]: isEmpty ? null : html } : prev
                 );

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -1,8 +1,8 @@
-import { useBlocker, useParams } from "react-router";
+import { useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import Add from "@mui/icons-material/Add";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getSanitizedHtmlOrUndefined, getTextOrDefault } from "../utils/productionPageFunctions";
+import { getSanitizedHtmlOrUndefined, getTextOrDefault, useUnsavedChangesBlocker, isEmptyHtml } from "../utils/productionPageFunctions";
 
 import type {
   Production,
@@ -206,32 +206,6 @@ async function handleInfoSave(
   } finally {
     setIsSaving(false);
   }
-}
-
-function useUnsavedChangesBlocker(when: boolean) {
-  const blocker = useBlocker(when);
-  const blockerRef = useRef(blocker);
-  const { t } = useTranslation();
-
-  useEffect(() => {
-    blockerRef.current = blocker;
-  });
-
-  const tRef = useRef(t);
-  useEffect(() => {
-    tRef.current = t;
-  });
-
-  useEffect(() => {
-    if (blockerRef.current.state === "blocked") {
-      const confirmLeave = window.confirm(tRef.current("notSaveChanges"));
-      if (confirmLeave) {
-        blockerRef.current.proceed();
-      } else {
-        blockerRef.current.reset();
-      }
-    }
-  }, [blocker.state]);
 }
 
 type TagsProps = {
@@ -651,9 +625,8 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
               infoHtml={infoHtml}
               isEditing={isEditing}
               onSave={(field, html) => {
-                const isEmpty = html === "<p><br></p>" || html === "" || html === "<p></p>";
                 setDraftInfo((prev) =>
-                  prev ? { ...prev, [field]: isEmpty ? null : html } : prev
+                  prev ? { ...prev, [field]: isEmptyHtml(html) ? null : html } : prev
                 );
               }}
               onQuillDirtyChange={useCallback(

--- a/frontend/app/features/archive/utils/productionPageFunctions.ts
+++ b/frontend/app/features/archive/utils/productionPageFunctions.ts
@@ -4,17 +4,27 @@ import { useTranslation } from "react-i18next";
 import { useBlocker } from "react-router";
 
 export function isEmptyHtml(html: string): boolean {
-  return html.trim().replace(/<p>(<br>)?<\/p>/g, "").trim().length === 0;
+  return (
+    html
+      .trim()
+      .replace(/<p>(<br>)?<\/p>/g, "")
+      .trim().length === 0
+  );
 }
 
-export function getSanitizedHtmlOrUndefined(value: string | null | undefined): string | undefined {
+export function getSanitizedHtmlOrUndefined(
+  value: string | null | undefined
+): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   if (trimmed.length === 0 || isEmptyHtml(trimmed)) return undefined;
   return DOMPurify.sanitize(trimmed);
 }
 
-export function getTextOrDefault(value: string | null | undefined, fallback: string): string {
+export function getTextOrDefault(
+  value: string | null | undefined,
+  fallback: string
+): string {
   if (typeof value !== "string") {
     return fallback;
   }

--- a/frontend/app/features/archive/utils/productionPageFunctions.ts
+++ b/frontend/app/features/archive/utils/productionPageFunctions.ts
@@ -1,9 +1,16 @@
 import DOMPurify from "dompurify";
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useBlocker } from "react-router";
+
+export function isEmptyHtml(html: string): boolean {
+  return html.trim().replace(/<p>(<br>)?<\/p>/g, "").trim().length === 0;
+}
 
 export function getSanitizedHtmlOrUndefined(value: string | null | undefined): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
-  if (trimmed.length === 0 || trimmed === "<p><br></p>") return undefined;
+  if (trimmed.length === 0 || isEmptyHtml(trimmed)) return undefined;
   return DOMPurify.sanitize(trimmed);
 }
 
@@ -14,4 +21,30 @@ export function getTextOrDefault(value: string | null | undefined, fallback: str
 
   const trimmedValue = value.trim();
   return trimmedValue.length > 0 ? trimmedValue : fallback;
+}
+
+export function useUnsavedChangesBlocker(when: boolean) {
+  const blocker = useBlocker(when);
+  const blockerRef = useRef(blocker);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    blockerRef.current = blocker;
+  });
+
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  });
+
+  useEffect(() => {
+    if (blockerRef.current.state === "blocked") {
+      const confirmLeave = window.confirm(tRef.current("notSaveChanges"));
+      if (confirmLeave) {
+        blockerRef.current.proceed();
+      } else {
+        blockerRef.current.reset();
+      }
+    }
+  }, [blocker.state]);
 }

--- a/frontend/app/features/archive/utils/productionPageFunctions.ts
+++ b/frontend/app/features/archive/utils/productionPageFunctions.ts
@@ -1,0 +1,17 @@
+import DOMPurify from "dompurify";
+
+export function getSanitizedHtmlOrUndefined(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed === "<p><br></p>") return undefined;
+  return DOMPurify.sanitize(trimmed);
+}
+
+export function getTextOrDefault(value: string | null | undefined, fallback: string): string {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : fallback;
+}

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -132,7 +132,7 @@
       "info": "Info"
     },
     "delete": {
-      "delete": "Delete",
+      "delete": "Delete info (en)",
       "confirm": "Are you sure you want to delete this production info? This action cannot be undone.",
       "error": "Error: Each production should have info in at least one language."
     }

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -42,6 +42,7 @@
       "subtext": "Change your search to contain less filters or keywords"
     },
     "create_production": "Create production",
+    "create_error": "Error whilst creating production: ",
     "accessDenied": {
       "sectionLabel": "Restricted area",
       "title": "You do not have access to the production creation page.",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -132,7 +132,7 @@
       "info": "Info"
     },
     "delete": {
-      "delete": "Verwijder",
+      "delete": "Verwijder info (nl)",
       "confirm": "Weet je zeker dat je deze productie-informatie wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
       "error": "Error: Elke productie heeft info in minstens één taal."
     }

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -53,6 +53,7 @@
       "subtext": "Pas je zoekopdracht aan om minder filter- of trefwoorden te bevatten"
     },
     "create_production": "Nieuwe productie",
+    "create_error": "Error tijdens aanmaken van productie: ",
     "accessDenied": {
       "sectionLabel": "Beperkt gebied",
       "title": "Je hebt geen toegang tot blogcreatie",

--- a/frontend/app/shared/components/ComplexEditableField.tsx
+++ b/frontend/app/shared/components/ComplexEditableField.tsx
@@ -98,6 +98,10 @@ export default function ComplexEditableField({
   if (isEditing) {
     return (
       <Protected permissions={permissions}>
+        <div className="flex items-center gap-2">
+          <p className="font-bold underline">{field}</p>
+          <FiEdit2 />
+        </div>
         <div id={id}>
           <ArchiveRichTextFieldWrapper
             label={field}

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -29,6 +29,7 @@ const translationMap: Record<string, TranslationValue> = {
   "home.buttons.history": "I18N_Home_Button_History",
   "archive.title": "I18N_Archive_Title",
   "archive.create_production": "I18_Archive_Create_Production",
+  "archive.add_info.title": "I18_Archive_addInfo_Title",
   "archive.accessDenied.title": "I18N_Archive_Access_Denied_Title",
   "archive.accessDenied.description": "I18N_Archive_Access_Denied_Description",
   "history.title": "I18N_History_Title",
@@ -100,6 +101,8 @@ const translationMap: Record<string, TranslationValue> = {
   "productionPage.edit.title": "I18N_ProductionInfo_Edit_Title",
   "productionPage.edit.teaser": "I18N_ProductionInfo_Edit_Teaser",
   "productionPage.edit.description": "I18N_ProductionInfo_Edit_Description",
+  "productionPage.edit.save": "I18N_ProductionPage_Edit_Save",
+  "productionPage.edit.cancel": "I18N_ProductionPage_Edit_Cancel",  
 };
 
 const mockTranslate = (key: string, options?: TranslationOptions) => {

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -102,7 +102,7 @@ const translationMap: Record<string, TranslationValue> = {
   "productionPage.edit.teaser": "I18N_ProductionInfo_Edit_Teaser",
   "productionPage.edit.description": "I18N_ProductionInfo_Edit_Description",
   "productionPage.edit.save": "I18N_ProductionPage_Edit_Save",
-  "productionPage.edit.cancel": "I18N_ProductionPage_Edit_Cancel",  
+  "productionPage.edit.cancel": "I18N_ProductionPage_Edit_Cancel",
 };
 
 const mockTranslate = (key: string, options?: TranslationOptions) => {

--- a/frontend/tests/unit/CreateProductionPage.test.tsx
+++ b/frontend/tests/unit/CreateProductionPage.test.tsx
@@ -21,9 +21,10 @@ describe("CreateProductionPage", () => {
   beforeEach(() => {
     vi.spyOn(loginServiceModule, "restoreSession").mockResolvedValue(adminUser);
     vi.mocked(productionService.createProduction).mockResolvedValue({
-        id_url: "/api/productions/123", production_infos: [],
-        event_id_urls: [],
-        tags: []
+      id_url: "/api/productions/123",
+      production_infos: [],
+      event_id_urls: [],
+      tags: [],
     });
   });
 

--- a/frontend/tests/unit/CreateProductionPage.test.tsx
+++ b/frontend/tests/unit/CreateProductionPage.test.tsx
@@ -1,0 +1,81 @@
+import { screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderWithRouterAndTheme } from "tests/utils/renderWithRouterAndTheme";
+import userEvent from "@testing-library/user-event";
+import * as productionService from "~/features/archive/services/productionService";
+import * as loginServiceModule from "~/features/auth/services/loginService";
+
+vi.mock("~/features/archive/services/productionService");
+
+const adminUser = {
+  id: 1,
+  username: "testadmin",
+  isSuperUser: true,
+  roles: [],
+  permissions: ["archive:create"],
+  createdAt: "2024-01-01T00:00:00Z",
+  lastLoginAt: null,
+};
+
+describe("CreateProductionPage", () => {
+  beforeEach(() => {
+    vi.spyOn(loginServiceModule, "restoreSession").mockResolvedValue(adminUser);
+    vi.mocked(productionService.createProduction).mockResolvedValue({
+        id_url: "/api/productions/123", production_infos: [],
+        event_id_urls: [],
+        tags: []
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("save button is disabled when no fields are filled in", async () => {
+    renderWithRouterAndTheme({
+      useRealCreateProductionPage: true,
+      initialPath: "/archive/productions/create",
+    });
+
+    const saveButton = await screen.findByText("I18N_ProductionPage_Edit_Save");
+    expect(saveButton).toBeDisabled();
+  });
+
+  it("save button is enabled after filling in title", async () => {
+    const user = userEvent.setup();
+    renderWithRouterAndTheme({
+      useRealCreateProductionPage: true,
+      initialPath: "/archive/productions/create",
+    });
+
+    const titleInput = await screen.findByPlaceholderText("I18_Archive_addInfo_Title");
+    await user.type(titleInput, "Test productie");
+
+    const saveButton = await screen.findByText("I18N_ProductionPage_Edit_Save");
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it("filling in title and saving calls createProduction and navigates", async () => {
+    const user = userEvent.setup();
+    renderWithRouterAndTheme({
+      useRealCreateProductionPage: true,
+      initialPath: "/archive/productions/create",
+    });
+
+    const titleInput = await screen.findByPlaceholderText("I18_Archive_addInfo_Title");
+    await user.type(titleInput, "Test productie");
+
+    const saveButton = await screen.findByText("I18N_ProductionPage_Edit_Save");
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(productionService.createProduction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          production_info: expect.objectContaining({
+            title: "Test productie",
+          }),
+        })
+      );
+    });
+  });
+});

--- a/frontend/tests/unit/components/CreateProductionButton.test.tsx
+++ b/frontend/tests/unit/components/CreateProductionButton.test.tsx
@@ -7,7 +7,6 @@ import * as productionService from "~/features/archive/services/productionServic
 import * as productionGroupService from "~/features/archive/services/productionGroupService";
 import * as tagService from "~/features/archive/services/tagService";
 import * as loginServiceModule from "~/features/auth/services/loginService";
-import * as productionGroupService from "~/features/archive/services/productionGroupService";
 
 vi.mock("~/features/archive/services/productionService");
 vi.mock("~/features/archive/services/productionGroupService");

--- a/frontend/tests/unit/components/CreateProductionButton.test.tsx
+++ b/frontend/tests/unit/components/CreateProductionButton.test.tsx
@@ -5,10 +5,12 @@ import userEvent from "@testing-library/user-event";
 import * as artistService from "~/features/archive/services/artistService";
 import * as tagService from "~/features/archive/services/tagService";
 import * as loginServiceModule from "~/features/auth/services/loginService";
+import * as productionGroupService from "~/features/archive/services/productionGroupService";
 
 vi.mock("~/features/archive/services/productionService");
 vi.mock("~/features/archive/services/artistService");
 vi.mock("~/features/archive/services/tagService");
+vi.mock("~/features/archive/services/productionGroupService");
 
 const adminUser = {
   id: 1,
@@ -41,6 +43,7 @@ describe("CreateProductionButton", () => {
   beforeEach(() => {
     vi.mocked(artistService.getArtists).mockResolvedValue([]);
     vi.mocked(tagService.getAllTags).mockResolvedValue([]);
+    vi.mocked(productionGroupService.getAllProductionGroups).mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/frontend/tests/unit/components/EditButton.test.tsx
+++ b/frontend/tests/unit/components/EditButton.test.tsx
@@ -84,10 +84,10 @@ describe("EditButton", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "productionPage.edit.save" })
+        screen.getByRole("button", { name: "I18N_ProductionPage_Edit_Save" })
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "productionPage.edit.cancel" })
+        screen.getByRole("button", { name: "I18N_ProductionPage_Edit_Cancel" })
       ).toBeInTheDocument();
     });
   });
@@ -98,7 +98,7 @@ describe("EditButton", () => {
     renderEditButton({ isEditing: true });
 
     const cancelButton = await screen.findByRole("button", {
-      name: "productionPage.edit.cancel",
+      name: "I18N_ProductionPage_Edit_Cancel",
     });
 
     await user.click(cancelButton);
@@ -116,7 +116,7 @@ describe("EditButton", () => {
     renderEditButton({ isEditing: true });
 
     const saveButton = await screen.findByRole("button", {
-      name: "productionPage.edit.save",
+      name: "I18N_ProductionPage_Edit_Save",
     });
 
     await user.click(saveButton);
@@ -131,7 +131,7 @@ describe("EditButton", () => {
     });
 
     const saveButton = await screen.findByRole("button", {
-      name: "productionPage.edit.save",
+      name: "I18N_ProductionPage_Edit_Save",
     });
 
     expect(saveButton).toBeDisabled();

--- a/frontend/tests/unit/productionPageFunctions.test.ts
+++ b/frontend/tests/unit/productionPageFunctions.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isEmptyHtml, getSanitizedHtmlOrUndefined, getTextOrDefault, useUnsavedChangesBlocker } from "~/features/archive/utils/productionPageFunctions";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("dompurify", () => ({
+  default: {
+    sanitize: (input: string) => input,
+  },
+}));
+
+vi.mock("react-router", () => ({
+  useBlocker: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+
+
+describe("isEmptyHtml", () => {
+  it("gives true for empty string", () => {
+    expect(isEmptyHtml("")).toBe(true);
+  });
+
+  it("gives true for only whitespace", () => {
+    expect(isEmptyHtml("   ")).toBe(true);
+  });
+
+  it("gives true for <p><br></p>", () => {
+    expect(isEmptyHtml("<p><br></p>")).toBe(true);
+  });
+
+  it("gives true for <p></p>", () => {
+    expect(isEmptyHtml("<p></p>")).toBe(true);
+  });
+
+  it("gives true for for multiple empty paragraphs", () => {
+    expect(isEmptyHtml("<p><br></p><p></p><p><br></p>")).toBe(true);
+  });
+
+  it("gives false for paragraph with text", () => {
+    expect(isEmptyHtml("<p>Hallo wereld</p>")).toBe(false);
+  });
+
+  it("gives false for normal text", () => {
+    expect(isEmptyHtml("gewone tekst")).toBe(false);
+  });
+});
+
+describe("getSanitizedHtmlOrUndefined", () => {
+  it("gives undefined for null", () => {
+    expect(getSanitizedHtmlOrUndefined(null)).toBeUndefined();
+  });
+
+  it("gives undefined for undefined", () => {
+    expect(getSanitizedHtmlOrUndefined(undefined)).toBeUndefined();
+  });
+
+  it("gives undefined for empty string", () => {
+    expect(getSanitizedHtmlOrUndefined("")).toBeUndefined();
+  });
+
+  it("gives undefined for only whitespace", () => {
+    expect(getSanitizedHtmlOrUndefined("   ")).toBeUndefined();
+  });
+
+  it("gives undefined for empty HTML (<p><br></p>)", () => {
+    expect(getSanitizedHtmlOrUndefined("<p><br></p>")).toBeUndefined();
+  });
+
+  it("gives sanitized HTML for valid text", () => {
+    const result = getSanitizedHtmlOrUndefined("<p>Hallo</p>");
+    expect(result).toBe("<p>Hallo</p>");
+  });
+
+  it("trims whitespace", () => {
+    const result = getSanitizedHtmlOrUndefined("  <p>Tekst</p>  ");
+    expect(result).toBe("<p>Tekst</p>");
+  });
+});
+
+describe("getTextOrDefault", () => {
+  it("gives fallback for null", () => {
+    expect(getTextOrDefault(null, "standaard")).toBe("standaard");
+  });
+
+  it("gives fallback for undefined", () => {
+    expect(getTextOrDefault(undefined, "standaard")).toBe("standaard");
+  });
+
+  it("gives fallback for empty string", () => {
+    expect(getTextOrDefault("", "standaard")).toBe("standaard");
+  });
+
+  it("gives fallback for only whitespace", () => {
+    expect(getTextOrDefault("   ", "standaard")).toBe("standaard");
+  });
+
+  it("gives value if exists", () => {
+    expect(getTextOrDefault("echte waarde", "standaard")).toBe("echte waarde");
+  });
+
+  it("trims value", () => {
+    expect(getTextOrDefault("  hallo  ", "standaard")).toBe("hallo");
+  });
+});
+
+describe("useUnsavedChangesBlocker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls blocker.proceed if user confirms", async () => {
+    const proceed = vi.fn();
+    const reset = vi.fn();
+    const { useBlocker } = await import("react-router");
+
+    vi.mocked(useBlocker).mockReturnValue({
+        state: "blocked",
+        proceed,
+        reset,
+        location: {
+            pathname: "/test",
+            search: "",
+            hash: "",
+            state: null,
+            key: "default",
+            unstable_mask: undefined
+        },
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const { rerender } = renderHook(() => useUnsavedChangesBlocker(true));
+    rerender();
+
+    expect(proceed).toHaveBeenCalled();
+    expect(reset).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls blocker.reset if user confirms", async () => {
+    const proceed = vi.fn();
+    const reset = vi.fn();
+    const { useBlocker } = await import("react-router");
+
+    vi.mocked(useBlocker).mockReturnValue({
+        state: "blocked",
+        proceed,
+        reset,
+        location: {
+            pathname: "/test",
+            search: "",
+            hash: "",
+            state: null,
+            key: "default",
+            unstable_mask: undefined
+        },
+    });
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const { rerender } = renderHook(() => useUnsavedChangesBlocker(true));
+    rerender();
+
+    expect(proceed).toHaveBeenCalledTimes(0);
+    expect(reset).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/unit/productionPageFunctions.test.ts
+++ b/frontend/tests/unit/productionPageFunctions.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isEmptyHtml, getSanitizedHtmlOrUndefined, getTextOrDefault, useUnsavedChangesBlocker } from "~/features/archive/utils/productionPageFunctions";
+import {
+  isEmptyHtml,
+  getSanitizedHtmlOrUndefined,
+  getTextOrDefault,
+  useUnsavedChangesBlocker,
+} from "~/features/archive/utils/productionPageFunctions";
 import { renderHook } from "@testing-library/react";
 
 vi.mock("dompurify", () => ({
@@ -15,8 +20,6 @@ vi.mock("react-router", () => ({
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
-
-
 
 describe("isEmptyHtml", () => {
   it("gives true for empty string", () => {
@@ -117,17 +120,17 @@ describe("useUnsavedChangesBlocker", () => {
     const { useBlocker } = await import("react-router");
 
     vi.mocked(useBlocker).mockReturnValue({
-        state: "blocked",
-        proceed,
-        reset,
-        location: {
-            pathname: "/test",
-            search: "",
-            hash: "",
-            state: null,
-            key: "default",
-            unstable_mask: undefined
-        },
+      state: "blocked",
+      proceed,
+      reset,
+      location: {
+        pathname: "/test",
+        search: "",
+        hash: "",
+        state: null,
+        key: "default",
+        unstable_mask: undefined,
+      },
     });
     vi.spyOn(window, "confirm").mockReturnValue(true);
 
@@ -144,17 +147,17 @@ describe("useUnsavedChangesBlocker", () => {
     const { useBlocker } = await import("react-router");
 
     vi.mocked(useBlocker).mockReturnValue({
-        state: "blocked",
-        proceed,
-        reset,
-        location: {
-            pathname: "/test",
-            search: "",
-            hash: "",
-            state: null,
-            key: "default",
-            unstable_mask: undefined
-        },
+      state: "blocked",
+      proceed,
+      reset,
+      location: {
+        pathname: "/test",
+        search: "",
+        hash: "",
+        state: null,
+        key: "default",
+        unstable_mask: undefined,
+      },
     });
     vi.spyOn(window, "confirm").mockReturnValue(false);
 


### PR DESCRIPTION
### Beschrijving
Deze PR laat toe om een nieuwe productie aan te maken en alle info in te vullen. Algemene velden (attendance_mode, ...) kunnen nog niet toegevoegd (of bewerkt) worden. Dit komt in een aparte PR (zie issue #445). Dit breng ikzelf later in orde.

<img width="1839" height="791" alt="image" src="https://github.com/user-attachments/assets/de2f2796-8289-4298-8f8b-eba507d509c7" />


### Aangepaste delen
- frontend: productionpage, createproductionpage
- warnings van createProductionButton even opgelost
- enkele testen al toegevoegd


### Speciale opmerkingen
- Je zal zien dat het aanmaken van een productie komt bij producties met onbekende datum. Dit is logisch aangezien er nog geen events aan kunnen toegevoegd worden. @PurpleCosmic zal dit in een aparte PR in orde brengen.
- Heb ook een file gemaakt waarin al enkele veelgebruikte functies zitten (in util van archive). 
- Ik weet dat er 3 reviewers zijn. @PurpleCosmic is toegevoegd zodat hij al eens kan kijken voor die events toe te voegen en hoeft niet volledig te reviewen. Verder leek het me logisch om dezelfde reviewers van part1 te nemen :)


### Afhankelijkheden
Geen.


### Testen
Er zijn al enkele testen toegevoegd. De andere (voor de veldjes zelf) zullen gelijkaardig zijn aan die @BWindey momenteel aan het implementeren is. :)


Closes #434 

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
