### PR TITLE
448 feat media editeerbaar en toevoegbaar maken

### DIFF
--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -263,51 +263,52 @@ export function ProductionPageMediaGallery({
             className="flex cursor-default gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin]"
           >
             {imageUrls.map((url, index) => (
-            <figure
-              key={`${production_id_url}-${url}-${index}`}
-              onClick={() => setLightboxImageUrl(url)}
-              className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 cursor-pointer overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"            >
-              <img
-                src={url}
-                alt={t("productionPage.archivePhotoAlt", {
-                  title,
-                  index: index + 1,
-                })}
-                loading="lazy"
-                className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
-              />
+              <figure
+                key={`${production_id_url}-${url}-${index}`}
+                onClick={() => setLightboxImageUrl(url)}
+                className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 cursor-pointer overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
+              >
+                <img
+                  src={url}
+                  alt={t("productionPage.archivePhotoAlt", {
+                    title,
+                    index: index + 1,
+                  })}
+                  loading="lazy"
+                  className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+                />
 
-              {isEditing && mediaIdUrlByImageUrl[url] !== undefined && (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setConfirmDeleteImageUrl(url);
-                  }}
-                  aria-label={t("productionPage.deleteMedia")}
-                  className="absolute top-2 right-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white opacity-0 backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100 hover:bg-red-600/80"
-                >
-                  <svg
-                    className="h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+                {isEditing && mediaIdUrlByImageUrl[url] !== undefined && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setConfirmDeleteImageUrl(url);
+                    }}
+                    aria-label={t("productionPage.deleteMedia")}
+                    className="absolute top-2 right-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white opacity-0 backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100 hover:bg-red-600/80"
                   >
-                    <polyline points="3 6 5 6 21 6" />
-                    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                    <path d="M10 11v6" />
-                    <path d="M14 11v6" />
-                    <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                  </svg>
-                </button>
-              )}
-            </figure>
-          ))}
-        </div>
-      )}
+                    <svg
+                      className="h-4 w-4"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                      <path d="M10 11v6" />
+                      <path d="M14 11v6" />
+                      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                    </svg>
+                  </button>
+                )}
+              </figure>
+            ))}
+          </div>
+        )}
       </section>
 
       {confirmDeleteImageUrl !== null && (

--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -170,6 +170,7 @@ export function ProductionPageMediaGallery({
     try {
       await deleteMedia(productionNumericId, mediaNumericId);
       setMediaImageUrls((prev) => prev.filter((url) => url !== confirmDeleteImageUrl));
+      if (lightboxImageUrl === confirmDeleteImageUrl) setLightboxImageUrl(null);
       setMediaIdUrlByImageUrl((prev) => {
         const next = { ...prev };
         delete next[confirmDeleteImageUrl];
@@ -359,6 +360,8 @@ export function ProductionPageMediaGallery({
       )}
       {lightboxImageUrl && (
         <div
+          role="dialog"
+          aria-modal="true"
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
           onClick={() => setLightboxImageUrl(null)}
         >

--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -1,10 +1,7 @@
 import { useTranslation } from "react-i18next";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-import { getMediaForProduction, deleteMedia } from "~/features/archive/services/mediaService";
-import type { MediaItem } from "~/features/archive/types/mediaTypes";
-import { Protected } from "~/features/auth";
-import { ARCHIVE_PERMISSIONS } from "~/features/archive/archive.constants";
+import { getMediaForProduction } from "~/features/archive/services/mediaService";
 
 // extract numeric production id from id_url for media requests
 function getProductionNumericIdFromUrl(idUrl: string): number | undefined {
@@ -17,53 +14,37 @@ function getProductionNumericIdFromUrl(idUrl: string): number | undefined {
   return Number.isInteger(parsedId) && parsedId > 0 ? parsedId : undefined;
 }
 
-function getMediaNumericId(idUrl: string): number {
-  return Number(idUrl.split("/").pop());
-}
-
-const FALLBACK_IMAGE_URL =
-  "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
-
 type MediaGalleryProps = {
   production_id_url: string;
   title: string;
 };
-
 export function ProductionPageMediaGallery({
   production_id_url,
   title,
 }: MediaGalleryProps) {
   const { t } = useTranslation();
-  const [mediaByProductionId, setMediaByProductionId] = useState<
-    Record<string, MediaItem[]>
+  const [mediaImageUrlsByProductionId, setMediaImageUrlsByProductionId] = useState<
+    Record<string, string[]>
   >({});
-  const [lightboxMedia, setLightboxMedia] = useState<MediaItem | null>(null);
+
+  const fallbackImageUrl =
+    "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
 
   const evidenceTrackRef = useRef<HTMLDivElement | null>(null);
 
-  const closeLightbox = useCallback(() => setLightboxMedia(null), []);
-
-  // keyboard close + scroll lock for lightbox
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") closeLightbox();
-    }
-    if (lightboxMedia) {
-      document.addEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [lightboxMedia, closeLightbox]);
-
-  const mediaItems = useMemo(
-    () => mediaByProductionId[production_id_url] ?? [],
-    [mediaByProductionId, production_id_url]
+  const imageUrls = useMemo(
+    () =>
+      (mediaImageUrlsByProductionId[production_id_url] ?? []).length > 0
+        ? mediaImageUrlsByProductionId[production_id_url]!
+        : [
+            fallbackImageUrl,
+            fallbackImageUrl,
+            fallbackImageUrl,
+            fallbackImageUrl,
+            fallbackImageUrl,
+          ],
+    [fallbackImageUrl, mediaImageUrlsByProductionId, production_id_url]
   );
-
-  const displayItems = mediaItems.length > 0 ? mediaItems : [];
 
   const productionNumericId = useMemo(
     () => getProductionNumericIdFromUrl(production_id_url),
@@ -71,6 +52,7 @@ export function ProductionPageMediaGallery({
   );
 
   useEffect(() => {
+    // skip media fetching if the production id cannot be parsed
     if (!productionNumericId) {
       return;
     }
@@ -79,11 +61,11 @@ export function ProductionPageMediaGallery({
 
     const loadAllMediaImages = async () => {
       try {
-        const collected: MediaItem[] = [];
-        const seenUrls = new Set<string>();
+        const imageUrlsSet = new Set<string>();
         let cursor: number | undefined;
         let hasMore = true;
 
+        // continue paginated requests until there are no more pages
         while (hasMore) {
           const response = await getMediaForProduction(productionNumericId, {
             cursor,
@@ -91,13 +73,13 @@ export function ProductionPageMediaGallery({
           });
 
           for (const media of response.media) {
+            // keep only image media for the visual evidence section
             if (!media.content_type.startsWith("image/")) {
               continue;
             }
-            if (!seenUrls.has(media.url)) {
-              seenUrls.add(media.url);
-              collected.push(media);
-            }
+
+            // a set avoids duplicate urls while preserving insertion order
+            imageUrlsSet.add(media.url);
           }
 
           cursor = response.pagination.next_cursor;
@@ -107,15 +89,15 @@ export function ProductionPageMediaGallery({
         }
 
         if (!isCancelled) {
-          setMediaByProductionId((prev) => ({
-            ...prev,
-            [production_id_url]: collected,
+          setMediaImageUrlsByProductionId((previousState) => ({
+            ...previousState,
+            [production_id_url]: Array.from(imageUrlsSet),
           }));
         }
       } catch {
         if (!isCancelled) {
-          setMediaByProductionId((prev) => ({
-            ...prev,
+          setMediaImageUrlsByProductionId((previousState) => ({
+            ...previousState,
             [production_id_url]: [],
           }));
         }
@@ -124,6 +106,7 @@ export function ProductionPageMediaGallery({
 
     void loadAllMediaImages();
 
+    // prevent state updates if the component unmounts during an in-flight request
     return () => {
       isCancelled = true;
     };
@@ -134,34 +117,7 @@ export function ProductionPageMediaGallery({
     if (!track) {
       return;
     }
-  }, [displayItems]);
-
-  async function handleDelete(mediaId: number) {
-    if (!productionNumericId) return;
-    if (!window.confirm(t("productionPage.confirmDeleteMedia"))) return;
-
-    try {
-      await deleteMedia(productionNumericId, mediaId);
-      setMediaByProductionId((prev) => ({
-        ...prev,
-        [production_id_url]: (prev[production_id_url] ?? []).filter(
-          (m) => getMediaNumericId(m.id_url) !== mediaId
-        ),
-      }));
-      // close lightbox if the deleted item was open
-      if (lightboxMedia && getMediaNumericId(lightboxMedia.id_url) === mediaId) {
-        closeLightbox();
-      }
-    } catch (error) {
-      window.alert(
-        t("productionPage.deleteMediaFailed", {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      );
-    }
-  }
-
-  const isFallback = mediaItems.length === 0;
+  }, [imageUrls]);
 
   return (
     <section
@@ -174,165 +130,29 @@ export function ProductionPageMediaGallery({
         </h2>
       </div>
 
-      <div
-        ref={evidenceTrackRef}
-        className="flex gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin] cursor-default"
-      >
-        {displayItems.length > 0 ? (
-          displayItems.map((item, index) => {
-            const isFallbackItem = item.id_url.startsWith("fallback-"); // never true now
-            const mediaId = getMediaNumericId(item.id_url);
-
-            return (
-              <figure
-                key={`${production_id_url}-${item.id_url}-${index}`}
-                className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
-              >
-                <div
-                  className="relative overflow-hidden cursor-pointer"
-                  onClick={() => setLightboxMedia(item)}
-                >
-                  <img
-                    src={item.url}
-                    alt={t("productionPage.archivePhotoAlt", {
-                      title,
-                      index: index + 1,
-                    })}
-                    loading="lazy"
-                    className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
-                  />
-                  {/* hover overlay with zoom icon */}
-                  <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/25">
-                    <span className="scale-0 text-white transition-transform group-hover:scale-100">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-7 w-7"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                  {/* delete button — top-right corner, visible on hover */}
-                  <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
-                    <button
-                      className="absolute top-2 right-2 z-10 rounded-full bg-black/50 p-1.5 text-white opacity-0 transition-opacity group-hover:opacity-100 hover:bg-red-600"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void handleDelete(mediaId);
-                      }}
-                      aria-label={t("productionPage.deleteMedia")}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="h-4 w-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M6 18L18 6M6 6l12 12"
-                        />
-                      </svg>
-                    </button>
-                  </Protected>
-                </div>
-              </figure>
-            );
-          })
-        ) : (
-          // fallback text instead of images
-          <div className="flex-1 min-w-full py-12 text-center text-gray-500">
-            {t("productionPage.noImagesYet")}
-          </div>
-        )}
-      </div>
-
-      {/* lightbox */}
-      {lightboxMedia && (
+      <>
         <div
-          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
-          onClick={closeLightbox}
+          ref={evidenceTrackRef}
+          className={`flex gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin] ${"cursor-default"}`}
         >
-          <div
-            className="bg-archive-paper relative mx-4 flex max-h-[90vh] max-w-5xl flex-col overflow-hidden rounded-lg shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* close button */}
-            <button
-              className="absolute top-3 right-3 z-10 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70"
-              onClick={closeLightbox}
-              aria-label={t("visuals.lightbox.close")}
+          {imageUrls.map((url, index) => (
+            <figure
+              key={`${production_id_url}-${url}-${index}`}
+              className="group bg-archive-surface min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            </button>
-
-            {/* image */}
-            <div className="flex-1 overflow-auto">
               <img
-                src={lightboxMedia.url}
+                src={url}
                 alt={t("productionPage.archivePhotoAlt", {
                   title,
-                  index: "",
+                  index: index + 1,
                 })}
-                className="max-h-[70vh] w-full object-contain"
+                loading="lazy"
+                className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
               />
-            </div>
-
-            {/* footer with delete */}
-            <div className="border-archive-ink/10 flex items-center justify-between border-t px-6 py-4">
-              <h2 className="font-serif text-xl italic opacity-75">{title}</h2>
-              <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
-                <button
-                  className="flex items-center gap-2 text-sm font-medium text-red-400 transition-colors hover:text-red-600"
-                  onClick={() => {
-                    void handleDelete(getMediaNumericId(lightboxMedia.id_url));
-                  }}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                    />
-                  </svg>
-                  {t("productionPage.deleteMedia")}
-                </button>
-              </Protected>
-            </div>
-          </div>
+            </figure>
+          ))}
         </div>
-      )}
+      </>
     </section>
   );
 }

--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from "react-i18next";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { getMediaForProduction } from "~/features/archive/services/mediaService";
+import { getMediaForProduction, deleteMedia } from "~/features/archive/services/mediaService";
+import type { MediaItem } from "~/features/archive/types/mediaTypes";
+import { Protected } from "~/features/auth";
+import { ARCHIVE_PERMISSIONS } from "~/features/archive/archive.constants";
 
 // extract numeric production id from id_url for media requests
 function getProductionNumericIdFromUrl(idUrl: string): number | undefined {
@@ -14,37 +17,64 @@ function getProductionNumericIdFromUrl(idUrl: string): number | undefined {
   return Number.isInteger(parsedId) && parsedId > 0 ? parsedId : undefined;
 }
 
+function getMediaNumericId(idUrl: string): number {
+  return Number(idUrl.split("/").pop());
+}
+
+const FALLBACK_IMAGE_URL =
+  "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
+
 type MediaGalleryProps = {
   production_id_url: string;
   title: string;
 };
+
 export function ProductionPageMediaGallery({
   production_id_url,
   title,
 }: MediaGalleryProps) {
   const { t } = useTranslation();
-  const [mediaImageUrlsByProductionId, setMediaImageUrlsByProductionId] = useState<
-    Record<string, string[]>
+  const [mediaByProductionId, setMediaByProductionId] = useState<
+    Record<string, MediaItem[]>
   >({});
-
-  const fallbackImageUrl =
-    "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
+  const [lightboxMedia, setLightboxMedia] = useState<MediaItem | null>(null);
 
   const evidenceTrackRef = useRef<HTMLDivElement | null>(null);
 
-  const imageUrls = useMemo(
-    () =>
-      (mediaImageUrlsByProductionId[production_id_url] ?? []).length > 0
-        ? mediaImageUrlsByProductionId[production_id_url]!
-        : [
-            fallbackImageUrl,
-            fallbackImageUrl,
-            fallbackImageUrl,
-            fallbackImageUrl,
-            fallbackImageUrl,
-          ],
-    [fallbackImageUrl, mediaImageUrlsByProductionId, production_id_url]
+  const closeLightbox = useCallback(() => setLightboxMedia(null), []);
+
+  // keyboard close + scroll lock for lightbox
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") closeLightbox();
+    }
+    if (lightboxMedia) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [lightboxMedia, closeLightbox]);
+
+  const mediaItems = useMemo(
+    () => mediaByProductionId[production_id_url] ?? [],
+    [mediaByProductionId, production_id_url]
   );
+
+  // fall back to placeholder images while real media hasn't loaded yet
+  const fallbackItems: MediaItem[] = useMemo(
+    () =>
+      Array.from({ length: 5 }, (_, i) => ({
+        id_url: `fallback-${i}`,
+        url: FALLBACK_IMAGE_URL,
+        content_type: "image/jpeg",
+      })) as MediaItem[],
+    []
+  );
+
+  const displayItems = mediaItems.length > 0 ? mediaItems : fallbackItems;
 
   const productionNumericId = useMemo(
     () => getProductionNumericIdFromUrl(production_id_url),
@@ -52,7 +82,6 @@ export function ProductionPageMediaGallery({
   );
 
   useEffect(() => {
-    // skip media fetching if the production id cannot be parsed
     if (!productionNumericId) {
       return;
     }
@@ -61,11 +90,11 @@ export function ProductionPageMediaGallery({
 
     const loadAllMediaImages = async () => {
       try {
-        const imageUrlsSet = new Set<string>();
+        const collected: MediaItem[] = [];
+        const seenUrls = new Set<string>();
         let cursor: number | undefined;
         let hasMore = true;
 
-        // continue paginated requests until there are no more pages
         while (hasMore) {
           const response = await getMediaForProduction(productionNumericId, {
             cursor,
@@ -73,13 +102,13 @@ export function ProductionPageMediaGallery({
           });
 
           for (const media of response.media) {
-            // keep only image media for the visual evidence section
             if (!media.content_type.startsWith("image/")) {
               continue;
             }
-
-            // a set avoids duplicate urls while preserving insertion order
-            imageUrlsSet.add(media.url);
+            if (!seenUrls.has(media.url)) {
+              seenUrls.add(media.url);
+              collected.push(media);
+            }
           }
 
           cursor = response.pagination.next_cursor;
@@ -89,15 +118,15 @@ export function ProductionPageMediaGallery({
         }
 
         if (!isCancelled) {
-          setMediaImageUrlsByProductionId((previousState) => ({
-            ...previousState,
-            [production_id_url]: Array.from(imageUrlsSet),
+          setMediaByProductionId((prev) => ({
+            ...prev,
+            [production_id_url]: collected,
           }));
         }
       } catch {
         if (!isCancelled) {
-          setMediaImageUrlsByProductionId((previousState) => ({
-            ...previousState,
+          setMediaByProductionId((prev) => ({
+            ...prev,
             [production_id_url]: [],
           }));
         }
@@ -106,7 +135,6 @@ export function ProductionPageMediaGallery({
 
     void loadAllMediaImages();
 
-    // prevent state updates if the component unmounts during an in-flight request
     return () => {
       isCancelled = true;
     };
@@ -117,7 +145,34 @@ export function ProductionPageMediaGallery({
     if (!track) {
       return;
     }
-  }, [imageUrls]);
+  }, [displayItems]);
+
+  async function handleDelete(mediaId: number) {
+    if (!productionNumericId) return;
+    if (!window.confirm(t("productionPage.confirmDeleteMedia"))) return;
+
+    try {
+      await deleteMedia(productionNumericId, mediaId);
+      setMediaByProductionId((prev) => ({
+        ...prev,
+        [production_id_url]: (prev[production_id_url] ?? []).filter(
+          (m) => getMediaNumericId(m.id_url) !== mediaId
+        ),
+      }));
+      // close lightbox if the deleted item was open
+      if (lightboxMedia && getMediaNumericId(lightboxMedia.id_url) === mediaId) {
+        closeLightbox();
+      }
+    } catch (error) {
+      window.alert(
+        t("productionPage.deleteMediaFailed", {
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    }
+  }
+
+  const isFallback = mediaItems.length === 0;
 
   return (
     <section
@@ -130,29 +185,164 @@ export function ProductionPageMediaGallery({
         </h2>
       </div>
 
-      <>
-        <div
-          ref={evidenceTrackRef}
-          className={`flex gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin] ${"cursor-default"}`}
-        >
-          {imageUrls.map((url, index) => (
+      <div
+        ref={evidenceTrackRef}
+        className="flex gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin] cursor-default"
+      >
+        {displayItems.map((item, index) => {
+          const isFallbackItem = isFallback || item.id_url.startsWith("fallback-");
+          const mediaId = isFallbackItem ? -1 : getMediaNumericId(item.id_url);
+
+          return (
             <figure
-              key={`${production_id_url}-${url}-${index}`}
-              className="group bg-archive-surface min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
+              key={`${production_id_url}-${item.id_url}-${index}`}
+              className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
             >
+              <div
+                className={`relative overflow-hidden ${!isFallbackItem ? "cursor-pointer" : ""}`}
+                onClick={() => {
+                  if (!isFallbackItem) setLightboxMedia(item);
+                }}
+              >
+                <img
+                  src={item.url}
+                  alt={t("productionPage.archivePhotoAlt", {
+                    title,
+                    index: index + 1,
+                  })}
+                  loading="lazy"
+                  className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+                />
+                {/* hover overlay with zoom icon */}
+                {!isFallbackItem && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/25">
+                    <span className="scale-0 text-white transition-transform group-hover:scale-100">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-7 w-7"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7"
+                        />
+                      </svg>
+                    </span>
+                  </div>
+                )}
+                {/* delete button — top-right corner, visible on hover */}
+                {!isFallbackItem && (
+                  <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
+                    <button
+                      className="absolute top-2 right-2 z-10 rounded-full bg-black/50 p-1.5 text-white opacity-0 transition-opacity group-hover:opacity-100 hover:bg-red-600"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void handleDelete(mediaId);
+                      }}
+                      aria-label={t("productionPage.deleteMedia")}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M6 18L18 6M6 6l12 12"
+                        />
+                      </svg>
+                    </button>
+                  </Protected>
+                )}
+              </div>
+            </figure>
+          );
+        })}
+      </div>
+
+      {/* lightbox */}
+      {lightboxMedia && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          onClick={closeLightbox}
+        >
+          <div
+            className="bg-archive-paper relative mx-4 flex max-h-[90vh] max-w-5xl flex-col overflow-hidden rounded-lg shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* close button */}
+            <button
+              className="absolute top-3 right-3 z-10 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70"
+              onClick={closeLightbox}
+              aria-label={t("visuals.lightbox.close")}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+
+            {/* image */}
+            <div className="flex-1 overflow-auto">
               <img
-                src={url}
+                src={lightboxMedia.url}
                 alt={t("productionPage.archivePhotoAlt", {
                   title,
-                  index: index + 1,
+                  index: "",
                 })}
-                loading="lazy"
-                className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+                className="max-h-[70vh] w-full object-contain"
               />
-            </figure>
-          ))}
+            </div>
+
+            {/* footer with delete */}
+            <div className="border-archive-ink/10 flex items-center justify-between border-t px-6 py-4">
+              <h2 className="font-serif text-xl italic opacity-75">{title}</h2>
+              <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
+                <button
+                  className="flex items-center gap-2 text-sm font-medium text-red-400 transition-colors hover:text-red-600"
+                  onClick={() => {
+                    void handleDelete(getMediaNumericId(lightboxMedia.id_url));
+                  }}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  {t("productionPage.deleteMedia")}
+                </button>
+              </Protected>
+            </div>
+          </div>
         </div>
-      </>
+      )}
     </section>
   );
 }

--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -63,18 +63,7 @@ export function ProductionPageMediaGallery({
     [mediaByProductionId, production_id_url]
   );
 
-  // fall back to placeholder images while real media hasn't loaded yet
-  const fallbackItems: MediaItem[] = useMemo(
-    () =>
-      Array.from({ length: 5 }, (_, i) => ({
-        id_url: `fallback-${i}`,
-        url: FALLBACK_IMAGE_URL,
-        content_type: "image/jpeg",
-      })) as MediaItem[],
-    []
-  );
-
-  const displayItems = mediaItems.length > 0 ? mediaItems : fallbackItems;
+  const displayItems = mediaItems.length > 0 ? mediaItems : [];
 
   const productionNumericId = useMemo(
     () => getProductionNumericIdFromUrl(production_id_url),
@@ -189,32 +178,30 @@ export function ProductionPageMediaGallery({
         ref={evidenceTrackRef}
         className="flex gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin] cursor-default"
       >
-        {displayItems.map((item, index) => {
-          const isFallbackItem = isFallback || item.id_url.startsWith("fallback-");
-          const mediaId = isFallbackItem ? -1 : getMediaNumericId(item.id_url);
+        {displayItems.length > 0 ? (
+          displayItems.map((item, index) => {
+            const isFallbackItem = item.id_url.startsWith("fallback-"); // never true now
+            const mediaId = getMediaNumericId(item.id_url);
 
-          return (
-            <figure
-              key={`${production_id_url}-${item.id_url}-${index}`}
-              className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
-            >
-              <div
-                className={`relative overflow-hidden ${!isFallbackItem ? "cursor-pointer" : ""}`}
-                onClick={() => {
-                  if (!isFallbackItem) setLightboxMedia(item);
-                }}
+            return (
+              <figure
+                key={`${production_id_url}-${item.id_url}-${index}`}
+                className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
               >
-                <img
-                  src={item.url}
-                  alt={t("productionPage.archivePhotoAlt", {
-                    title,
-                    index: index + 1,
-                  })}
-                  loading="lazy"
-                  className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
-                />
-                {/* hover overlay with zoom icon */}
-                {!isFallbackItem && (
+                <div
+                  className="relative overflow-hidden cursor-pointer"
+                  onClick={() => setLightboxMedia(item)}
+                >
+                  <img
+                    src={item.url}
+                    alt={t("productionPage.archivePhotoAlt", {
+                      title,
+                      index: index + 1,
+                    })}
+                    loading="lazy"
+                    className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+                  />
+                  {/* hover overlay with zoom icon */}
                   <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/25">
                     <span className="scale-0 text-white transition-transform group-hover:scale-100">
                       <svg
@@ -233,9 +220,7 @@ export function ProductionPageMediaGallery({
                       </svg>
                     </span>
                   </div>
-                )}
-                {/* delete button — top-right corner, visible on hover */}
-                {!isFallbackItem && (
+                  {/* delete button — top-right corner, visible on hover */}
                   <Protected permissions={[ARCHIVE_PERMISSIONS.delete]}>
                     <button
                       className="absolute top-2 right-2 z-10 rounded-full bg-black/50 p-1.5 text-white opacity-0 transition-opacity group-hover:opacity-100 hover:bg-red-600"
@@ -261,11 +246,16 @@ export function ProductionPageMediaGallery({
                       </svg>
                     </button>
                   </Protected>
-                )}
-              </div>
-            </figure>
-          );
-        })}
+                </div>
+              </figure>
+            );
+          })
+        ) : (
+          // fallback text instead of images
+          <div className="flex-1 min-w-full py-12 text-center text-gray-500">
+            {t("productionPage.noImagesYet")}
+          </div>
+        )}
       </div>
 
       {/* lightbox */}

--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -49,30 +49,34 @@ export function ProductionPageMediaGallery({
   const [isUploading, setIsUploading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const fallbackImageUrl =
-    "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
-
   const evidenceTrackRef = useRef<HTMLDivElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [lightboxImageUrl, setLightboxImageUrl] = useState<string | null>(null);
 
-  const imageUrls = useMemo(
-    () =>
-      mediaImageUrls.length > 0
-        ? mediaImageUrls
-        : [
-            fallbackImageUrl,
-            fallbackImageUrl,
-            fallbackImageUrl,
-            fallbackImageUrl,
-            fallbackImageUrl,
-          ],
-    [fallbackImageUrl, mediaImageUrls]
-  );
+  const imageUrls = mediaImageUrls;
 
   const productionNumericId = useMemo(
     () => getProductionNumericIdFromUrl(production_id_url),
     [production_id_url]
   );
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setLightboxImageUrl(null);
+      }
+    }
+
+    if (lightboxImageUrl) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [lightboxImageUrl]);
 
   useEffect(() => {
     // skip media fetching if the production id cannot be parsed
@@ -247,15 +251,22 @@ export function ProductionPageMediaGallery({
           onChange={handleFileChange}
         />
 
-        <div
-          ref={evidenceTrackRef}
-          className="flex cursor-default gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin]"
-        >
-          {imageUrls.map((url, index) => (
+        {imageUrls.length === 0 ? (
+          <div className="flex min-h-[180px] items-center justify-center rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] bg-[color:color-mix(in_srgb,var(--archive-accent)_3%,transparent)] px-6 py-10 text-center">
+            <p className="font-serif text-2xl italic opacity-60">
+              {t("productionPage.noImagesYet")}
+            </p>
+          </div>
+        ) : (
+          <div
+            ref={evidenceTrackRef}
+            className="flex cursor-default gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin]"
+          >
+            {imageUrls.map((url, index) => (
             <figure
               key={`${production_id_url}-${url}-${index}`}
-              className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
-            >
+              onClick={() => setLightboxImageUrl(url)}
+              className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 cursor-pointer overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"            >
               <img
                 src={url}
                 alt={t("productionPage.archivePhotoAlt", {
@@ -269,7 +280,10 @@ export function ProductionPageMediaGallery({
               {isEditing && mediaIdUrlByImageUrl[url] !== undefined && (
                 <button
                   type="button"
-                  onClick={() => setConfirmDeleteImageUrl(url)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setConfirmDeleteImageUrl(url);
+                  }}
                   aria-label={t("productionPage.deleteMedia")}
                   className="absolute top-2 right-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white opacity-0 backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100 hover:bg-red-600/80"
                 >
@@ -293,6 +307,7 @@ export function ProductionPageMediaGallery({
             </figure>
           ))}
         </div>
+      )}
       </section>
 
       {confirmDeleteImageUrl !== null && (
@@ -338,6 +353,45 @@ export function ProductionPageMediaGallery({
                 {t("productionPage.edit.delete")}
               </button>
             </div>
+          </div>
+        </div>
+      )}
+      {lightboxImageUrl && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          onClick={() => setLightboxImageUrl(null)}
+        >
+          <div
+            className="relative mx-4 max-h-[90vh] max-w-6xl overflow-hidden rounded-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={() => setLightboxImageUrl(null)}
+              aria-label={t("productionPage.closeLightbox")}
+              className="absolute top-3 right-3 z-10 rounded-full bg-black/50 p-2 text-white transition-colors hover:bg-black/70"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-5 w-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+
+            <img
+              src={lightboxImageUrl}
+              alt={t("productionPage.archivePhoto")}
+              className="max-h-[90vh] max-w-full object-contain"
+            />
           </div>
         </div>
       )}

--- a/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
+++ b/frontend/app/features/archive/components/ProductionPageMediaGallery.tsx
@@ -1,7 +1,11 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { getMediaForProduction } from "~/features/archive/services/mediaService";
+import {
+  getMediaForProduction,
+  uploadMedia,
+  deleteMedia,
+} from "~/features/archive/services/mediaService";
 
 // extract numeric production id from id_url for media requests
 function getProductionNumericIdFromUrl(idUrl: string): number | undefined {
@@ -14,28 +18,47 @@ function getProductionNumericIdFromUrl(idUrl: string): number | undefined {
   return Number.isInteger(parsedId) && parsedId > 0 ? parsedId : undefined;
 }
 
+function getMediaNumericIdFromUrl(idUrl: string): number | undefined {
+  const match = idUrl.match(/\/media\/(\d+)(?:[/?#]|$)/);
+  if (!match) return undefined;
+  const parsedId = Number(match[1]);
+  return Number.isInteger(parsedId) && parsedId > 0 ? parsedId : undefined;
+}
+
 type MediaGalleryProps = {
   production_id_url: string;
   title: string;
+  isEditing: boolean;
+  setMediaEdited: React.Dispatch<React.SetStateAction<boolean>>;
 };
+
 export function ProductionPageMediaGallery({
   production_id_url,
   title,
+  isEditing,
+  setMediaEdited,
 }: MediaGalleryProps) {
   const { t } = useTranslation();
-  const [mediaImageUrlsByProductionId, setMediaImageUrlsByProductionId] = useState<
-    Record<string, string[]>
+  const [mediaImageUrls, setMediaImageUrls] = useState<string[]>([]);
+  const [mediaIdUrlByImageUrl, setMediaIdUrlByImageUrl] = useState<
+    Record<string, string>
   >({});
+  const [confirmDeleteImageUrl, setConfirmDeleteImageUrl] = useState<string | null>(
+    null
+  );
+  const [isUploading, setIsUploading] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const fallbackImageUrl =
     "https://images.unsplash.com/photo-1518998053901-5348d3961a04?q=80&w=1600&auto=format&fit=crop";
 
   const evidenceTrackRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const imageUrls = useMemo(
     () =>
-      (mediaImageUrlsByProductionId[production_id_url] ?? []).length > 0
-        ? mediaImageUrlsByProductionId[production_id_url]!
+      mediaImageUrls.length > 0
+        ? mediaImageUrls
         : [
             fallbackImageUrl,
             fallbackImageUrl,
@@ -43,7 +66,7 @@ export function ProductionPageMediaGallery({
             fallbackImageUrl,
             fallbackImageUrl,
           ],
-    [fallbackImageUrl, mediaImageUrlsByProductionId, production_id_url]
+    [fallbackImageUrl, mediaImageUrls]
   );
 
   const productionNumericId = useMemo(
@@ -62,6 +85,7 @@ export function ProductionPageMediaGallery({
     const loadAllMediaImages = async () => {
       try {
         const imageUrlsSet = new Set<string>();
+        const idUrlMap: Record<string, string> = {};
         let cursor: number | undefined;
         let hasMore = true;
 
@@ -80,6 +104,7 @@ export function ProductionPageMediaGallery({
 
             // a set avoids duplicate urls while preserving insertion order
             imageUrlsSet.add(media.url);
+            idUrlMap[media.url] = media.id_url;
           }
 
           cursor = response.pagination.next_cursor;
@@ -89,17 +114,13 @@ export function ProductionPageMediaGallery({
         }
 
         if (!isCancelled) {
-          setMediaImageUrlsByProductionId((previousState) => ({
-            ...previousState,
-            [production_id_url]: Array.from(imageUrlsSet),
-          }));
+          setMediaImageUrls(Array.from(imageUrlsSet));
+          setMediaIdUrlByImageUrl(idUrlMap);
         }
       } catch {
         if (!isCancelled) {
-          setMediaImageUrlsByProductionId((previousState) => ({
-            ...previousState,
-            [production_id_url]: [],
-          }));
+          setMediaImageUrls([]);
+          setMediaIdUrlByImageUrl({});
         }
       }
     };
@@ -110,7 +131,52 @@ export function ProductionPageMediaGallery({
     return () => {
       isCancelled = true;
     };
-  }, [production_id_url, productionNumericId]);
+  }, [productionNumericId, isEditing]);
+
+  const handleUploadClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !productionNumericId) return;
+
+    setIsUploading(true);
+    try {
+      const newMedia = await uploadMedia(productionNumericId, file);
+      setMediaImageUrls((prev) => [...prev, newMedia.url]);
+      setMediaIdUrlByImageUrl((prev) => ({ ...prev, [newMedia.url]: newMedia.id_url }));
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      setMediaEdited(true);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (confirmDeleteImageUrl === null || !productionNumericId) return;
+
+    const mediaIdUrl = mediaIdUrlByImageUrl[confirmDeleteImageUrl];
+    const mediaNumericId = mediaIdUrl
+      ? getMediaNumericIdFromUrl(mediaIdUrl)
+      : undefined;
+    if (mediaNumericId === undefined) return;
+
+    setIsDeleting(true);
+    try {
+      await deleteMedia(productionNumericId, mediaNumericId);
+      setMediaImageUrls((prev) => prev.filter((url) => url !== confirmDeleteImageUrl));
+      setMediaIdUrlByImageUrl((prev) => {
+        const next = { ...prev };
+        delete next[confirmDeleteImageUrl];
+        return next;
+      });
+    } finally {
+      setIsDeleting(false);
+      setConfirmDeleteImageUrl(null);
+      setMediaEdited(true);
+    }
+  };
 
   useEffect(() => {
     const track = evidenceTrackRef.current;
@@ -120,25 +186,75 @@ export function ProductionPageMediaGallery({
   }, [imageUrls]);
 
   return (
-    <section
-      id="production-media-gallery"
-      className="mt-16 border-t border-[color:color-mix(in_srgb,var(--archive-accent)_14%,transparent)] pt-14"
-    >
-      <div className="mb-8 flex items-end justify-between gap-6">
-        <h2 className="font-serif text-4xl italic opacity-85 md:text-6xl">
-          {t("productionPage.visualEvidence")}
-        </h2>
-      </div>
+    <>
+      <section
+        id="production-media-gallery"
+        className="mt-16 border-t border-[color:color-mix(in_srgb,var(--archive-accent)_14%,transparent)] pt-14"
+      >
+        <div className="mb-8 flex items-end justify-between gap-6">
+          <h2 className="font-serif text-4xl italic opacity-85 md:text-6xl">
+            {t("productionPage.visualEvidence")}
+          </h2>
 
-      <>
+          {isEditing && (
+            <button
+              type="button"
+              onClick={handleUploadClick}
+              disabled={isUploading}
+              className="flex cursor-pointer items-center gap-2 rounded-lg border border-[color:color-mix(in_srgb,var(--archive-accent)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--archive-accent)_8%,transparent)] px-3 py-1.5 text-sm font-medium opacity-80 transition hover:opacity-100 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {isUploading ? (
+                <>
+                  <svg
+                    className="h-4 w-4 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                  </svg>
+                  {t("productionPage.uploading")}
+                </>
+              ) : (
+                <>
+                  <svg
+                    className="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="17 8 12 3 7 8" />
+                    <line x1="12" y1="3" x2="12" y2="15" />
+                  </svg>
+                  {t("productionPage.uploadMedia")}
+                </>
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* hidden inputfield to have cleaner file selection ui */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+
         <div
           ref={evidenceTrackRef}
-          className={`flex gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin] ${"cursor-default"}`}
+          className="flex cursor-default gap-4 overflow-x-auto pb-3 select-none [scrollbar-width:thin]"
         >
           {imageUrls.map((url, index) => (
             <figure
               key={`${production_id_url}-${url}-${index}`}
-              className="group bg-archive-surface min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
+              className="group bg-archive-surface relative min-w-[260px] flex-shrink-0 overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_12%,transparent)] sm:min-w-[320px] lg:min-w-[340px]"
             >
               <img
                 src={url}
@@ -149,10 +265,82 @@ export function ProductionPageMediaGallery({
                 loading="lazy"
                 className="h-40 w-full object-cover transition duration-500 group-hover:scale-[1.03]"
               />
+
+              {isEditing && mediaIdUrlByImageUrl[url] !== undefined && (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDeleteImageUrl(url)}
+                  aria-label={t("productionPage.deleteMedia")}
+                  className="absolute top-2 right-2 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-black/60 text-white opacity-0 backdrop-blur-sm transition-opacity duration-200 group-hover:opacity-100 hover:bg-red-600/80"
+                >
+                  <svg
+                    className="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                    <path d="M10 11v6" />
+                    <path d="M14 11v6" />
+                    <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                  </svg>
+                </button>
+              )}
             </figure>
           ))}
         </div>
-      </>
-    </section>
+      </section>
+
+      {confirmDeleteImageUrl !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-dialog-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+        >
+          <div className="bg-archive-surface mx-4 w-full max-w-sm rounded-2xl border border-[color:color-mix(in_srgb,var(--archive-accent)_16%,transparent)] p-6 shadow-xl">
+            <h4 id="delete-dialog-title" className="mb-2 font-serif text-xl">
+              {t("productionPage.edit.confirmDeleteTitle")}
+            </h4>
+            <p className="mb-6 text-sm opacity-60">
+              {t("productionPage.edit.confirmDeleteBody")}
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setConfirmDeleteImageUrl(null)}
+                disabled={isDeleting}
+                className="cursor-pointer rounded-lg px-4 py-2 text-sm font-medium opacity-60 transition hover:opacity-100 disabled:cursor-not-allowed"
+              >
+                {t("productionPage.edit.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleDeleteConfirm}
+                disabled={isDeleting}
+                className="flex cursor-pointer items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isDeleting && (
+                  <svg
+                    className="h-4 w-4 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                  </svg>
+                )}
+                {t("productionPage.edit.delete")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -126,6 +126,7 @@ async function handleInfoSave(
   setNewEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>,
   deletedEvents: EventWithResolvedRelations[],
   setDeletedEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>,
+  setMediaEdited: React.Dispatch<React.SetStateAction<boolean>>,
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
   language: string,
@@ -205,6 +206,7 @@ async function handleInfoSave(
     setDraftEvents([...draftEvents, ...createdEvents]);
     setNewEvents([]);
     setDeletedEvents([]);
+    setMediaEdited(false);
 
     setIsEditing(false);
     if (!originalInfo) {
@@ -264,6 +266,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   );
 
   const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [mediaEdited, setMediaEdited] = useState<boolean>(false);
 
   const _handleSave = () =>
     handleInfoSave(
@@ -285,6 +288,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       setNewEvents,
       deletedEvents,
       setDeletedEvents,
+      setMediaEdited,
       setIsEditing,
       setIsSaving,
       language,
@@ -313,7 +317,8 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       tagsModified ||
       generalModified ||
       isInfoModified(originalInfo, draftInfo) ||
-      areEventsModified
+      areEventsModified ||
+      mediaEdited
     );
   }, [
     originalInfo,
@@ -326,6 +331,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
     draftAttendanceMode,
     originalPerformerType,
     draftPerformerType,
+    mediaEdited,
   ]);
 
   useEffect(() => {
@@ -589,6 +595,8 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
         <ProductionPageMediaGallery
           production_id_url={production.id_url}
           title={title}
+          isEditing={isEditing}
+          setMediaEdited={setMediaEdited}
         />
       </main>
 

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -159,6 +159,9 @@
     "deleteMedia": "Delete media",
     "uploadMedia": "Upload media",
     "archivePhotoAlt": "Archive photo for {{title}} {{index}}",
+    "noImagesYet": "No images yet",
+    "closeLightbox": "Close image viewer",
+    "archivePhoto": "Archive photo",
     "edit": {
       "add": "Add info",
       "edit": "Edit",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -160,6 +160,7 @@
     "deleteMedia": "Delete photo",
     "deleteMediaFailed": "Failed to delete photo: {{error}}",
     "archivePhotoAlt": "Archive photo for {{title}} {{index}}",
+    "noImagesYet": "No images yet",
     "edit": {
       "add": "Add info",
       "edit": "Edit",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -156,11 +156,9 @@
     "address": "Address",
     "addressUnknown": "Address unknown",
     "visualEvidence": "Photos",
-    "confirmDeleteMedia": "Are you sure you want to delete this media item? This action cannot be undone.",
-    "deleteMedia": "Delete photo",
-    "deleteMediaFailed": "Failed to delete photo: {{error}}",
+    "deleteMedia": "Delete media",
+    "uploadMedia": "Upload media",
     "archivePhotoAlt": "Archive photo for {{title}} {{index}}",
-    "noImagesYet": "No images yet",
     "edit": {
       "add": "Add info",
       "edit": "Edit",
@@ -175,7 +173,10 @@
       "teaser": "Teaser",
       "info": "Info",
       "search_tags": "Search tags...",
-      "no_tags": "No tags found"
+      "no_tags": "No tags found",
+      "delete": "Delete",
+      "confirmDeleteTitle": "Delete media?",
+      "confirmDeleteBody": "Are you sure you want to delete this image? This action cannot be undone."
     },
     "delete": {
       "delete": "Delete info (en)",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -192,7 +192,7 @@
       "no_tags": "No tags found",
       "delete": "Delete",
       "confirmDeleteTitle": "Delete media?",
-      "confirmDeleteBody": "Are you sure you want to delete this image? This action cannot be undone."
+      "confirmDeleteBody": "Are you sure you want to delete this image? This action cannot be undone.",
       "create_new_tag": "Create new tag \"{{tag}}\"",
       "create_tag": "Create tag",
       "create_tag_description": "Enter the Dutch and English names for the tag.",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -156,6 +156,10 @@
     "address": "Address",
     "addressUnknown": "Address unknown",
     "visualEvidence": "Photos",
+    "confirmDeleteMedia": "Are you sure you want to delete this media item? This action cannot be undone.",
+    "deleteMedia": "Delete photo",
+    "deleteMediaFailed": "Failed to delete photo: {{error}}",
+    "archivePhotoAlt": "Archive photo for {{title}} {{index}}",
     "edit": {
       "add": "Add info",
       "edit": "Edit",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -190,7 +190,7 @@
       "no_tags": "Geen tags gevonden",
       "delete": "Verwijder",
       "confirmDeleteTitle": "Verwijder media?",
-      "confirmDeleteBody": "Bent u zeker dat dit bestand verwijderd mag worden? Deze actie kan niet ongedaan gemaakt worden."
+      "confirmDeleteBody": "Bent u zeker dat dit bestand verwijderd mag worden? Deze actie kan niet ongedaan gemaakt worden.",
       "create_new_tag": "Maak nieuwe tag \"{{tag}}\" aan",
       "create_tag": "Tag aanmaken",
       "create_tag_description": "Voer de Nederlandse en Engelse naam van de tag in.",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -156,11 +156,9 @@
     "address": "Adres",
     "addressUnknown": "Adres onbekend",
     "visualEvidence": "Foto's",
-    "confirmDeleteMedia": "Weet je zeker dat je dit media-item wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
-    "deleteMedia": "Foto verwijderen",
-    "deleteMediaFailed": "Foto verwijderen mislukt: {{error}}",
+    "deleteMedia": "Verwijder media",
+    "uploadMedia": "Upload media",
     "archivePhotoAlt": "Archieffoto voor {{title}} {{index}}",
-    "noImagesYet": "Nog geen afbeeldingen",
     "edit": {
       "add": "Voeg info toe",
       "edit": "Pas aan",
@@ -175,7 +173,10 @@
       "teaser": "Teaser",
       "info": "Info",
       "search_tags": "Zoek tags...",
-      "no_tags": "Geen tags gevonden"
+      "no_tags": "Geen tags gevonden",
+      "delete": "Verwijder",
+      "confirmDeleteTitle": "Verwijder media?",
+      "confirmDeleteBody": "Bent u zeker dat dit bestand verwijderd mag worden? Deze actie kan niet ongedaan gemaakt worden."
     },
     "delete": {
       "delete": "Verwijder info (nl)",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -160,6 +160,7 @@
     "deleteMedia": "Foto verwijderen",
     "deleteMediaFailed": "Foto verwijderen mislukt: {{error}}",
     "archivePhotoAlt": "Archieffoto voor {{title}} {{index}}",
+    "noImagesYet": "Nog geen afbeeldingen",
     "edit": {
       "add": "Voeg info toe",
       "edit": "Pas aan",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -156,6 +156,10 @@
     "address": "Adres",
     "addressUnknown": "Adres onbekend",
     "visualEvidence": "Foto's",
+    "confirmDeleteMedia": "Weet je zeker dat je dit media-item wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+    "deleteMedia": "Foto verwijderen",
+    "deleteMediaFailed": "Foto verwijderen mislukt: {{error}}",
+    "archivePhotoAlt": "Archieffoto voor {{title}} {{index}}",
     "edit": {
       "add": "Voeg info toe",
       "edit": "Pas aan",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -159,6 +159,9 @@
     "deleteMedia": "Verwijder media",
     "uploadMedia": "Upload media",
     "archivePhotoAlt": "Archieffoto voor {{title}} {{index}}",
+    "noImagesYet": "Nog geen foto's",
+    "closeLightbox": "Sluit fotokijker",
+    "archivePhoto": "Archieffoto",
     "edit": {
       "add": "Voeg info toe",
       "edit": "Pas aan",

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -164,6 +164,14 @@ const translationMap: Record<string, TranslationValue> = {
   "productionPage.edit.cancel": "I18N_ProductionPage_Edit_Cancel",
   "productionPage.edit.attendance_mode": "I18N_ProductionPage_AttendanceMode",
   "productionPage.edit.performer_type": "I18N_ProductionPage_PerformerType",
+  "productionPage.deleteMedia": "I18N_Production_DeleteMedia",
+  "productionPage.uploadMedia": "I18N_Production_UploadMedia",
+  "productionPage.noImagesYet": "I18N_Production_NoImagesYet",
+  "productionPage.closeLightbox": "I18N_Production_CloseLightbox",
+  "productionPage.archivePhoto": "I18N_Production_ArchivePhoto",
+  "productionPage.edit.confirmDeleteTitle": "I18N_Production_ConfirmDeleteTitle",
+  "productionPage.edit.confirmDeleteBody": "I18N_Production_ConfirmDeleteBody",
+  "productionPage.edit.delete": "I18N_Production_Edit_Delete",
 };
 
 const mockTranslate = (key: string, options?: TranslationOptions) => {

--- a/frontend/tests/unit/productionPageMediaGallery.test.tsx
+++ b/frontend/tests/unit/productionPageMediaGallery.test.tsx
@@ -84,7 +84,7 @@ describe("ProductionPageMediaGallery", () => {
       renderGallery({ isEditing: false });
 
       expect(
-        screen.queryByRole("button", { name: "productionPage.uploadMedia" })
+        screen.queryByRole("button", { name: "I18N_Production_UploadMedia" })
       ).not.toBeInTheDocument();
     });
 
@@ -92,7 +92,7 @@ describe("ProductionPageMediaGallery", () => {
       renderGallery({ isEditing: false });
 
       expect(
-        screen.queryByRole("button", { name: "productionPage.deleteMedia" })
+        screen.queryByRole("button", { name: "I18N_Production_DeleteMedia" })
       ).not.toBeInTheDocument();
     });
 
@@ -103,7 +103,7 @@ describe("ProductionPageMediaGallery", () => {
       await user.click(images[0]);
 
       expect(
-        screen.getByRole("button", { name: "productionPage.closeLightbox" })
+        screen.getByRole("button", { name: "I18N_Production_CloseLightbox" })
       ).toBeInTheDocument();
     });
   });
@@ -125,7 +125,7 @@ describe("ProductionPageMediaGallery", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: "productionPage.uploadMedia" })
+          screen.getByRole("button", { name: "I18N_Production_UploadMedia" })
         ).toBeInTheDocument();
       });
     });
@@ -135,7 +135,7 @@ describe("ProductionPageMediaGallery", () => {
 
       await waitFor(() => {
         const deleteButtons = screen.getAllByRole("button", {
-          name: "productionPage.deleteMedia",
+          name: "I18N_Production_DeleteMedia",
         });
         expect(deleteButtons).toHaveLength(2);
       });
@@ -149,7 +149,9 @@ describe("ProductionPageMediaGallery", () => {
 
       renderGallery({ isEditing: true });
 
-      expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
+      expect(
+        await screen.findByText("I18N_Production_NoImagesYet")
+      ).toBeInTheDocument();
     });
 
     it("shows the no-media message when the fetch fails", async () => {
@@ -157,7 +159,9 @@ describe("ProductionPageMediaGallery", () => {
 
       renderGallery({ isEditing: true });
 
-      expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
+      expect(
+        await screen.findByText("I18N_Production_NoImagesYet")
+      ).toBeInTheDocument();
     });
 
     it("does not render the no-media message when images are present", async () => {
@@ -165,7 +169,7 @@ describe("ProductionPageMediaGallery", () => {
 
       await screen.findAllByRole("img");
 
-      expect(screen.queryByText("productionPage.noImagesYet")).not.toBeInTheDocument();
+      expect(screen.queryByText("I18N_Production_NoImagesYet")).not.toBeInTheDocument();
     });
   });
 
@@ -174,24 +178,22 @@ describe("ProductionPageMediaGallery", () => {
       const { user } = renderGallery({ isEditing: true });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
 
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
-        screen.getByText("productionPage.edit.confirmDeleteTitle")
+        screen.getByText("I18N_Production_ConfirmDeleteTitle")
       ).toBeInTheDocument();
-      expect(
-        screen.getByText("productionPage.edit.confirmDeleteBody")
-      ).toBeInTheDocument();
+      expect(screen.getByText("I18N_Production_ConfirmDeleteBody")).toBeInTheDocument();
     });
 
     it("closes the dialog without deleting when cancel is clicked", async () => {
       const { user } = renderGallery({ isEditing: true });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
@@ -199,7 +201,7 @@ describe("ProductionPageMediaGallery", () => {
       );
 
       expect(
-        screen.queryByText("productionPage.edit.confirmDeleteTitle")
+        screen.queryByText("I18N_Production_ConfirmDeleteTitle")
       ).not.toBeInTheDocument();
       expect(vi.mocked(deleteMedia)).not.toHaveBeenCalled();
     });
@@ -208,11 +210,11 @@ describe("ProductionPageMediaGallery", () => {
       const { user } = renderGallery({ isEditing: true });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
       await waitFor(() => {
@@ -225,11 +227,11 @@ describe("ProductionPageMediaGallery", () => {
 
       await screen.findAllByRole("img");
       const deleteButtons = screen.getAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
       await waitFor(() => {
@@ -241,16 +243,16 @@ describe("ProductionPageMediaGallery", () => {
       const { user } = renderGallery({ isEditing: true });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
       await waitFor(() => {
         expect(
-          screen.queryByText("productionPage.edit.confirmDeleteTitle")
+          screen.queryByText("I18N_Production_ConfirmDeleteTitle")
         ).not.toBeInTheDocument();
       });
     });
@@ -260,11 +262,11 @@ describe("ProductionPageMediaGallery", () => {
       const { user } = renderGallery({ isEditing: true, setMediaEdited });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
       await waitFor(() => {
@@ -282,15 +284,15 @@ describe("ProductionPageMediaGallery", () => {
       const { user } = renderGallery({ isEditing: true });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
       expect(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       ).toBeDisabled();
 
       resolveDelete();
@@ -305,14 +307,16 @@ describe("ProductionPageMediaGallery", () => {
       const { user } = renderGallery({ isEditing: true });
 
       const deleteButtons = await screen.findAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
-      expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
+      expect(
+        await screen.findByText("I18N_Production_NoImagesYet")
+      ).toBeInTheDocument();
     });
   });
 
@@ -320,7 +324,7 @@ describe("ProductionPageMediaGallery", () => {
     it("calls uploadMedia with the correct production id and file", async () => {
       const { user } = renderGallery({ isEditing: true });
 
-      await screen.findByRole("button", { name: "productionPage.uploadMedia" });
+      await screen.findByRole("button", { name: "I18N_Production_UploadMedia" });
       const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
       const input = document.querySelector<HTMLInputElement>("input[type='file']")!;
       await user.upload(input, file);
@@ -348,9 +352,9 @@ describe("ProductionPageMediaGallery", () => {
     it("shows a delete button on the newly uploaded image", async () => {
       const { user } = renderGallery({ isEditing: true });
 
-      await screen.findAllByRole("button", { name: "productionPage.deleteMedia" });
+      await screen.findAllByRole("button", { name: "I18N_Production_DeleteMedia" });
       const before = screen.getAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       }).length;
 
       const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
@@ -359,7 +363,7 @@ describe("ProductionPageMediaGallery", () => {
 
       await waitFor(() => {
         expect(
-          screen.getAllByRole("button", { name: "productionPage.deleteMedia" })
+          screen.getAllByRole("button", { name: "I18N_Production_DeleteMedia" })
         ).toHaveLength(before + 1);
       });
     });
@@ -368,7 +372,7 @@ describe("ProductionPageMediaGallery", () => {
       const setMediaEdited = vi.fn();
       const { user } = renderGallery({ isEditing: true, setMediaEdited });
 
-      await screen.findByRole("button", { name: "productionPage.uploadMedia" });
+      await screen.findByRole("button", { name: "I18N_Production_UploadMedia" });
       const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
       const input = document.querySelector<HTMLInputElement>("input[type='file']")!;
       await user.upload(input, file);
@@ -387,9 +391,9 @@ describe("ProductionPageMediaGallery", () => {
       await user.click(images[0]);
 
       expect(
-        screen.getByRole("button", { name: "productionPage.closeLightbox" })
+        screen.getByRole("button", { name: "I18N_Production_CloseLightbox" })
       ).toBeInTheDocument();
-      expect(screen.getByAltText("productionPage.archivePhoto")).toHaveAttribute(
+      expect(screen.getByAltText("I18N_Production_ArchivePhoto")).toHaveAttribute(
         "src",
         "https://example.com/image1.jpg"
       );
@@ -401,11 +405,11 @@ describe("ProductionPageMediaGallery", () => {
       const images = await screen.findAllByRole("img");
       await user.click(images[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.closeLightbox" })
+        screen.getByRole("button", { name: "I18N_Production_CloseLightbox" })
       );
 
       expect(
-        screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+        screen.queryByRole("button", { name: "I18N_Production_CloseLightbox" })
       ).not.toBeInTheDocument();
     });
 
@@ -419,7 +423,7 @@ describe("ProductionPageMediaGallery", () => {
       await user.click(dialog);
 
       expect(
-        screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+        screen.queryByRole("button", { name: "I18N_Production_CloseLightbox" })
       ).not.toBeInTheDocument();
     });
 
@@ -431,7 +435,7 @@ describe("ProductionPageMediaGallery", () => {
       await user.keyboard("{Escape}");
 
       expect(
-        screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+        screen.queryByRole("button", { name: "I18N_Production_CloseLightbox" })
       ).not.toBeInTheDocument();
     });
 
@@ -441,7 +445,7 @@ describe("ProductionPageMediaGallery", () => {
       const images = await screen.findAllByRole("img");
       await user.click(images[1]);
 
-      expect(screen.getByAltText("productionPage.archivePhoto")).toHaveAttribute(
+      expect(screen.getByAltText("I18N_Production_ArchivePhoto")).toHaveAttribute(
         "src",
         "https://example.com/image2.jpg"
       );
@@ -455,16 +459,16 @@ describe("ProductionPageMediaGallery", () => {
 
       // delete from within the lightbox (or gallery card — either triggers same flow)
       const deleteButtons = screen.getAllByRole("button", {
-        name: "productionPage.deleteMedia",
+        name: "I18N_Production_DeleteMedia",
       });
       await user.click(deleteButtons[0]);
       await user.click(
-        screen.getByRole("button", { name: "productionPage.edit.delete" })
+        screen.getByRole("button", { name: "I18N_Production_Edit_Delete" })
       );
 
       await waitFor(() => {
         expect(
-          screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+          screen.queryByRole("button", { name: "I18N_Production_CloseLightbox" })
         ).not.toBeInTheDocument();
       });
     });

--- a/frontend/tests/unit/productionPageMediaGallery.test.tsx
+++ b/frontend/tests/unit/productionPageMediaGallery.test.tsx
@@ -1,0 +1,440 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProductionPageMediaGallery } from "~/features/archive/components/ProductionPageMediaGallery";
+import type { MediaList } from "~/features/archive/types/mediaTypes";
+import {
+  deleteMedia,
+  getMediaForProduction,
+  uploadMedia,
+} from "~/features/archive/services/mediaService";
+
+vi.mock("~/features/archive/services/mediaService", () => ({
+  getMediaForProduction: vi.fn(),
+  deleteMedia: vi.fn(),
+  uploadMedia: vi.fn(),
+}));
+
+const PRODUCTION_ID_URL = "http://localhost/api/v1/productions/1";
+
+const baseMediaResponse: MediaList = {
+  media: [
+    {
+      id_url: "http://localhost/api/v1/productions/1/media/10",
+      url: "https://example.com/image1.jpg",
+      production_id_url: PRODUCTION_ID_URL,
+      blog_id_url: null,
+      content_type: "image/jpeg",
+      uploaded_at: "2026-03-29T14:00:00",
+    },
+    {
+      id_url: "http://localhost/api/v1/productions/1/media/11",
+      url: "https://example.com/image2.jpg",
+      production_id_url: PRODUCTION_ID_URL,
+      blog_id_url: null,
+      content_type: "image/jpeg",
+      uploaded_at: "2026-03-29T14:00:00",
+    },
+  ],
+  pagination: {
+    has_more: false,
+    next_cursor: undefined,
+    total_count: 2,
+  },
+};
+
+const baseProps = {
+  title: "Test Production",
+  production_id_url: PRODUCTION_ID_URL,
+  setMediaEdited: vi.fn(),
+};
+
+function renderGallery(props: Partial<typeof baseProps & { isEditing: boolean }> = {}) {
+  return {
+    user: userEvent.setup(),
+    ...render(<ProductionPageMediaGallery {...baseProps} isEditing={false} {...props} />),
+  };
+}
+
+describe("ProductionPageMediaGallery", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(getMediaForProduction).mockResolvedValue(baseMediaResponse);
+    vi.mocked(deleteMedia).mockResolvedValue(undefined);
+    vi.mocked(uploadMedia).mockResolvedValue({
+      id_url: "http://localhost/api/v1/productions/1/media/99",
+      url: "https://example.com/uploaded.jpg",
+      content_type: "image/jpeg",
+      production_id_url: PRODUCTION_ID_URL,
+      blog_id_url: null,
+      uploaded_at: "2026-03-29T14:00:00",
+    });
+  });
+
+  describe("view mode (isEditing: false)", () => {
+    it("fetches media from the service", () => {
+      renderGallery({ isEditing: false });
+
+      expect(vi.mocked(getMediaForProduction)).toHaveBeenCalled();
+    });
+
+    it("does not render the upload button", () => {
+      renderGallery({ isEditing: false });
+
+      expect(
+        screen.queryByRole("button", { name: "productionPage.uploadMedia" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render delete buttons on images", () => {
+      renderGallery({ isEditing: false });
+
+      expect(
+        screen.queryByRole("button", { name: "productionPage.deleteMedia" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("images are still clickable to open the lightbox", async () => {
+      const { user } = renderGallery({ isEditing: false });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[0]);
+
+      expect(
+        screen.getByRole("button", { name: "productionPage.closeLightbox" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("edit mode (isEditing: true)", () => {
+    it("fetches media from the service on mount", async () => {
+      renderGallery({ isEditing: true });
+
+      await waitFor(() => {
+        expect(vi.mocked(getMediaForProduction)).toHaveBeenCalledWith(
+          1,
+          expect.any(Object)
+        );
+      });
+    });
+
+    it("renders the upload button", async () => {
+      renderGallery({ isEditing: true });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "productionPage.uploadMedia" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders a delete button on each fetched media image", async () => {
+      renderGallery({ isEditing: true });
+
+      await waitFor(() => {
+        const deleteButtons = screen.getAllByRole("button", {
+          name: "productionPage.deleteMedia",
+        });
+        expect(deleteButtons).toHaveLength(2);
+      });
+    });
+
+    it("shows the no-media message when fetch returns no images", async () => {
+      vi.mocked(getMediaForProduction).mockResolvedValue({
+        media: [],
+        pagination: { has_more: false, next_cursor: undefined, total_count: 0 },
+      });
+
+      renderGallery({ isEditing: true });
+
+      expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
+    });
+
+    it("shows the no-media message when the fetch fails", async () => {
+      vi.mocked(getMediaForProduction).mockRejectedValue(new Error("Network error"));
+
+      renderGallery({ isEditing: true });
+
+      expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
+    });
+
+    it("does not render the no-media message when images are present", async () => {
+      renderGallery({ isEditing: true });
+
+      await screen.findAllByRole("img");
+
+      expect(screen.queryByText("productionPage.noImagesYet")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("delete functionality", () => {
+    it("opens a confirmation dialog when the delete button is clicked", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText("productionPage.edit.confirmDeleteTitle")).toBeInTheDocument();
+      expect(screen.getByText("productionPage.edit.confirmDeleteBody")).toBeInTheDocument();
+    });
+
+    it("closes the dialog without deleting when cancel is clicked", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "I18N_ProductionPage_Edit_Cancel" }));
+
+      expect(screen.queryByText("productionPage.edit.confirmDeleteTitle")).not.toBeInTheDocument();
+      expect(vi.mocked(deleteMedia)).not.toHaveBeenCalled();
+    });
+
+    it("calls deleteMedia with the correct ids when confirmed", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      await waitFor(() => {
+        expect(vi.mocked(deleteMedia)).toHaveBeenCalledWith(1, 10);
+      });
+    });
+
+    it("removes the deleted image from the gallery after confirmation", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      await screen.findAllByRole("img");
+      const deleteButtons = screen.getAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("img")).toHaveLength(1);
+      });
+    });
+
+    it("closes the dialog after a successful delete", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("productionPage.edit.confirmDeleteTitle")).not.toBeInTheDocument();
+      });
+    });
+
+    it("calls setMediaEdited after a successful delete", async () => {
+      const setMediaEdited = vi.fn();
+      const { user } = renderGallery({ isEditing: true, setMediaEdited });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      await waitFor(() => {
+        expect(setMediaEdited).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it("disables the confirm delete button while deleting", async () => {
+      let resolveDelete!: () => void;
+      vi.mocked(deleteMedia).mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        })
+      );
+      const { user } = renderGallery({ isEditing: true });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      expect(screen.getByRole("button", { name: "productionPage.edit.delete" })).toBeDisabled();
+
+      resolveDelete();
+    });
+
+    it("shows the no-media message after the last image is deleted", async () => {
+      vi.mocked(getMediaForProduction).mockResolvedValue({
+        media: [baseMediaResponse.media[0]!],
+        pagination: { has_more: false, next_cursor: undefined, total_count: 1 },
+      });
+
+      const { user } = renderGallery({ isEditing: true });
+
+      const deleteButtons = await screen.findAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
+    });
+  });
+
+  describe("upload functionality", () => {
+    it("calls uploadMedia with the correct production id and file", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      await screen.findByRole("button", { name: "productionPage.uploadMedia" });
+      const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
+      const input = document.querySelector<HTMLInputElement>("input[type='file']")!;
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(vi.mocked(uploadMedia)).toHaveBeenCalledWith(1, file);
+      });
+    });
+
+    it("appends the uploaded image to the gallery", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      await screen.findAllByRole("img");
+      const before = screen.getAllByRole("img").length;
+
+      const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
+      const input = document.querySelector<HTMLInputElement>("input[type='file']")!;
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("img")).toHaveLength(before + 1);
+      });
+    });
+
+    it("shows a delete button on the newly uploaded image", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      await screen.findAllByRole("button", { name: "productionPage.deleteMedia" });
+      const before = screen.getAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      }).length;
+
+      const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
+      const input = document.querySelector<HTMLInputElement>("input[type='file']")!;
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByRole("button", { name: "productionPage.deleteMedia" })
+        ).toHaveLength(before + 1);
+      });
+    });
+
+    it("calls setMediaEdited after a successful upload", async () => {
+      const setMediaEdited = vi.fn();
+      const { user } = renderGallery({ isEditing: true, setMediaEdited });
+
+      await screen.findByRole("button", { name: "productionPage.uploadMedia" });
+      const file = new File(["img"], "photo.jpg", { type: "image/jpeg" });
+      const input = document.querySelector<HTMLInputElement>("input[type='file']")!;
+      await user.upload(input, file);
+
+      await waitFor(() => {
+        expect(setMediaEdited).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+
+  describe("lightbox", () => {
+    it("opens the lightbox when an image is clicked", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[0]);
+
+      expect(
+        screen.getByRole("button", { name: "productionPage.closeLightbox" })
+      ).toBeInTheDocument();
+      expect(screen.getByAltText("productionPage.archivePhoto")).toHaveAttribute(
+        "src",
+        "https://example.com/image1.jpg"
+      );
+    });
+
+    it("closes the lightbox when the close button is clicked", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.closeLightbox" }));
+
+      expect(
+        screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("closes the lightbox when the backdrop is clicked", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[0]);
+
+      const dialog = screen.getByRole("dialog");
+      await user.click(dialog);
+
+      expect(
+        screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("closes the lightbox when escape is pressed", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[0]);
+      await user.keyboard("{Escape}");
+
+      expect(
+        screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the correct image when a second image is clicked", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[1]);
+
+      expect(screen.getByAltText("productionPage.archivePhoto")).toHaveAttribute(
+        "src",
+        "https://example.com/image2.jpg"
+      );
+    });
+
+    it("closes the lightbox when the open image is deleted", async () => {
+      const { user } = renderGallery({ isEditing: true });
+
+      const images = await screen.findAllByRole("img");
+      await user.click(images[0]);
+
+      // delete from within the lightbox (or gallery card — either triggers same flow)
+      const deleteButtons = screen.getAllByRole("button", { name: "productionPage.deleteMedia" });
+      await user.click(deleteButtons[0]);
+      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: "productionPage.closeLightbox" })
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/tests/unit/productionPageMediaGallery.test.tsx
+++ b/frontend/tests/unit/productionPageMediaGallery.test.tsx
@@ -52,7 +52,9 @@ const baseProps = {
 function renderGallery(props: Partial<typeof baseProps & { isEditing: boolean }> = {}) {
   return {
     user: userEvent.setup(),
-    ...render(<ProductionPageMediaGallery {...baseProps} isEditing={false} {...props} />),
+    ...render(
+      <ProductionPageMediaGallery {...baseProps} isEditing={false} {...props} />
+    ),
   };
 }
 
@@ -177,8 +179,12 @@ describe("ProductionPageMediaGallery", () => {
       await user.click(deleteButtons[0]);
 
       expect(screen.getByRole("dialog")).toBeInTheDocument();
-      expect(screen.getByText("productionPage.edit.confirmDeleteTitle")).toBeInTheDocument();
-      expect(screen.getByText("productionPage.edit.confirmDeleteBody")).toBeInTheDocument();
+      expect(
+        screen.getByText("productionPage.edit.confirmDeleteTitle")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("productionPage.edit.confirmDeleteBody")
+      ).toBeInTheDocument();
     });
 
     it("closes the dialog without deleting when cancel is clicked", async () => {
@@ -188,9 +194,13 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "I18N_ProductionPage_Edit_Cancel" }));
+      await user.click(
+        screen.getByRole("button", { name: "I18N_ProductionPage_Edit_Cancel" })
+      );
 
-      expect(screen.queryByText("productionPage.edit.confirmDeleteTitle")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("productionPage.edit.confirmDeleteTitle")
+      ).not.toBeInTheDocument();
       expect(vi.mocked(deleteMedia)).not.toHaveBeenCalled();
     });
 
@@ -201,7 +211,9 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
       await waitFor(() => {
         expect(vi.mocked(deleteMedia)).toHaveBeenCalledWith(1, 10);
@@ -216,7 +228,9 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
       await waitFor(() => {
         expect(screen.getAllByRole("img")).toHaveLength(1);
@@ -230,10 +244,14 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
       await waitFor(() => {
-        expect(screen.queryByText("productionPage.edit.confirmDeleteTitle")).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("productionPage.edit.confirmDeleteTitle")
+        ).not.toBeInTheDocument();
       });
     });
 
@@ -245,7 +263,9 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
       await waitFor(() => {
         expect(setMediaEdited).toHaveBeenCalledWith(true);
@@ -265,9 +285,13 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
-      expect(screen.getByRole("button", { name: "productionPage.edit.delete" })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      ).toBeDisabled();
 
       resolveDelete();
     });
@@ -284,7 +308,9 @@ describe("ProductionPageMediaGallery", () => {
         name: "productionPage.deleteMedia",
       });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
       expect(await screen.findByText("productionPage.noImagesYet")).toBeInTheDocument();
     });
@@ -374,7 +400,9 @@ describe("ProductionPageMediaGallery", () => {
 
       const images = await screen.findAllByRole("img");
       await user.click(images[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.closeLightbox" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.closeLightbox" })
+      );
 
       expect(
         screen.queryByRole("button", { name: "productionPage.closeLightbox" })
@@ -426,9 +454,13 @@ describe("ProductionPageMediaGallery", () => {
       await user.click(images[0]);
 
       // delete from within the lightbox (or gallery card — either triggers same flow)
-      const deleteButtons = screen.getAllByRole("button", { name: "productionPage.deleteMedia" });
+      const deleteButtons = screen.getAllByRole("button", {
+        name: "productionPage.deleteMedia",
+      });
       await user.click(deleteButtons[0]);
-      await user.click(screen.getByRole("button", { name: "productionPage.edit.delete" }));
+      await user.click(
+        screen.getByRole("button", { name: "productionPage.edit.delete" })
+      );
 
       await waitFor(() => {
         expect(


### PR DESCRIPTION
### Beschrijving
Je kan in een gemaakte productie nu foto's toevoegen en verwijderen. Het is ook mogelijk op fotos te klikken zodat ze volledig zichtbaar zijn. 

Dit is een combinatie van hoe de mediagallery werkt in blogs samen met het openen van fotos in een apart scherm van visuals.

### Aangepaste delen
Producitonmediagallery en een beejte Producitonpage

Closes #448 
