### PR TITLE
[Subfeat] Scraper - update events

### DIFF
--- a/backend/src/worker/sync/update/event.py
+++ b/backend/src/worker/sync/update/event.py
@@ -37,6 +37,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
                 api_event_to_model_event(json_event)
             )
 
+            # Find the event to update in our database
             existing_event: Event = db_session.scalar(
                 select(Event).where(
                     Event.viernulvier_id == updated_event.viernulvier_id
@@ -74,6 +75,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
             if viernulvier_hall_id:
                 internal_hall_id = hall_map.get(viernulvier_hall_id)
                 if not internal_hall_id:
+                    # Linked hall not in our DB, ignoring
                     logger.warning(
                         f"[UPDATE] Event "
                         f"(viernulvier_id={updated_event.viernulvier_id}) "
@@ -82,6 +84,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
                         "Not updating the hall for this event."
                     )
                 elif internal_hall_id != existing_event.hall_id:
+                    # Linked hall is different, updating event
                     old_hall_vnv_id = (
                         existing_event.hall.viernulvier_id
                         if existing_event.hall
@@ -94,6 +97,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
                     )
                     existing_event.hall_id = old_hall_vnv_id
             elif existing_event.hall_id:
+                # Hall got deleted
                 logger.info(
                     f"[UPDATE] hall for "
                     f"Event(viernulvier_id={existing_event.viernulvier_id})"
@@ -102,6 +106,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
                 )
                 existing_event.hall_id = None
 
+            # Update the simple fields that do not depend on other tables in DB
             sync_simple_fields(
                 existing_event,
                 updated_event,
@@ -112,6 +117,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
             # No need to call db_session.merge(), it already is updated by
             # sqlalchemy
 
+            # Set newest_timestamp to later update sync_state DB table
             updated_at_str = json_event.get("updated_at")
             if updated_at_str:
                 updated_at = datetime.fromisoformat(updated_at_str)

--- a/backend/src/worker/sync/update/event.py
+++ b/backend/src/worker/sync/update/event.py
@@ -95,7 +95,7 @@ def store_updated_events(db_session: Session, events: list[dict]):
                         f"'{old_hall_vnv_id}' to '{viernulvier_hall_id}' "
                         f"for Event(viernulvier_id={existing_event.viernulvier_id})"
                     )
-                    existing_event.hall_id = old_hall_vnv_id
+                    existing_event.hall_id = internal_hall_id
             elif existing_event.hall_id:
                 # Hall got deleted
                 logger.info(

--- a/backend/src/worker/sync/update/event.py
+++ b/backend/src/worker/sync/update/event.py
@@ -122,6 +122,8 @@ def store_updated_events(db_session: Session, events: list[dict]):
             logger.error(f"Error updating event ({json_event}):\n{e}")
 
     if deletes > 2:
-        logger.warning(f"[UPDATE] Deleted {deletes} events due to no valid production_id")
+        logger.warning(
+            f"[UPDATE] Deleted {deletes} events due to no valid production_id"
+        )
 
     return newest_timestamp

--- a/backend/src/worker/sync/update/event.py
+++ b/backend/src/worker/sync/update/event.py
@@ -1,0 +1,127 @@
+import logging
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import select
+from src.models.event import Event
+from src.models.hall import Hall
+from src.models.production import Production
+from src.worker.converters.event import api_event_to_model_event
+from src.worker.sync.update.utils import sync_simple_fields
+
+logger = logging.getLogger(__name__)
+
+
+def store_updated_events(db_session: Session, events: list[dict]):
+    newest_timestamp = None
+
+    existing_productions = db_session.execute(
+        select(Production.id, Production.viernulvier_id)
+    )
+    prod_map: dict[int, int] = {
+        prod_viernulvier_id: prod_id
+        for (prod_id, prod_viernulvier_id) in existing_productions
+    }
+
+    existing_halls = db_session.execute(select(Hall.id, Hall.viernulvier_id))
+    hall_map: dict[int, int] = {
+        hall_viernulvier_id: hall_id
+        for (hall_id, hall_viernulvier_id) in existing_halls
+    }
+
+    deletes = 0
+
+    for json_event in events:
+        try:
+            updated_event, viernulvier_prod_id, viernulvier_hall_id = (
+                api_event_to_model_event(json_event)
+            )
+
+            existing_event: Event = db_session.scalar(
+                select(Event).where(
+                    Event.viernulvier_id == updated_event.viernulvier_id
+                )
+            )
+
+            # Drop unknown events
+            if not existing_event:
+                continue
+
+            # Check if the event is tied to a valid production, else we would get a
+            # ForeignKey violation
+            if not viernulvier_prod_id or viernulvier_prod_id not in prod_map:
+                logger.warning(
+                    f"[UPDATE] Deleting stored event (viernulvier_id="
+                    f"{updated_event.viernulvier_id}) because its link to a production "
+                    "was removed"
+                )
+                db_session.delete(existing_event)
+                deletes += 1
+                continue
+
+            # Update production if needed
+            internal_prod_id = prod_map.get(viernulvier_prod_id)
+            if internal_prod_id != existing_event.production_id:
+                logger.info(
+                    f"[UPDATE] viernulvier_production_id changed from "
+                    f"'{existing_event.production.viernulvier_id}' to "
+                    f"'{viernulvier_prod_id}' "
+                    f"for Event(viernulvier_id={existing_event.viernulvier_id})"
+                )
+                existing_event.production_id = internal_prod_id
+
+            # Update hall if needed
+            if viernulvier_hall_id:
+                internal_hall_id = hall_map.get(viernulvier_hall_id)
+                if not internal_hall_id:
+                    logger.warning(
+                        f"[UPDATE] Event "
+                        f"(viernulvier_id={updated_event.viernulvier_id}) "
+                        f"references hall with viernulvier_id={viernulvier_hall_id}"
+                        ", but this hall does not exist in the database. "
+                        "Not updating the hall for this event."
+                    )
+                elif internal_hall_id != existing_event.hall_id:
+                    old_hall_vnv_id = (
+                        existing_event.hall.viernulvier_id
+                        if existing_event.hall
+                        else None
+                    )
+                    logger.info(
+                        f"[UPDATE] viernulvier_hall_id changed from "
+                        f"'{old_hall_vnv_id}' to '{viernulvier_hall_id}' "
+                        f"for Event(viernulvier_id={existing_event.viernulvier_id})"
+                    )
+                    existing_event.hall_id = old_hall_vnv_id
+            elif existing_event.hall_id:
+                logger.info(
+                    f"[UPDATE] hall for "
+                    f"Event(viernulvier_id={existing_event.viernulvier_id})"
+                    f" was deleted, deleting the reference to "
+                    f"Hall(viernulvier_id={existing_event.hall.viernulvier_id})"
+                )
+                existing_event.hall_id = None
+
+            sync_simple_fields(
+                existing_event,
+                updated_event,
+                ["starts_at", "ends_at", "order_url"],
+                "Event",
+            )
+
+            # No need to call db_session.merge(), it already is updated by
+            # sqlalchemy
+
+            updated_at_str = json_event.get("updated_at")
+            if updated_at_str:
+                updated_at = datetime.fromisoformat(updated_at_str)
+                if newest_timestamp is None or updated_at > newest_timestamp:
+                    newest_timestamp = updated_at
+
+        except Exception as e:
+            logger.error(f"Error updating event ({json_event}):\n{e}")
+
+    if deletes > 2:
+        logger.warning(f"[UPDATE] Deleted {deletes} events due to no valid production_id")
+
+    return newest_timestamp

--- a/backend/src/worker/sync/update/event.py
+++ b/backend/src/worker/sync/update/event.py
@@ -50,7 +50,8 @@ def store_updated_events(db_session: Session, events: list[dict]):
 
             # Check if the event is tied to a valid production, else we would get a
             # ForeignKey violation
-            if not viernulvier_prod_id or viernulvier_prod_id not in prod_map:
+            internal_prod_id = prod_map.get(viernulvier_prod_id)
+            if not viernulvier_prod_id or not internal_prod_id:
                 logger.warning(
                     f"[UPDATE] Deleting stored event (viernulvier_id="
                     f"{updated_event.viernulvier_id}) because its link to a production "
@@ -61,7 +62,6 @@ def store_updated_events(db_session: Session, events: list[dict]):
                 continue
 
             # Update production if needed
-            internal_prod_id = prod_map.get(viernulvier_prod_id)
             if internal_prod_id != existing_event.production_id:
                 logger.info(
                     f"[UPDATE] viernulvier_production_id changed from "

--- a/backend/src/worker/sync/update/utils.py
+++ b/backend/src/worker/sync/update/utils.py
@@ -1,0 +1,31 @@
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+# This is literally ONLY for local sqlite-based testing, because sqlite for
+# some stupid reason does not support timezones which ruins my nice logic
+def comparable(value):
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+
+        return value.astimezone(timezone.utc)
+
+    return value
+
+
+def sync_simple_fields(
+    existing_item, updated_item, simple_fields_to_sync, entity_label
+):
+    for field in simple_fields_to_sync:
+        old = getattr(existing_item, field)
+        new = getattr(updated_item, field)
+
+        if comparable(old) != comparable(new):
+            logger.info(
+                f"[UPDATE] {field} changed from '{old}' to '{new}' "
+                f"for {entity_label}(viernulvier_id={existing_item.viernulvier_id})"
+            )
+            setattr(existing_item, field, new)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,26 +1,24 @@
 # Configuratie van integratietesten
 import os
+import sqlite3
+from datetime import datetime, timezone
+from unittest.mock import Mock
 
 import pytest
-from datetime import datetime, timezone
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 from src.database import Base, get_db
 from src.main import app
-from src.models.production import ProdInfo, Production
-from src.models.event import Event
-from src.models.tag import Tag, TagName
-from src.models.blogs import Blog, BlogContent
-from src.models.production_group import ProductionGroup
-from src.services.language import Languages
 from src.models import Media
-
-from unittest.mock import Mock
+from src.models.blogs import Blog, BlogContent
+from src.models.event import Event
+from src.models.production import ProdInfo, Production
+from src.models.production_group import ProductionGroup
+from src.models.tag import Tag, TagName
+from src.services.language import Languages
 from src.services.media import get_minio_client
-
 
 # Laat CI/CD pipelines een echte PostgreSQL test database URL injecteren
 # via omgevingsvariabelen.
@@ -34,6 +32,15 @@ if TEST_DATABASE_URL.startswith("sqlite"):
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    # SQLite forceert foreign keys standaard niet.
+    # Activeer dit expliciet zodat lokale tests dichter bij PostgreSQL gedrag zitten.
+    @event.listens_for(test_engine, "connect")
+    def set_sqlite_pragma(dbapi_connection, connection_record):
+        if isinstance(dbapi_connection, sqlite3.Connection):
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON;")
+            cursor.close()
 else:
     # Voor PostgreSQL hebben we de SQLite-specifieke argumenten niet nodig
     if TEST_DATABASE_URL.startswith("postgresql://"):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,3 @@
-# Configuratie van integratietesten
 import os
 import sqlite3
 from datetime import datetime, timezone
@@ -20,12 +19,12 @@ from src.models.tag import Tag, TagName
 from src.services.language import Languages
 from src.services.media import get_minio_client
 
-# Laat CI/CD pipelines een echte PostgreSQL test database URL injecteren
-# via omgevingsvariabelen.
-# Val terug op in-memory SQLite voor snelle, lokale developer testen.
+# Let CI/CD pipelines inject a real PostgreSQL test database URL via
+# environment variables.
+# Fall back onto in-memory SQLite for faster local testing
 TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL", "sqlite://")
 
-# Configureer de engine op basis van het database type
+# Config database engine depending on type of database
 if TEST_DATABASE_URL.startswith("sqlite"):
     test_engine = create_engine(
         TEST_DATABASE_URL,
@@ -33,8 +32,8 @@ if TEST_DATABASE_URL.startswith("sqlite"):
         poolclass=StaticPool,
     )
 
-    # SQLite forceert foreign keys standaard niet.
-    # Activeer dit expliciet zodat lokale tests dichter bij PostgreSQL gedrag zitten.
+    # By default SQLite does not enforce foreign key constraingst, so we activate
+    # this explicitly to behave more closely like PostgreSQL
     @event.listens_for(test_engine, "connect")
     def set_sqlite_pragma(dbapi_connection, connection_record):
         if isinstance(dbapi_connection, sqlite3.Connection):
@@ -42,7 +41,6 @@ if TEST_DATABASE_URL.startswith("sqlite"):
             cursor.execute("PRAGMA foreign_keys=ON;")
             cursor.close()
 else:
-    # Voor PostgreSQL hebben we de SQLite-specifieke argumenten niet nodig
     if TEST_DATABASE_URL.startswith("postgresql://"):
         TEST_DATABASE_URL = TEST_DATABASE_URL.replace(
             "postgresql://", "postgresql+psycopg2://"
@@ -52,7 +50,7 @@ else:
 TEST_SESSION_LOCAL = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
 
 
-# Overschrijf dependency
+# Overwrite dependency
 def override_get_db():
     db = TEST_SESSION_LOCAL()
     try:
@@ -63,18 +61,19 @@ def override_get_db():
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_test_db():
-    # Maak tabellen aan voordat testen draaien
+    # Make the tables before starting tests
     Base.metadata.create_all(bind=test_engine)
     yield
-    # Verwijder tabellen nadat testen klaar zijn
+    # And remove them when tests are done
     Base.metadata.drop_all(bind=test_engine)
 
 
 @pytest.fixture(scope="function")
 def db_session():
     """
-    Levert een database sessie voor unit testen.
-    Omdat setup_test_db autouse=True is, zijn de tabellen al aangemaakt.
+    Yields a database session for unit tests.
+    Because setup_test_db() has autouse=True, the tables for this db will
+    already have been created.
     """
     db = TEST_SESSION_LOCAL()
     try:

--- a/backend/tests/unit/worker/update/test_update_events.py
+++ b/backend/tests/unit/worker/update/test_update_events.py
@@ -1,9 +1,3 @@
-"""
-Dit bestand gebruikt nogal veel van tests/unit/worker/test_stores.py.
-Superveel eigenlijk. Dit omdat het logisch is om eerst een store te doen,
-en daarna de data aan te passen om te updaten
-"""
-
 import logging
 from copy import deepcopy
 from datetime import datetime

--- a/backend/tests/unit/worker/update/test_update_events.py
+++ b/backend/tests/unit/worker/update/test_update_events.py
@@ -83,6 +83,9 @@ def test_store_updated_events_normal(db_session: Session, caplog):
     infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
     assert len(infos) == 2  # Changed starts_at and order_url
 
+    # NOTE: this order is implementation-dependant but should be deterministic
+    #       if order changes in src/worker/sync/update/event.py:113,
+    #       this might need to change as well
     assert infos[0].startswith("[UPDATE] starts_at changed from '")
     assert infos[0].endswith("' for Event(viernulvier_id=6169)")
 

--- a/backend/tests/unit/worker/update/test_update_events.py
+++ b/backend/tests/unit/worker/update/test_update_events.py
@@ -1,0 +1,296 @@
+"""
+Dit bestand gebruikt nogal veel van tests/unit/worker/test_stores.py.
+Superveel eigenlijk. Dit omdat het logisch is om eerst een store te doen,
+en daarna de data aan te passen om te updaten
+"""
+
+import logging
+from copy import deepcopy
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from src.models.event import Event
+from src.models.hall import Hall
+from src.models.production import Production
+from src.worker.sync.store.event import store_new_events
+from src.worker.sync.update.event import store_updated_events
+from src.worker.sync.update.utils import comparable
+
+# Real event data from the API, some fields removed
+BASE_EVENT = {
+    "@id": "/api/v1/events/6169",
+    "created_at": "2021-08-16T14:36:53+00:00",
+    "updated_at": "2025-09-16T07:33:34+00:00",
+    "starts_at": "2021-11-26T19:00:00+00:00",
+    "ends_at": "2021-11-26T20:00:00+00:00",
+    "hall": "/api/v1/halls/12",
+    "production": {
+        "@type": "StandardProduction",
+        "@id": "/api/v1/productions/4129",
+    },
+}
+
+
+# Helper function for some boilerplate, returns the created production to be
+# able to use its generated id
+def _add_normal_event_with_prod_and_hall(db_session: Session) -> Production:
+    # Add a dummy production to the DB so that an event can be stored
+    prod = Production(viernulvier_id=4129)
+    hall = Hall(viernulvier_id=12)
+    db_session.add_all([prod, hall])
+    db_session.commit()
+
+    # Store the events
+    store_new_events(db_session, [BASE_EVENT])
+    db_session.commit()
+    return prod, hall
+
+
+# Test if events are correctly put inside our database, or not when they
+# need not be added
+def test_store_updated_events_normal(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    prod, hall = _add_normal_event_with_prod_and_hall(db_session)
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["starts_at"] = "2021-11-26T18:00:00+00:00"
+    updated_event["external_order_url"] = {"nl": "https://www.example.org"}
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    db_session.commit()
+    assert timestamp == datetime.fromisoformat("2025-09-16T07:33:34+00:00")
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 1
+
+    db_event: Event = db_events[0]
+
+    # Check that all the fields are as expected
+    assert db_event.viernulvier_id == 6169
+    assert db_event.production_id == prod.id
+    assert db_event.hall_id == hall.id
+    assert comparable(db_event.starts_at) == datetime.fromisoformat(
+        "2021-11-26T18:00:00+00:00"
+    )
+    assert comparable(db_event.ends_at) == datetime.fromisoformat(
+        "2021-11-26T20:00:00+00:00"
+    )
+    assert db_event.order_url == "https://www.example.org"
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 2  # Changed starts_at and order_url
+
+    assert infos[0].startswith("[UPDATE] starts_at changed from '")
+    assert infos[0].endswith("' for Event(viernulvier_id=6169)")
+
+    assert infos[1] == (
+        "[UPDATE] order_url changed from 'None' to 'https://www.example.org' "
+        "for Event(viernulvier_id=6169)"
+    )
+
+
+def test_store_updated_events_update_prod(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_event_with_prod_and_hall(db_session)
+    prod2 = Production(viernulvier_id=323)
+    db_session.add(prod2)
+    db_session.commit()
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["production"] = {"@id": "/api/v1/productions/323"}
+
+    store_updated_events(db_session, [updated_event])
+    db_session.commit()
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 1
+
+    db_event: Event = db_events[0]
+
+    # Check that all the fields are as expected
+    assert db_event.viernulvier_id == 6169
+    assert db_event.production_id == prod2.id
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 1
+
+    assert infos[0] == (
+        "[UPDATE] viernulvier_production_id changed from '4129' to '323' "
+        "for Event(viernulvier_id=6169)"
+    )
+
+
+def test_store_updated_events_delete_production(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_event_with_prod_and_hall(db_session)
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["production"] = {"@id": "/api/v1/productions/1"}
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    db_session.commit()
+    assert timestamp is None
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 0
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 0
+
+    assert warnings[0] == (
+        "[UPDATE] Deleting stored event (viernulvier_id=6169) because its link "
+        "to a production was removed"
+    )
+
+
+def test_store_updated_events_update_hall_normal(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_event_with_prod_and_hall(db_session)
+    hall2 = Hall(viernulvier_id=57)
+    db_session.add(hall2)
+    db_session.commit()
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["hall"] = "/api/v1/halls/57"
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    db_session.commit()
+
+    assert timestamp is not None
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 1
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 1
+
+    assert infos[0] == (
+        "[UPDATE] viernulvier_hall_id changed from '12' to '57' "
+        "for Event(viernulvier_id=6169)"
+    )
+
+
+def test_store_updated_events_update_hall_unknown(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_event_with_prod_and_hall(db_session)
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["hall"] = "/api/v1/halls/57"
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    db_session.commit()
+
+    assert timestamp is not None
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 1
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 0
+
+    assert warnings[0] == (
+        "[UPDATE] Event (viernulvier_id=6169) references hall with "
+        "viernulvier_id=57, but this hall does not exist in the database. "
+        "Not updating the hall for this event."
+    )
+
+
+def test_store_updated_events_update_hall_delete(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_event_with_prod_and_hall(db_session)
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["hall"] = None
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    db_session.commit()
+
+    assert timestamp is not None
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 1
+    assert db_events[0].hall_id is None
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 1
+
+    assert infos[0] == (
+        "[UPDATE] hall for Event(viernulvier_id=6169) was deleted, deleting the "
+        "reference to Hall(viernulvier_id=12)"
+    )
+
+
+def test_store_updated_events_unknown_event(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_event_with_prod_and_hall(db_session)
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["@id"] = "/api/v1/events/1"
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    db_session.commit()
+    assert timestamp is None
+
+    db_events = db_session.scalars(select(Event)).all()
+    assert len(db_events) == 1
+
+
+def test_store_updated_events_general_error(db_session: Session, caplog):
+    caplog.set_level(logging.ERROR)
+    _add_normal_event_with_prod_and_hall(db_session)
+
+    updated_event = deepcopy(BASE_EVENT)
+    updated_event["@id"] = "strange things"
+
+    timestamp = store_updated_events(db_session, [updated_event])
+    assert timestamp is None
+
+    errors = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+
+    assert errors[0].startswith("Error updating event (")
+
+
+def test_store_updated_events_delete_count_warning(db_session, caplog):
+    caplog.set_level(logging.WARNING)
+
+    # Populate database with production and 6 events for that production
+    prod = Production(viernulvier_id=4129)
+    db_session.add(prod)
+    db_session.commit()
+
+    events = [deepcopy(BASE_EVENT) for _ in range(6)]
+    for i in range(len(events)):
+        events[i]["@id"] = f"/api/v1/events/{i + 3}"
+        del events[i]["hall"]
+
+    # Store the events
+    store_new_events(db_session, events)
+    db_session.commit()
+
+    # Now update the production URL's and check that the logger issued a warning
+    for i in range(len(events)):
+        events[i]["production"]["@id"] = "/api/v1/productions/900"
+
+    timestamp = store_updated_events(db_session, events)
+    assert timestamp is None
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1 + len(events)
+    assert (
+        warnings[-1]
+        == f"[UPDATE] Deleted {len(events)} events due to no valid production_id"
+    )

--- a/devx
+++ b/devx
@@ -331,7 +331,10 @@ function test_cmd() {
 			ci)
 				run docker compose -f docker-compose.ci.yml \
 					--project-name viernulvier-ci \
-					exec -T backend pytest tests/
+					up --build -d --wait
+				run docker compose -f docker-compose.ci.yml \
+					--project-name viernulvier-ci \
+					exec -T backend pytest "${3:-tests/}"
 				;;
 			esac
 	fi


### PR DESCRIPTION
### Beschrijving
Deze PR voegt code toe die de scraper toelaat om geupdatete events uit de API te verwerken en in onze databank samen te voegen met reeds bestaand events.


### Aangepaste delen
`backend/src/worker/sync/update/*` en overeenkomstige test.


### Testen
De toegevoegde code is 100% gecovered.


- [X] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
