### PR TITLE
[Subfeat] Scraper - update eventprices

### DIFF
--- a/backend/src/worker/sync/store/eventprice.py
+++ b/backend/src/worker/sync/store/eventprice.py
@@ -53,6 +53,8 @@ def store_new_eventprices(db_session: Session, eventprices: list[dict]):
                 orphans += 1
                 continue
 
+            eventprice.event_id = internal_event_id
+
             # Valid event id, so store this eventprice
             db_session.merge(eventprice)
 

--- a/backend/src/worker/sync/update/eventprice.py
+++ b/backend/src/worker/sync/update/eventprice.py
@@ -1,0 +1,89 @@
+import logging
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import select
+from src.models.event import Event, EventPrice
+from src.worker.converters.eventprice import api_eventprice_to_model_eventprice
+from src.worker.sync.update.utils import sync_simple_fields
+
+logger = logging.getLogger(__name__)
+
+
+def store_updated_eventprices(db_session: Session, eventprices: list[dict]):
+    newest_timestamp = None
+
+    existing_events = db_session.execute(select(Event.id, Event.viernulvier_id))
+    event_map: dict[int, int] = {
+        event_viernulvier_id: event_id
+        for event_id, event_viernulvier_id in existing_events
+    }
+
+    deletes = 0
+
+    for json_price in eventprices:
+        try:
+            updated_eventprice, viernulvier_event_id = (
+                api_eventprice_to_model_eventprice(json_price)
+            )
+
+            # Find the eventprice to update in our database
+            existing_price: EventPrice = db_session.scalar(
+                select(EventPrice).where(
+                    EventPrice.viernulvier_id == updated_eventprice.viernulvier_id
+                )
+            )
+
+            # Drop unknown price
+            if not existing_price:
+                continue
+
+            # Check if the eventprice is tied to a valid event, else we would get a
+            # ForeignKey violation
+            internal_event_id = event_map.get(viernulvier_event_id)
+            if not viernulvier_event_id or not internal_event_id:
+                logger.warning(
+                    f"[UPDATE] Deleting stored eventprice (viernulvier_id="
+                    f"{updated_eventprice.viernulvier_id}) because its link to "
+                    "an event was removed"
+                )
+                db_session.delete(existing_price)
+                deletes += 1
+                continue
+
+            # Update tied event if needed
+            if internal_event_id != existing_price.event_id:
+                logger.info(
+                    f"[UPDATE] viernulvier_event_id changed from "
+                    f"'{existing_price.event.viernulvier_id}' to "
+                    f"'{viernulvier_event_id}' "
+                    f"for EventPrice(viernulvier_id={existing_price.viernulvier_id})"
+                )
+                existing_price.event_id = internal_event_id
+
+            # Update the simple fields that are not linked to other DB tables
+            sync_simple_fields(
+                existing_price,
+                updated_eventprice,
+                ["amount", "available", "expires_at"],
+                "EventPrice",
+            )
+
+            # No need to call merge as sqlalchemy does that for us
+
+            # Set newest_timestamp to later update sync_state DB table
+            updated_at_str = json_price.get("updated_at")
+            if updated_at_str:
+                updated_at = datetime.fromisoformat(updated_at_str)
+                if newest_timestamp is None or updated_at > newest_timestamp:
+                    newest_timestamp = updated_at
+
+        except Exception as e:
+            logger.error(f"Error updating eventprice ({json_price}):\n{e}")
+
+    if deletes > 2:
+        logger.warning(
+            f"[UPDATE] Deleted {deletes} eventprices due to no valid event_id"
+        )
+
+    return newest_timestamp

--- a/backend/tests/unit/worker/update/test_update_eventprices.py
+++ b/backend/tests/unit/worker/update/test_update_eventprices.py
@@ -63,10 +63,8 @@ def test_store_updated_eventprices_normal(db_session: Session, caplog):
     # NOTE: this order is implementation-dependant but should be deterministic
     #       if order changes in src/worker/sync/update/eventprice.py:68,
     #       this might need to change as well
