### PR TITLE
[ENHANCEMENT] production selection ux

### DIFF
--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -279,13 +279,13 @@ export function ProductionCard({
       }}
       elevation={0}
     >
-	{ !anySelected &&
+      {!anySelected && (
         <Link
           to={lp(`/archive/productions/${productionId}`)}
           aria-label={`Open details for ${title}`}
           style={{ position: "absolute", inset: 0, zIndex: 1 }}
         />
-	}
+      )}
       <Box sx={{ position: "relative", overflow: "hidden" }}>
         <CardMedia
           className="production-card-image"
@@ -293,7 +293,7 @@ export function ProductionCard({
           height="236"
           image={imageUrl}
           alt={title}
-		  onClick={(e) => anySelected ? handleToggleSelected(e) : null}
+          onClick={(e) => (anySelected ? handleToggleSelected(e) : null)}
           sx={{
             transition: `transform ${CARD_MOTION.transitionDuration} ${CARD_MOTION.transitionEasing}`,
             transform: "translateY(0) scale(1)",
@@ -398,13 +398,13 @@ export function ProductionCard({
           willChange: "transform",
         }}
       >
-		{ anySelected &&
-			<Link
-			  to={lp(`/archive/productions/${productionId}`)}
-			  aria-label={`Open details for ${title}`}
-			  style={{ position: "absolute", inset: 0, zIndex: 1 }}
-			/>
-		}
+        {anySelected && (
+          <Link
+            to={lp(`/archive/productions/${productionId}`)}
+            aria-label={`Open details for ${title}`}
+            style={{ position: "absolute", inset: 0, zIndex: 1 }}
+          />
+        )}
         <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
           <Stack direction="row" justifyContent="space-between" sx={{ mb: 1.1 }}>
             <Typography

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -48,15 +48,6 @@ function colorWithOpacity(color: string, opacity: number): string {
   return `color-mix(in srgb, ${color} ${Math.round(opacity * 100)}%, transparent)`;
 }
 
-interface ProductionCardProps {
-  production: Production;
-  preferredLanguage?: string;
-  className?: string;
-  isSelectable?: boolean;
-  selected?: boolean;
-  onToggleSelected?: (productionId: string) => void;
-}
-
 export function getProductionInfoByLanguage(
   productionInfos: ProductionInfo[],
   language: string
@@ -175,12 +166,23 @@ function getProductionStartLabel(
 //   	venues.map((venue) => <p className="text-nowrap">@ {venue}</p>)}
 //   </Typography>
 
+interface ProductionCardProps {
+  production: Production;
+  preferredLanguage?: string;
+  className?: string;
+  isSelectable?: boolean;
+  selected?: boolean;
+  anySelected?: boolean;
+  onToggleSelected?: (productionId: string) => void;
+}
+
 export function ProductionCard({
   production,
   preferredLanguage = "nl",
   className,
   isSelectable = false,
   selected = false,
+  anySelected = false,
   onToggleSelected,
 }: ProductionCardProps) {
   const { t } = useTranslation();

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -281,7 +281,13 @@ export function ProductionCard({
     >
       {anySelected ? (
         <div
-          onClick={(e) => (anySelected ? handleToggleSelected(e) : null)}
+          onClick={(e) => handleToggleSelected(e)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              handleToggleSelected(e);
+            }
+          }}
           style={{ position: "absolute", inset: 0, zIndex: 1 }}
           aria-label={`${selected ? t("archive.selection.selected") : t("archive.selection.select")} ${title}`}
         />

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -279,25 +279,13 @@ export function ProductionCard({
       }}
       elevation={0}
     >
-      {anySelected ? (
-        <div
-          onClick={(e) => handleToggleSelected(e)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              handleToggleSelected(e);
-            }
-          }}
-          style={{ position: "absolute", inset: 0, zIndex: 1 }}
-          aria-label={`${selected ? t("archive.selection.selected") : t("archive.selection.select")} ${title}`}
-        />
-      ) : (
+	{ !anySelected &&
         <Link
           to={lp(`/archive/productions/${productionId}`)}
           aria-label={`Open details for ${title}`}
           style={{ position: "absolute", inset: 0, zIndex: 1 }}
         />
-      )}
+	}
       <Box sx={{ position: "relative", overflow: "hidden" }}>
         <CardMedia
           className="production-card-image"
@@ -305,6 +293,7 @@ export function ProductionCard({
           height="236"
           image={imageUrl}
           alt={title}
+		  onClick={(e) => anySelected ? handleToggleSelected(e) : null}
           sx={{
             transition: `transform ${CARD_MOTION.transitionDuration} ${CARD_MOTION.transitionEasing}`,
             transform: "translateY(0) scale(1)",
@@ -409,6 +398,13 @@ export function ProductionCard({
           willChange: "transform",
         }}
       >
+		{ anySelected &&
+			<Link
+			  to={lp(`/archive/productions/${productionId}`)}
+			  aria-label={`Open details for ${title}`}
+			  style={{ position: "absolute", inset: 0, zIndex: 1 }}
+			/>
+		}
         <Box sx={{ display: "flex", flexDirection: "column", flexGrow: 1 }}>
           <Stack direction="row" justifyContent="space-between" sx={{ mb: 1.1 }}>
             <Typography

--- a/frontend/app/features/archive/components/ProductionCard.tsx
+++ b/frontend/app/features/archive/components/ProductionCard.tsx
@@ -279,11 +279,19 @@ export function ProductionCard({
       }}
       elevation={0}
     >
-      <Link
-        to={lp(`/archive/productions/${productionId}`)}
-        aria-label={`Open details for ${title}`}
-        style={{ position: "absolute", inset: 0, zIndex: 1 }}
-      />
+      {anySelected ? (
+        <div
+          onClick={(e) => (anySelected ? handleToggleSelected(e) : null)}
+          style={{ position: "absolute", inset: 0, zIndex: 1 }}
+          aria-label={`${selected ? t("archive.selection.selected") : t("archive.selection.select")} ${title}`}
+        />
+      ) : (
+        <Link
+          to={lp(`/archive/productions/${productionId}`)}
+          aria-label={`Open details for ${title}`}
+          style={{ position: "absolute", inset: 0, zIndex: 1 }}
+        />
+      )}
       <Box sx={{ position: "relative", overflow: "hidden" }}>
         <CardMedia
           className="production-card-image"

--- a/frontend/app/features/archive/components/ProductionTimeline.tsx
+++ b/frontend/app/features/archive/components/ProductionTimeline.tsx
@@ -72,6 +72,8 @@ function MonthDisplay({
 
   const language = preferredLanguage ?? lang;
 
+  const anySelected = selectedProductionIds ? selectedProductionIds.length > 0 : false
+
   return (
     <div>
       {/* Sticky month */}
@@ -98,6 +100,7 @@ function MonthDisplay({
             preferredLanguage={language}
             isSelectable={isSelectable}
             selected={selectedProductionIds?.includes(prod.id_url)}
+			anySelected={anySelected}
             onToggleSelected={onToggleProductionSelection}
           />
         ))}

--- a/frontend/app/features/archive/components/ProductionTimeline.tsx
+++ b/frontend/app/features/archive/components/ProductionTimeline.tsx
@@ -72,7 +72,7 @@ function MonthDisplay({
 
   const language = preferredLanguage ?? lang;
 
-  const anySelected = selectedProductionIds ? selectedProductionIds.length > 0 : false
+  const anySelected = selectedProductionIds ? selectedProductionIds.length > 0 : false;
 
   return (
     <div>
@@ -100,7 +100,7 @@ function MonthDisplay({
             preferredLanguage={language}
             isSelectable={isSelectable}
             selected={selectedProductionIds?.includes(prod.id_url)}
-			anySelected={anySelected}
+            anySelected={anySelected}
             onToggleSelected={onToggleProductionSelection}
           />
         ))}


### PR DESCRIPTION
### Beschrijving
Productie selectie was niet zeer user friendly en het was best vervelend als je net naast het selectie knopje klikte. Nu kan je overal op de productiekaart klikken als minstens 1 productie geselecteerd is.


### Aangepaste delen
ProductionCard: functionaliteit toegevoegd
ProductionTimeline: controle dat minstens 1 productie geselecteerd is


### Speciale opmerkingen
geen


### Afhankelijkheden
geen


### Testen
Ik heb geen reeds bestaande testen gevonden voor productionCards dus  heb ik geen testen toegevoegd


Closes #444 

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
