### PR TITLE
Add delete action for production groups

### DIFF
--- a/frontend/app/features/archive/components/CreateProductionGroupDialog.tsx
+++ b/frontend/app/features/archive/components/CreateProductionGroupDialog.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useState, type SubmitEvent } from "react";
-import axios from "axios";
 import {
-  Alert,
   Button,
   Checkbox,
   CircularProgress,
@@ -16,37 +14,18 @@ import { ArchiveTextField } from "~/shared/components/ArchiveTextField";
 
 import { createProductionGroup } from "../services/productionGroupService";
 import type { ProductionGroup } from "../types/productionGroupTypes";
-
-function getApiErrorMessage(error: unknown, fallbackMessage: string): string {
-  if (!axios.isAxiosError(error)) {
-    return fallbackMessage;
-  }
-
-  const detail = error.response?.data;
-
-  if (
-    detail &&
-    typeof detail === "object" &&
-    "detail" in detail &&
-    typeof detail.detail === "string"
-  ) {
-    return detail.detail;
-  }
-
-  return fallbackMessage;
-}
-
-function MutationAlert({ message }: { message: string | null }) {
-  if (!message) {
-    return null;
-  }
-
-  return (
-    <Alert severity="error" variant="outlined" sx={bannerSx}>
-      {message}
-    </Alert>
-  );
-}
+import {
+  getProductionGroupApiErrorMessage,
+  ProductionGroupMutationAlert,
+  productionGroupDialogActionsSx,
+  productionGroupDialogBackdropSx,
+  productionGroupDialogCheckboxSx,
+  productionGroupDialogContentSx,
+  productionGroupDialogPaperSx,
+  productionGroupDialogPrimaryButtonSx,
+  productionGroupDialogSecondaryButtonSx,
+  productionGroupDialogTitleSx,
+} from "./ProductionGroupDialog.shared";
 
 export function CreateProductionGroupDialog({
   open,
@@ -125,7 +104,10 @@ export function CreateProductionGroupDialog({
       onClose();
     } catch (error) {
       setErrorMessage(
-        getApiErrorMessage(error, t("archive.productionGroups.messages.createFailed"))
+        getProductionGroupApiErrorMessage(
+          error,
+          t("archive.productionGroups.messages.createFailed")
+        )
       );
     } finally {
       setIsSubmitting(false);
@@ -139,14 +121,14 @@ export function CreateProductionGroupDialog({
       fullWidth
       maxWidth="sm"
       slotProps={{
-        paper: { sx: dialogPaperSx },
-        backdrop: { sx: dialogBackdropSx },
+        paper: { sx: productionGroupDialogPaperSx },
+        backdrop: { sx: productionGroupDialogBackdropSx },
       }}
     >
-      <DialogTitle sx={dialogTitleSx}>
+      <DialogTitle sx={productionGroupDialogTitleSx}>
         {t("archive.productionGroups.dialog.title")}
       </DialogTitle>
-      <DialogContent sx={dialogContentSx}>
+      <DialogContent sx={productionGroupDialogContentSx}>
         <p className="mb-3 text-sm leading-relaxed text-(--archive-ink) opacity-70">
           {t("archive.productionGroups.dialog.description")}
         </p>
@@ -156,7 +138,7 @@ export function CreateProductionGroupDialog({
           })}
         </p>
 
-        <MutationAlert message={validationError || errorMessage} />
+        <ProductionGroupMutationAlert message={validationError || errorMessage} />
 
         <form
           id="create-production-group-form"
@@ -181,7 +163,7 @@ export function CreateProductionGroupDialog({
               <Checkbox
                 checked={isPublicFilter}
                 onChange={(event) => setIsPublicFilter(event.target.checked)}
-                sx={checkboxSx}
+                sx={productionGroupDialogCheckboxSx}
               />
               <span className="space-y-1 pt-0.5">
                 <span className="block text-sm font-medium text-(--archive-ink)">
@@ -195,15 +177,19 @@ export function CreateProductionGroupDialog({
           </div>
         </form>
       </DialogContent>
-      <DialogActions sx={dialogActionsSx}>
-        <Button onClick={handleClose} disabled={isSubmitting} sx={secondaryButtonSx}>
+      <DialogActions sx={productionGroupDialogActionsSx}>
+        <Button
+          onClick={handleClose}
+          disabled={isSubmitting}
+          sx={productionGroupDialogSecondaryButtonSx}
+        >
           {t("archive.productionGroups.actions.cancel")}
         </Button>
         <Button
           type="submit"
           form="create-production-group-form"
           disabled={isSubmitDisabled}
-          sx={primaryButtonSx}
+          sx={productionGroupDialogPrimaryButtonSx}
         >
           {isSubmitting ? (
             <>
@@ -218,83 +204,3 @@ export function CreateProductionGroupDialog({
     </Dialog>
   );
 }
-
-const bannerSx = {
-  "mt": 4,
-  "fontFamily": "var(--font-sans)",
-  "fontSize": "0.875rem",
-  "borderColor": "rgba(196, 164, 132, 0.4)",
-  "color": "var(--archive-ink)",
-  "& .MuiAlert-icon": { color: "var(--archive-accent)" },
-};
-
-const secondaryButtonSx = {
-  py: 1.15,
-  px: 2.35,
-  borderRadius: "999px",
-  textTransform: "none" as const,
-  fontFamily: "var(--font-sans)",
-  fontSize: "0.72rem",
-  fontWeight: 700,
-  letterSpacing: "0.18em",
-  color: "var(--archive-ink)",
-  border: "1px solid var(--archive-border)",
-};
-
-const primaryButtonSx = {
-  ...secondaryButtonSx,
-  "color": "#f6f0e8",
-  "borderColor": "transparent",
-  "backgroundColor": "var(--archive-accent)",
-  "&:hover": {
-    backgroundColor: "#92653e",
-  },
-};
-
-const dialogTitleSx = {
-  fontFamily: "var(--font-serif)",
-  fontStyle: "italic",
-  fontSize: "1.9rem",
-  color: "var(--archive-ink)",
-  pb: 1,
-  px: 3,
-  pt: 3,
-};
-
-const dialogContentSx = {
-  pt: "0.25rem !important",
-  pb: 1,
-  px: 3,
-  color: "var(--archive-ink)",
-};
-
-const dialogActionsSx = {
-  px: 3,
-  pt: 2,
-  pb: 3,
-  gap: 1.5,
-  borderTop: "1px solid var(--archive-border)",
-};
-
-const checkboxSx = {
-  "color": "rgba(196, 164, 132, 0.7)",
-  "padding": 0,
-  "mt": 0.25,
-  "&.Mui-checked": {
-    color: "var(--archive-accent)",
-  },
-};
-
-const dialogPaperSx = {
-  borderRadius: "1.75rem",
-  border: "1px solid var(--archive-border)",
-  backgroundColor: "var(--archive-surface-strong)",
-  color: "var(--archive-ink)",
-  backdropFilter: "blur(18px)",
-  boxShadow: "0 28px 90px rgba(0, 0, 0, 0.24)",
-};
-
-const dialogBackdropSx = {
-  backgroundColor: "rgba(17, 16, 14, 0.48)",
-  backdropFilter: "blur(4px)",
-};

--- a/frontend/app/features/archive/components/DeleteProductionGroupDialog.tsx
+++ b/frontend/app/features/archive/components/DeleteProductionGroupDialog.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+import { deleteProductionGroup } from "../services/productionGroupService";
+import type { ProductionGroup } from "../types/productionGroupTypes";
+import { getProductionGroupId } from "../utils/productionGroupFilters";
+import {
+  getProductionGroupApiErrorMessage,
+  ProductionGroupMutationAlert,
+  productionGroupDialogActionsSx,
+  productionGroupDialogBackdropSx,
+  productionGroupDialogContentSx,
+  productionGroupDialogDangerButtonSx,
+  productionGroupDialogPaperSx,
+  productionGroupDialogSecondaryButtonSx,
+  productionGroupDialogTitleSx,
+} from "./ProductionGroupDialog.shared";
+
+export function DeleteProductionGroupDialog({
+  productionGroup,
+  onClose,
+  onDeleted,
+}: {
+  productionGroup: ProductionGroup | null;
+  onClose: () => void;
+  onDeleted: (productionGroup: ProductionGroup) => void;
+}) {
+  const { t } = useTranslation();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetState = useCallback(() => {
+    setErrorMessage(null);
+    setIsSubmitting(false);
+  }, []);
+
+  useEffect(() => {
+    if (!productionGroup) {
+      resetState();
+    }
+  }, [productionGroup, resetState]);
+
+  function handleClose() {
+    if (isSubmitting) {
+      return;
+    }
+
+    resetState();
+    onClose();
+  }
+
+  async function handleDelete() {
+    if (!productionGroup) {
+      return;
+    }
+
+    const productionGroupId = Number.parseInt(
+      getProductionGroupId(productionGroup),
+      10
+    );
+
+    if (Number.isNaN(productionGroupId)) {
+      setErrorMessage(t("archive.productionGroups.messages.deleteFailed"));
+      return;
+    }
+
+    setErrorMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      await deleteProductionGroup(productionGroupId);
+      onDeleted(productionGroup);
+    } catch (error) {
+      setErrorMessage(
+        getProductionGroupApiErrorMessage(
+          error,
+          t("archive.productionGroups.messages.deleteFailed")
+        )
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={Boolean(productionGroup)}
+      onClose={isSubmitting ? undefined : handleClose}
+      fullWidth
+      maxWidth="sm"
+      slotProps={{
+        paper: { sx: productionGroupDialogPaperSx },
+        backdrop: { sx: productionGroupDialogBackdropSx },
+      }}
+    >
+      <DialogTitle sx={productionGroupDialogTitleSx}>
+        {t("archive.productionGroups.deleteDialog.title")}
+      </DialogTitle>
+      <DialogContent sx={productionGroupDialogContentSx}>
+        <p className="mb-3 text-sm leading-relaxed text-(--archive-ink) opacity-70">
+          {t("archive.productionGroups.deleteDialog.description", {
+            title: productionGroup?.title ?? "",
+          })}
+        </p>
+        <p className="mb-5 text-[0.72rem] font-bold tracking-[0.18em] uppercase opacity-55">
+          {t("archive.productionGroups.deleteDialog.selectedCount", {
+            count: productionGroup?.production_id_urls.length ?? 0,
+          })}
+        </p>
+        <p className="text-sm leading-relaxed text-(--archive-ink) opacity-65">
+          {t("archive.productionGroups.deleteDialog.warning")}
+        </p>
+
+        <ProductionGroupMutationAlert message={errorMessage} />
+      </DialogContent>
+      <DialogActions sx={productionGroupDialogActionsSx}>
+        <Button
+          onClick={handleClose}
+          disabled={isSubmitting}
+          sx={productionGroupDialogSecondaryButtonSx}
+        >
+          {t("archive.productionGroups.actions.cancel")}
+        </Button>
+        <Button
+          onClick={handleDelete}
+          disabled={isSubmitting}
+          sx={productionGroupDialogDangerButtonSx}
+        >
+          {isSubmitting ? (
+            <>
+              <CircularProgress size={13} sx={{ color: "inherit", mr: 1 }} />
+              {t("archive.productionGroups.actions.deleting")}
+            </>
+          ) : (
+            t("archive.productionGroups.deleteDialog.actions.delete")
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/app/features/archive/components/ProductionGroupDialog.shared.tsx
+++ b/frontend/app/features/archive/components/ProductionGroupDialog.shared.tsx
@@ -1,0 +1,125 @@
+import axios from "axios";
+import { Alert } from "@mui/material";
+
+export function getProductionGroupApiErrorMessage(
+  error: unknown,
+  fallbackMessage: string
+): string {
+  if (!axios.isAxiosError(error)) {
+    return fallbackMessage;
+  }
+
+  const detail = error.response?.data;
+
+  if (
+    detail &&
+    typeof detail === "object" &&
+    "detail" in detail &&
+    typeof detail.detail === "string"
+  ) {
+    return detail.detail;
+  }
+
+  return fallbackMessage;
+}
+
+export function ProductionGroupMutationAlert({ message }: { message: string | null }) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <Alert severity="error" variant="outlined" sx={productionGroupDialogBannerSx}>
+      {message}
+    </Alert>
+  );
+}
+
+const productionGroupDialogBannerSx = {
+  "mt": 4,
+  "fontFamily": "var(--font-sans)",
+  "fontSize": "0.875rem",
+  "borderColor": "rgba(196, 164, 132, 0.4)",
+  "color": "var(--archive-ink)",
+  "& .MuiAlert-icon": { color: "var(--archive-accent)" },
+};
+
+export const productionGroupDialogSecondaryButtonSx = {
+  py: 1.15,
+  px: 2.35,
+  borderRadius: "999px",
+  textTransform: "none" as const,
+  fontFamily: "var(--font-sans)",
+  fontSize: "0.72rem",
+  fontWeight: 700,
+  letterSpacing: "0.18em",
+  color: "var(--archive-ink)",
+  border: "1px solid var(--archive-border)",
+};
+
+export const productionGroupDialogPrimaryButtonSx = {
+  ...productionGroupDialogSecondaryButtonSx,
+  "color": "#f6f0e8",
+  "borderColor": "transparent",
+  "backgroundColor": "var(--archive-accent)",
+  "&:hover": {
+    backgroundColor: "#92653e",
+  },
+};
+
+export const productionGroupDialogDangerButtonSx = {
+  ...productionGroupDialogSecondaryButtonSx,
+  "color": "#c0392b",
+  "borderColor": "rgba(192, 57, 43, 0.4)",
+  "&:hover": {
+    backgroundColor: "rgba(192, 57, 43, 0.08)",
+  },
+};
+
+export const productionGroupDialogTitleSx = {
+  fontFamily: "var(--font-serif)",
+  fontStyle: "italic",
+  fontSize: "1.9rem",
+  color: "var(--archive-ink)",
+  pb: 1,
+  px: 3,
+  pt: 3,
+};
+
+export const productionGroupDialogContentSx = {
+  pt: "0.25rem !important",
+  pb: 1,
+  px: 3,
+  color: "var(--archive-ink)",
+};
+
+export const productionGroupDialogActionsSx = {
+  px: 3,
+  pt: 2,
+  pb: 3,
+  gap: 1.5,
+  borderTop: "1px solid var(--archive-border)",
+};
+
+export const productionGroupDialogCheckboxSx = {
+  "color": "rgba(196, 164, 132, 0.7)",
+  "padding": 0,
+  "mt": 0.25,
+  "&.Mui-checked": {
+    color: "var(--archive-accent)",
+  },
+};
+
+export const productionGroupDialogPaperSx = {
+  borderRadius: "1.75rem",
+  border: "1px solid var(--archive-border)",
+  backgroundColor: "var(--archive-surface-strong)",
+  color: "var(--archive-ink)",
+  backdropFilter: "blur(18px)",
+  boxShadow: "0 28px 90px rgba(0, 0, 0, 0.24)",
+};
+
+export const productionGroupDialogBackdropSx = {
+  backgroundColor: "rgba(17, 16, 14, 0.48)",
+  backdropFilter: "blur(4px)",
+};

--- a/frontend/app/features/archive/pages/ArchivePage.tsx
+++ b/frontend/app/features/archive/pages/ArchivePage.tsx
@@ -6,7 +6,8 @@ import { Outlet, useSearchParams } from "react-router";
 
 import { ProductionTimeline } from "~/features/archive/components/ProductionTimeline";
 import { getAllProductionGroups } from "~/features/archive/services/productionGroupService";
-import { Button, Divider } from "@mui/material";
+import { Button, Divider, IconButton, Tooltip } from "@mui/material";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { getProductionsPaginated } from "~/features/archive/services/productionService";
 import type { ProductionList } from "~/features/archive/types/productionTypes";
 import FilterSidebar from "../components/FilterSidebar";
@@ -384,30 +385,56 @@ export default function ArchivePage() {
                   </Button>
                 </Protected>
                 <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
-                  {selectedProductionGroupForDeletion ? (
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      onClick={() =>
-                        setProductionGroupToDelete(selectedProductionGroupForDeletion)
-                      }
-                      sx={{
-                        "borderColor": "rgba(192, 57, 43, 0.4)",
-                        "color": "#c0392b",
-                        "fontFamily": "var(--font-sans)",
-                        "textTransform": "uppercase",
-                        "letterSpacing": "0.08em",
-                        "fontSize": "0.72rem",
-                        "fontWeight": 600,
-                        "&:hover": {
-                          borderColor: "rgba(192, 57, 43, 0.55)",
-                          backgroundColor: "rgba(192, 57, 43, 0.08)",
-                        },
-                      }}
+                  <div className="flex items-center gap-1.5">
+                    <Tooltip
+                      title={t("archive.productionGroups.deleteInfo.tooltip")}
+                      arrow
                     >
-                      {t("archive.productionGroups.actions.delete")}
-                    </Button>
-                  ) : null}
+                      <IconButton
+                        type="button"
+                        size="small"
+                        aria-label={t("archive.productionGroups.deleteInfo.ariaLabel")}
+                        sx={{
+                          "color": "var(--color-archive-ink)",
+                          "opacity": 0.55,
+                          "padding": 0.5,
+                          "transition":
+                            "opacity 150ms ease, background-color 150ms ease",
+                          "&:hover": {
+                            opacity: 1,
+                            backgroundColor:
+                              "color-mix(in srgb, var(--color-archive-accent) 10%, transparent)",
+                          },
+                        }}
+                      >
+                        <InfoOutlinedIcon fontSize="inherit" />
+                      </IconButton>
+                    </Tooltip>
+                    {selectedProductionGroupForDeletion ? (
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={() =>
+                          setProductionGroupToDelete(selectedProductionGroupForDeletion)
+                        }
+                        sx={{
+                          "borderColor": "rgba(192, 57, 43, 0.4)",
+                          "color": "#c0392b",
+                          "fontFamily": "var(--font-sans)",
+                          "textTransform": "uppercase",
+                          "letterSpacing": "0.08em",
+                          "fontSize": "0.72rem",
+                          "fontWeight": 600,
+                          "&:hover": {
+                            borderColor: "rgba(192, 57, 43, 0.55)",
+                            backgroundColor: "rgba(192, 57, 43, 0.08)",
+                          },
+                        }}
+                      >
+                        {t("archive.productionGroups.actions.delete")}
+                      </Button>
+                    ) : null}
+                  </div>
                 </Protected>
                 <Button
                   variant="outlined"

--- a/frontend/app/features/archive/pages/ArchivePage.tsx
+++ b/frontend/app/features/archive/pages/ArchivePage.tsx
@@ -14,6 +14,7 @@ import { CreateProductionButton } from "../components/CreateProductionButton";
 import { ShowMoreButton } from "../components/ShowMoreButton";
 import { MobileToggleButton } from "../components/MobileToggleButton";
 import { CreateProductionGroupDialog } from "../components/CreateProductionGroupDialog";
+import { DeleteProductionGroupDialog } from "../components/DeleteProductionGroupDialog";
 import { useDebouncedState } from "../utils/debouncedState";
 import {
   SortOrderEnum,
@@ -58,6 +59,26 @@ function buildProductionFilters({
   };
 }
 
+function matchesExactlySelectedProductionIds(
+  selectedProductionIds: string[],
+  productionIds: string[]
+): boolean {
+  const uniqueSelectedProductionIds = Array.from(new Set(selectedProductionIds));
+  const uniqueProductionIds = Array.from(new Set(productionIds));
+
+  if (
+    uniqueSelectedProductionIds.length === 0 ||
+    uniqueSelectedProductionIds.length !== uniqueProductionIds.length
+  ) {
+    return false;
+  }
+
+  const selectedProductionIdSet = new Set(uniqueSelectedProductionIds);
+  return uniqueProductionIds.every((productionId) =>
+    selectedProductionIdSet.has(productionId)
+  );
+}
+
 export default function ArchivePage() {
   const { t, i18n } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -66,7 +87,11 @@ export default function ArchivePage() {
   const canCreateArchive =
     isAuthenticated &&
     !!(user?.isSuperUser || user?.permissions.includes(ARCHIVE_PERMISSIONS.create));
-  const isSelectable = canCreateArchive;
+  const canDeleteArchive =
+    isAuthenticated &&
+    !!(user?.isSuperUser || user?.permissions.includes(ARCHIVE_PERMISSIONS.delete));
+  const canManageProductionGroups = canCreateArchive || canDeleteArchive;
+  const isSelectable = canManageProductionGroups;
 
   const [sortOrder, setSortOrder] = useState<SortOrderEnum>(SortOrderEnum.NewestFirst);
 
@@ -81,6 +106,8 @@ export default function ArchivePage() {
   const [selectedProductionIds, setSelectedProductionIds] = useState<string[]>([]);
   const [isCreateProductionGroupDialogOpen, setIsCreateProductionGroupDialogOpen] =
     useState(false);
+  const [productionGroupToDelete, setProductionGroupToDelete] =
+    useState<ProductionGroup | null>(null);
 
   const selectedProductionGroupIds = useMemo(
     () => getRequestedProductionGroupIds(searchParams),
@@ -117,7 +144,7 @@ export default function ArchivePage() {
 
     async function fetchProductionGroups() {
       try {
-        const result = await getAllProductionGroups(!canCreateArchive);
+        const result = await getAllProductionGroups(!canManageProductionGroups);
 
         if (!isCancelled) {
           setProductionGroups(result);
@@ -132,7 +159,7 @@ export default function ArchivePage() {
     return () => {
       isCancelled = true;
     };
-  }, [canCreateArchive]);
+  }, [canManageProductionGroups]);
 
   const handleSelectedProductionGroupsChange = (nextGroups: ProductionGroup[]) => {
     setSearchParams(
@@ -178,6 +205,26 @@ export default function ArchivePage() {
     visibleProductionIds.length > 0 &&
     visibleProductionIds.every((id) => selectedProductionIds.includes(id));
 
+  // Only expose the delete action when the archive is filtered to exactly one
+  // production group and the current selection matches that group's full set.
+  const selectedProductionGroupForDeletion = useMemo(() => {
+    if (
+      selectedProductionGroupIds.length !== 1 ||
+      selectedProductionGroups.length !== 1
+    ) {
+      return null;
+    }
+
+    const [productionGroup] = selectedProductionGroups;
+
+    return matchesExactlySelectedProductionIds(
+      selectedProductionIds,
+      productionGroup.production_id_urls
+    )
+      ? productionGroup
+      : null;
+  }, [selectedProductionGroupIds, selectedProductionGroups, selectedProductionIds]);
+
   const toggleMobileFilters = () => {
     setShowFilters((prev) => !prev);
   };
@@ -215,6 +262,24 @@ export default function ArchivePage() {
 
     setSelectedProductionIds([]);
     setIsCreateProductionGroupDialogOpen(false);
+  };
+
+  const handleProductionGroupDeleted = (deletedProductionGroup: ProductionGroup) => {
+    setProductionGroups((currentGroups) =>
+      currentGroups.filter(
+        (currentGroup) => currentGroup.id_url !== deletedProductionGroup.id_url
+      )
+    );
+    setSelectedProductionIds([]);
+    setProductionGroupToDelete(null);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete(PRODUCTION_GROUP_QUERY_PARAM);
+        return next;
+      },
+      { replace: true }
+    );
   };
 
   return (
@@ -255,7 +320,10 @@ export default function ArchivePage() {
                 {total_count === 1 ? t("archive.result") : t("archive.results")}
               </p>
               <CreateProductionButton />
-              <Protected permissions={[ARCHIVE_PERMISSIONS.create]}>
+              <Protected
+                permissions={[ARCHIVE_PERMISSIONS.create, ARCHIVE_PERMISSIONS.delete]}
+                requireAllPermissions={false}
+              >
                 <Button
                   variant="text"
                   size="small"
@@ -314,6 +382,32 @@ export default function ArchivePage() {
                   >
                     {t("archive.productionGroups.actions.create")}
                   </Button>
+                </Protected>
+                <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
+                  {selectedProductionGroupForDeletion ? (
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={() =>
+                        setProductionGroupToDelete(selectedProductionGroupForDeletion)
+                      }
+                      sx={{
+                        "borderColor": "rgba(192, 57, 43, 0.4)",
+                        "color": "#c0392b",
+                        "fontFamily": "var(--font-sans)",
+                        "textTransform": "uppercase",
+                        "letterSpacing": "0.08em",
+                        "fontSize": "0.72rem",
+                        "fontWeight": 600,
+                        "&:hover": {
+                          borderColor: "rgba(192, 57, 43, 0.55)",
+                          backgroundColor: "rgba(192, 57, 43, 0.08)",
+                        },
+                      }}
+                    >
+                      {t("archive.productionGroups.actions.delete")}
+                    </Button>
+                  ) : null}
                 </Protected>
                 <Button
                   variant="outlined"
@@ -376,6 +470,11 @@ export default function ArchivePage() {
         selectedProductionIds={selectedProductionIds}
         onClose={() => setIsCreateProductionGroupDialogOpen(false)}
         onCreated={handleProductionGroupCreated}
+      />
+      <DeleteProductionGroupDialog
+        productionGroup={productionGroupToDelete}
+        onClose={() => setProductionGroupToDelete(null)}
+        onDeleted={handleProductionGroupDeleted}
       />
       <Outlet />
     </div>

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -49,6 +49,10 @@
         "deleting": "Deleting...",
         "cancel": "Cancel"
       },
+      "deleteInfo": {
+        "ariaLabel": "How to delete a production group",
+        "tooltip": "To delete a production group, first select that group in the filters and then select every production from it. Once the full group is selected, the delete button will appear."
+      },
       "dialog": {
         "title": "Create a production group",
         "description": "Group the selected productions under a shared title so visitors can use them as a filter in the archive.",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -44,6 +44,8 @@
       "actions": {
         "create": "Create production group",
         "creating": "Creating...",
+        "delete": "Delete production group",
+        "deleting": "Deleting...",
         "cancel": "Cancel"
       },
       "dialog": {
@@ -54,10 +56,20 @@
         "publicLabel": "Show this group in the public archive filters",
         "publicHint": "When enabled, visitors can use this production group as a filter in the archive."
       },
+      "deleteDialog": {
+        "title": "Delete production group",
+        "description": "You are about to remove \"{{title}}\" from the archive filters.",
+        "selectedCount": "{{count}} grouped productions",
+        "warning": "The productions themselves stay available in the archive. This action cannot be undone.",
+        "actions": {
+          "delete": "Delete"
+        }
+      },
       "messages": {
         "titleRequired": "A production group title is required.",
         "noProductionsSelected": "Select at least one production before creating a production group.",
-        "createFailed": "Could not create the production group."
+        "createFailed": "Could not create the production group.",
+        "deleteFailed": "Could not delete the production group."
       }
     },
     "accessDenied": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -60,6 +60,10 @@
         "deleting": "Bezig met verwijderen...",
         "cancel": "Annuleer"
       },
+      "deleteInfo": {
+        "ariaLabel": "Hoe je een productiegroep verwijdert",
+        "tooltip": "Om een productiegroep te verwijderen, selecteer je eerst die groep in de filters en daarna alle producties uit die groep. Zodra de volledige groep geselecteerd is, verschijnt de verwijderknop."
+      },
       "dialog": {
         "title": "Maak een productiegroep",
         "description": "Groepeer de geselecteerde producties onder een gedeelde titel zodat bezoekers ze als filter kunnen gebruiken in het archief.",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -55,6 +55,8 @@
       "actions": {
         "create": "Maak productiegroep",
         "creating": "Bezig met aanmaken...",
+        "delete": "Verwijder productiegroep",
+        "deleting": "Bezig met verwijderen...",
         "cancel": "Annuleer"
       },
       "dialog": {
@@ -65,10 +67,20 @@
         "publicLabel": "Toon deze groep in de publieke archieffilters",
         "publicHint": "Wanneer ingeschakeld, kunnen bezoekers deze productiegroep gebruiken als filter in het archief."
       },
+      "deleteDialog": {
+        "title": "Verwijder productiegroep",
+        "description": "Je staat op het punt om \"{{title}}\" uit de archieffilters te verwijderen.",
+        "selectedCount": "{{count}} gegroepeerde producties",
+        "warning": "De producties zelf blijven beschikbaar in het archief. Deze actie kan niet ongedaan worden gemaakt.",
+        "actions": {
+          "delete": "Verwijder"
+        }
+      },
       "messages": {
         "titleRequired": "Een titel voor de productiegroep is verplicht.",
         "noProductionsSelected": "Selecteer minstens één productie voordat je een productiegroep maakt.",
-        "createFailed": "Kon de productiegroep niet aanmaken."
+        "createFailed": "Kon de productiegroep niet aanmaken.",
+        "deleteFailed": "Kon de productiegroep niet verwijderen."
       }
     },
     "accessDenied": {

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderWithRouterAndTheme } from "tests/utils/renderWithRouterAndTheme";
 import userEvent from "@testing-library/user-event";
@@ -39,6 +39,26 @@ const adminUser = {
   lastLoginAt: null,
 };
 
+const createOnlyUser = {
+  ...adminUser,
+  isSuperUser: false,
+  permissions: ["archive:create"],
+};
+
+const deleteOnlyUser = {
+  ...adminUser,
+  isSuperUser: false,
+  permissions: ["archive:delete"],
+};
+
+const FILTERED_PRODUCTIONS = mockProductions.slice(0, 2);
+const FILTERED_PRODUCTION_GROUP = {
+  id_url: "/api/v1/archive/production-groups/1",
+  title: "Vooruit Klassiek",
+  is_public_filter: true,
+  production_id_urls: FILTERED_PRODUCTIONS.map((production) => production.id_url),
+};
+
 async function renderArchiveAndNavigate() {
   renderWithRouterAndTheme({ useRealArchive: true });
   const user = userEvent.setup();
@@ -61,6 +81,30 @@ function expectEveryProductionVisible(productions: Production[]) {
 
     expect(exists).toBe(true);
   }
+}
+
+function mockFilteredProductionGroupSelection() {
+  vi.mocked(productionGroupService.getAllProductionGroups).mockResolvedValue([
+    FILTERED_PRODUCTION_GROUP,
+  ]);
+  mockFetchedProductions(FILTERED_PRODUCTIONS);
+}
+
+function renderArchiveWithFilteredProductionGroup() {
+  renderWithRouterAndTheme({
+    useRealArchive: true,
+    initialPath: "/archive?group=1",
+  });
+}
+
+async function selectAllVisibleProductions() {
+  const user = userEvent.setup();
+
+  await user.click(
+    await screen.findByRole("button", { name: "archive.selection.select_all" })
+  );
+
+  return user;
 }
 
 describe("Archive", () => {
@@ -109,6 +153,47 @@ describe("Archive", () => {
           `${mockProductions.length} archive.selection.selected_plural`
       )
     ).toBeInTheDocument();
+  });
+
+  it("shows the delete action for a selected production group when a user with delete permission selects every grouped production", async () => {
+    vi.spyOn(loginServiceModule, "restoreSession").mockResolvedValue(deleteOnlyUser);
+    vi.mocked(productionGroupService.deleteProductionGroup).mockResolvedValue();
+    mockFilteredProductionGroupSelection();
+    renderArchiveWithFilteredProductionGroup();
+
+    const user = await selectAllVisibleProductions();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "I18N_Archive_ProductionGroups_Actions_Delete_Production_Group",
+      })
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    await user.click(
+      within(dialog).getByRole("button", {
+        name: "I18N_Archive_ProductionGroups_DeleteDialog_Actions_Delete",
+      })
+    );
+
+    await waitFor(() =>
+      expect(productionGroupService.deleteProductionGroup).toHaveBeenCalledWith(1)
+    );
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+
+  it("does not show the delete action without archive delete permission", async () => {
+    vi.spyOn(loginServiceModule, "restoreSession").mockResolvedValue(createOnlyUser);
+    mockFilteredProductionGroupSelection();
+    renderArchiveWithFilteredProductionGroup();
+
+    await selectAllVisibleProductions();
+
+    expect(
+      screen.queryByRole("button", {
+        name: "I18N_Archive_ProductionGroups_Actions_Delete_Production_Group",
+      })
+    ).toBeNull();
   });
 
   describe("Result count", async () => {

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -163,6 +163,12 @@ describe("Archive", () => {
 
     const user = await selectAllVisibleProductions();
 
+    expect(
+      await screen.findByRole("button", {
+        name: "I18N_Archive_ProductionGroups_DeleteInfo_AriaLabel",
+      })
+    ).toBeInTheDocument();
+
     await user.click(
       await screen.findByRole("button", {
         name: "I18N_Archive_ProductionGroups_Actions_Delete_Production_Group",

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -37,6 +37,10 @@ const translationMap: Record<string, TranslationValue> = {
     "I18N_Archive_ProductionGroups_Actions_Delete_Production_Group",
   "archive.productionGroups.actions.deleting":
     "I18N_Archive_ProductionGroups_Actions_Deleting",
+  "archive.productionGroups.deleteInfo.ariaLabel":
+    "I18N_Archive_ProductionGroups_DeleteInfo_AriaLabel",
+  "archive.productionGroups.deleteInfo.tooltip":
+    "I18N_Archive_ProductionGroups_DeleteInfo_Tooltip",
   "archive.productionGroups.actions.cancel":
     "I18N_Archive_ProductionGroups_Actions_Cancel",
   "archive.productionGroups.dialog.title": "I18N_Archive_ProductionGroups_Dialog_Title",

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -33,6 +33,10 @@ const translationMap: Record<string, TranslationValue> = {
     "I18N_Archive_ProductionGroups_Actions_Create",
   "archive.productionGroups.actions.creating":
     "I18N_Archive_ProductionGroups_Actions_Creating",
+  "archive.productionGroups.actions.delete":
+    "I18N_Archive_ProductionGroups_Actions_Delete_Production_Group",
+  "archive.productionGroups.actions.deleting":
+    "I18N_Archive_ProductionGroups_Actions_Deleting",
   "archive.productionGroups.actions.cancel":
     "I18N_Archive_ProductionGroups_Actions_Cancel",
   "archive.productionGroups.dialog.title": "I18N_Archive_ProductionGroups_Dialog_Title",
@@ -46,12 +50,24 @@ const translationMap: Record<string, TranslationValue> = {
     "I18N_Archive_ProductionGroups_Dialog_PublicLabel",
   "archive.productionGroups.dialog.publicHint":
     "I18N_Archive_ProductionGroups_Dialog_PublicHint",
+  "archive.productionGroups.deleteDialog.title":
+    "I18N_Archive_ProductionGroups_DeleteDialog_Title",
+  "archive.productionGroups.deleteDialog.description":
+    "I18N_Archive_ProductionGroups_DeleteDialog_Description",
+  "archive.productionGroups.deleteDialog.selectedCount":
+    "I18N_Archive_ProductionGroups_DeleteDialog_SelectedCount_{{count}}",
+  "archive.productionGroups.deleteDialog.warning":
+    "I18N_Archive_ProductionGroups_DeleteDialog_Warning",
+  "archive.productionGroups.deleteDialog.actions.delete":
+    "I18N_Archive_ProductionGroups_DeleteDialog_Actions_Delete",
   "archive.productionGroups.messages.titleRequired":
     "I18N_Archive_ProductionGroups_Messages_TitleRequired",
   "archive.productionGroups.messages.noProductionsSelected":
     "I18N_Archive_ProductionGroups_Messages_NoProductionsSelected",
   "archive.productionGroups.messages.createFailed":
     "I18N_Archive_ProductionGroups_Messages_CreateFailed",
+  "archive.productionGroups.messages.deleteFailed":
+    "I18N_Archive_ProductionGroups_Messages_DeleteFailed",
   "archive.accessDenied.title": "I18N_Archive_Access_Denied_Title",
   "archive.accessDenied.description": "I18N_Archive_Access_Denied_Description",
   "history.title": "I18N_History_Title",


### PR DESCRIPTION
### Beschrijving
Functionaliteit om reeksen te verwijderen in de frontend.
<img width="1920" height="1062" alt="image" src="https://github.com/user-attachments/assets/f3fab880-85e7-4196-8998-900d3bbf050e" />
De user flow is een beetje vreemd eerst, je moet een reeks selecteren en dan alle producties van die reeks selecteren om de delete knop te laten verschijnen. Ik denk dat dit de beste ux is voor deze functionaliteit maar als er betere opties zijn wil ik het zeker nog veranderen. Ik heb over een paar nagedacht maar dit voelde als de meest complete/consistente met de rest van de site.

### Testen
Voldoende testen zijn toegevoegd

Closes #437 