-    assert infos[0] == (
-        "[UPDATE] amount changed from '0E-10' to '3.14' for EventPrice"
-        "(viernulvier_id=14085)"
-    )
+    assert infos[0].startswith("[UPDATE] amount changed from '")
+    assert infos[0].endswith("' to '3.14' for EventPrice(viernulvier_id=14085)")
     assert infos[1] == (
         "[UPDATE] available changed from '0' to '52' for EventPrice"
         "(viernulvier_id=14085)"

--- a/backend/tests/unit/worker/update/test_update_eventprices.py
+++ b/backend/tests/unit/worker/update/test_update_eventprices.py
@@ -53,12 +53,12 @@ def test_store_updated_eventprices_normal(db_session: Session, caplog):
     assert db_price.event_id == event.id
     assert db_price.amount == Decimal("3.14")
     assert db_price.available == 52
-    assert db_price.expires_at is None             # Not set anywhere
+    assert db_price.expires_at is None  # Not set anywhere
 
     warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warnings) == 0
     infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
-    assert len(infos) == 2                  # Changed amount and available
+    assert len(infos) == 2  # Changed amount and available
 
     # NOTE: this order is implementation-dependant but should be deterministic
     #       if order changes in src/worker/sync/update/eventprice.py:68,

--- a/backend/tests/unit/worker/update/test_update_eventprices.py
+++ b/backend/tests/unit/worker/update/test_update_eventprices.py
@@ -1,0 +1,191 @@
+import logging
+from datetime import datetime
+from copy import deepcopy
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from src.models.event import Event, EventPrice
+from src.worker.sync.store.eventprice import store_new_eventprices
+from src.worker.sync.update.eventprice import store_updated_eventprices
+
+BASE_PRICE = {
+    "@id": "/api/v1/events/prices/14085",
+    "created_at": "2023-01-20T10:26:50+00:00",
+    "updated_at": "2023-03-04T11:16:07+00:00",
+    "available": 0,
+    "amount": "0.00",
+    "event": "/api/v1/events/8625",
+}
+
+
+def _add_normal_price_with_event(db_session: Session) -> Event:
+    event = Event(viernulvier_id=8625)
+    db_session.add(event)
+    db_session.commit()
+
+    store_new_eventprices(db_session, [BASE_PRICE])
+    db_session.commit()
+
+    return event
+
+
+# Test normal working
+def test_store_updated_eventprices_normal(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    event = _add_normal_price_with_event(db_session)
+
+    updated_price = deepcopy(BASE_PRICE)
+    updated_price["amount"] = "3.14"
+    updated_price["available"] = 52
+
+    timestamp = store_updated_eventprices(db_session, [updated_price])
+    db_session.commit()
+    assert timestamp == datetime.fromisoformat("2023-03-04T11:16:07+00:00")
+
+    db_prices = db_session.scalars(select(EventPrice)).all()
+    assert len(db_prices) == 1
+
+    db_price: EventPrice = db_prices[0]
+
+    # Check that all fields are as expected
+    assert db_price.viernulvier_id == 14085
+    assert db_price.event_id == event.id
+    assert db_price.amount == Decimal("3.14")
+    assert db_price.available == 52
+    assert db_price.expires_at is None             # Not set anywhere
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 2                  # Changed amount and available
+
+    # NOTE: this order is implementation-dependant but should be deterministic
+    #       if order changes in src/worker/sync/update/eventprice.py:68,
+    #       this might need to change as well
+    assert infos[0] == (
+        "[UPDATE] amount changed from '0E-10' to '3.14' for EventPrice"
+        "(viernulvier_id=14085)"
+    )
+    assert infos[1] == (
+        "[UPDATE] available changed from '0' to '52' for EventPrice"
+        "(viernulvier_id=14085)"
+    )
+
+
+def test_store_updated_eventprices_update_event(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_price_with_event(db_session)
+    event2 = Event(viernulvier_id=99)
+    db_session.add(event2)
+    db_session.commit()
+
+    updated_price = deepcopy(BASE_PRICE)
+    updated_price["event"] = "/api/v1/events/99"
+
+    store_updated_eventprices(db_session, [updated_price])
+    db_session.commit()
+
+    db_prices = db_session.scalars(select(EventPrice)).all()
+    assert len(db_prices) == 1
+
+    db_price: EventPrice = db_prices[0]
+
+    assert db_price.viernulvier_id == 14085
+    assert db_price.event_id == event2.id
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 0
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 1
+
+    assert infos[0] == (
+        "[UPDATE] viernulvier_event_id changed from '8625' to '99' "
+        "for EventPrice(viernulvier_id=14085)"
+    )
+
+
+def test_store_updated_eventprices_delete_event(db_session: Session, caplog):
+    caplog.set_level(logging.INFO)
+    _add_normal_price_with_event(db_session)
+
+    updated_price = deepcopy(BASE_PRICE)
+    updated_price["event"] = "/api/v1/events/99"
+
+    timestamp = store_updated_eventprices(db_session, [updated_price])
+    db_session.commit()
+    assert timestamp is None
+
+    db_prices = db_session.scalars(select(EventPrice)).all()
+    assert len(db_prices) == 0
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert len(infos) == 0
+
+    assert warnings[0] == (
+        "[UPDATE] Deleting stored eventprice (viernulvier_id=14085) because its"
+        " link to an event was removed"
+    )
+
+
+def test_store_updated_eventprices_unknown_eventprice(db_session: Session):
+    _add_normal_price_with_event(db_session)
+
+    # Create some new price object which' viernulvier_id is not present in DB
+    updated_price = deepcopy(BASE_PRICE)
+    updated_price["@id"] = "/api/v1/events/prices/20"
+
+    timestamp = store_updated_eventprices(db_session, [updated_price])
+    db_session.commit()
+    assert timestamp is None
+
+    # Old one is still present
+    assert len(db_session.scalars(select(EventPrice.id)).all()) == 1
+
+
+def test_store_updated_eventprices_general_error(db_session: Session, caplog):
+    caplog.set_level(logging.ERROR)
+    _add_normal_price_with_event(db_session)
+
+    updated_event = deepcopy(BASE_PRICE)
+    updated_event["@id"] = "mice and cheese are like cookies and milk but different"
+
+    timestamp = store_updated_eventprices(db_session, [updated_event])
+    assert timestamp is None
+
+    errors = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+    assert len(errors) == 1
+
+    assert errors[0].startswith("Error updating eventprice (")
+
+
+def test_store_updated_eventprices_delete_count_warning(db_session: Session, caplog):
+    caplog.set_level(logging.WARNING)
+
+    event = Event(viernulvier_id=8625)
+    db_session.add(event)
+    db_session.commit()
+
+    prices = [deepcopy(BASE_PRICE) for _ in range(6)]
+    for i in range(len(prices)):
+        prices[i]["@id"] = f"/api/v1/events/prices/{i + 3}"
+
+    store_new_eventprices(db_session, prices)
+    db_session.commit()
+
+    # Now update the event URL's and check that the logger issued warning for
+    # deleting all of them
+    for i in range(len(prices)):
+        prices[i]["event"] = "/api/v1/events/10"
+
+    timestamp = store_updated_eventprices(db_session, prices)
+    assert timestamp is None
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1 + len(prices)
+    assert (
+        warnings[-1]
+        == f"[UPDATE] Deleted {len(prices)} eventprices due to no valid event_id"
+    )


### PR DESCRIPTION
### Beschrijving
Deze PR introduceert code om geupdatete event prices uit de API te mergen in onze databank.

Voortzetting van #459 , maar nu voor eventprices ipv events. 

> [!WARNING]
> Bevat belangrijke bugfix: vroeger werden events blijkbaar nog niet gelinkt aan eventprices
> wat nu het geval is. Als je op deze branch dus eens je databank cleart en je
> de sync worker nog eens runt, dan zal je in de frontend eindelijk prijs info zien.



### Testen
100% covered



- [X] Goede testen toegevoegd.
- [X] Auteur wil zelf mergen.
