### PR TITLE
Fix Bug CreateProduction Cancel

### DIFF
--- a/frontend/app/features/archive/components/EditButton.tsx
+++ b/frontend/app/features/archive/components/EditButton.tsx
@@ -30,6 +30,7 @@ type EditButtonProps = {
   enable_save: boolean;
   is_saving: boolean;
   _handleSave: () => Promise<void>;
+  _handleCancel?: () => void | Promise<void>;
   permissions: string[];
 };
 
@@ -52,6 +53,7 @@ export function EditButton({
   enable_save,
   is_saving,
   _handleSave,
+  _handleCancel,
   permissions,
 }: EditButtonProps) {
   const { t } = useTranslation();
@@ -82,17 +84,21 @@ export function EditButton({
           <button
             id="cancel-edit-production-button"
             onClick={() => {
-              // Copy (not by reference)
-              setDraftInfo(originalInfo ? { ...originalInfo } : null);
-              setDraftTags(originalTags ? [...originalTags] : []);
-              setDraftEvents(
-                originalEvents ? originalEvents.map((e) => ({ ...e })) : []
-              );
-              setNewEvents([]);
-              setDeletedEvents([]);
-              setIsEditing(false);
-              setDraftAttendanceMode(originalAttendanceMode);
-              setDraftPerformerType(originalPerformerType);
+              if (_handleCancel) {
+                _handleCancel();
+              } else {
+                // Copy (not by reference)
+                setDraftInfo(originalInfo ? { ...originalInfo } : null);
+                setDraftTags(originalTags ? [...originalTags] : []);
+                setDraftEvents(
+                  originalEvents ? originalEvents.map((e) => ({ ...e })) : []
+                );
+                setNewEvents([]);
+                setDeletedEvents([]);
+                setIsEditing(false);
+                setDraftAttendanceMode(originalAttendanceMode);
+                setDraftPerformerType(originalPerformerType);
+              }
             }}
             className={`${shared_css} bg-gray-300`}
           >

--- a/frontend/app/features/archive/components/EditButton.tsx
+++ b/frontend/app/features/archive/components/EditButton.tsx
@@ -88,6 +88,9 @@ export function EditButton({
                 _handleCancel();
               } else {
                 // Copy (not by reference)
+                if (enable_save && !window.confirm(t("notSaveChanges"))) {
+                  return;
+                }
                 setDraftInfo(originalInfo ? { ...originalInfo } : null);
                 setDraftTags(originalTags ? [...originalTags] : []);
                 setDraftEvents(

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -143,6 +143,16 @@ export function CreateProductionPage() {
     !skipWarningState && !isSaving && (isInfoModified(draftInfo) || isQuillDirty)
   );
   const navigate = useNavigate();
+
+  const isModified = useMemo(() => {
+    return (
+      draftTags.length > 0 ||
+      draftEvents.length > 0 ||
+      isInfoModified(draftInfo) ||
+      isQuillDirty
+    );
+  }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
+
   const handleCancel = async () => {
     if (isModified && !window.confirm(t("notSaveChanges"))) {
       return;
@@ -166,14 +176,6 @@ export function CreateProductionPage() {
     skipWarning.current = true;
     navigate("/archive");
   };
-  const isModified = useMemo(() => {
-    return (
-      draftTags.length > 0 ||
-      draftEvents.length > 0 ||
-      isInfoModified(draftInfo) ||
-      isQuillDirty
-    );
-  }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
 
   const _handleAddProduction = () =>
     handleAddProduction(

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -179,18 +179,24 @@ export function CreateProductionPage() {
     }
   }, [blocker, t]);
 
-  const handleCancel = async () => {
+  const handleCancel = () => {
     if (isModified) {
-      setIsCancelling(true);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      if (!window.confirm(t("notSaveChanges"))) {
-        setIsCancelling(false);
-        return;
-      }
+      setIsCancelling(true); // triggert re-render → blocker uit → useEffect hieronder
+    } else {
+      skipWarning.current = true;
+      navigate("/archive");
     }
-    skipWarning.current = true;
-    navigate("/archive");
   };
+
+  useEffect(() => {
+    if (!isCancelling) return;
+    const confirmed = window.confirm(t("notSaveChanges"));
+    if (confirmed) {
+      skipWarning.current = true;
+      navigate("/archive");
+    }
+    setIsCancelling(false);
+  }, [isCancelling]);
 
   const _handleAddProduction = () =>
     handleAddProduction(

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -179,9 +179,12 @@ export function CreateProductionPage() {
     }
   }, [blocker, t]);
 
+  const isCancellingRef = useRef(false);
+
   const handleCancel = () => {
     if (isModified) {
-      setIsCancelling(true); // triggert re-render → blocker uit → useEffect hieronder
+      isCancellingRef.current = true;
+      setIsCancelling(true);
     } else {
       skipWarning.current = true;
       navigate("/archive");
@@ -190,13 +193,17 @@ export function CreateProductionPage() {
 
   useEffect(() => {
     if (!isCancelling) return;
+    if (!isCancellingRef.current) return;
+    isCancellingRef.current = false;
+
     const confirmed = window.confirm(t("notSaveChanges"));
     if (confirmed) {
       skipWarning.current = true;
       navigate("/archive");
+    } else {
+      setIsCancelling(false);
     }
-    setIsCancelling(false);
-  }, [isCancelling]);
+  }, [isCancelling, t, navigate]);
 
   const _handleAddProduction = () =>
     handleAddProduction(

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -155,15 +155,15 @@ export function CreateProductionPage() {
   );
 
   useEffect(() => {
-  if (blocker.state === "blocked") {
-    const confirmed = window.confirm(t("notSaveChanges"));
-    if (confirmed) {
-      blocker.proceed();
-    } else {
-      blocker.reset();
+    if (blocker.state === "blocked") {
+      const confirmed = window.confirm(t("notSaveChanges"));
+      if (confirmed) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
     }
-  }
-}, [blocker.state]);
+  }, [blocker.state]);
 
   const handleCancel = async () => {
     if (isModified) {

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -139,6 +139,25 @@ export function CreateProductionPage() {
   const skipWarning = useRef(false);
   const [skipWarningState, setSkipWarningState] = useState(false);
 
+  const handleCancel = () => {
+    setDraftInfo({
+      production_id_url: "",
+      language: lang!,
+      title: "",
+      supertitle: "",
+      artist: "",
+      tagline: "",
+      teaser: "",
+      description: "",
+      info: "",
+    });
+    setDraftTags([]);
+    setDraftEvents([]);
+    setDraftAttendanceMode("");
+    setDraftPerformerType("");
+    setIsQuillDirty(false);
+  };
+
   useUnsavedChangesBlocker(
     !skipWarningState && !isSaving && (isInfoModified(draftInfo) || isQuillDirty)
   );
@@ -279,6 +298,7 @@ export function CreateProductionPage() {
             originalPerformerType=""
             is_saving={isSaving}
             _handleSave={_handleAddProduction}
+            _handleCancel={handleCancel}
             originalTags={null}
             setDraftTags={() => {}}
             permissions={[ARCHIVE_PERMISSIONS.create]}

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -35,8 +35,6 @@ function isInfoModified(draftInfo: ProductionInfo | null): boolean {
   );
 }
 
-// ─── Save handler ──────────────────────────────────────────────────────────
-
 async function handleAddProduction(
   language: string,
   attendanceMode: string,
@@ -110,8 +108,6 @@ async function handleAddProduction(
   }
 }
 
-// ─── Access denied ─────────────────────────────────────────────────────────
-
 export function CreateProductionPageAccessDenied() {
   const { t } = useTranslation();
 
@@ -132,8 +128,6 @@ export function CreateProductionPageAccessDenied() {
     </section>
   );
 }
-
-// ─── Page ──────────────────────────────────────────────────────────────────
 
 export function CreateProductionPage() {
   const { lang } = useParams();
@@ -182,17 +176,19 @@ export function CreateProductionPage() {
     draftEvents,
     draftAttendanceMode,
     draftPerformerType,
+    mediaFiles,
   ]);
 
   const [isCancelling, setIsCancelling] = useState(false);
 
   const blocker = useBlocker(
-    !isSaving &&
+    (!isSaving &&
       !isCancelling &&
       (isInfoModified(draftInfo) ||
         draftAttendanceMode !== "" ||
         draftPerformerType !== "" ||
-        isQuillDirty)
+        isQuillDirty)) ||
+      mediaFiles.length > 0
   );
 
   useEffect(() => {

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -163,7 +163,7 @@ export function CreateProductionPage() {
         blocker.reset();
       }
     }
-  }, [blocker.state]);
+  }, [blocker, t]);
 
   const handleCancel = async () => {
     if (isModified) {

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -161,7 +161,7 @@ export function CreateProductionPage() {
     setDraftPerformerType("");
     setIsQuillDirty(false);
     skipWarning.current = true;
-    navigate("../..");
+    navigate("/archive");
   };
   const isModified = useMemo(() => {
     return (

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -144,6 +144,9 @@ export function CreateProductionPage() {
   );
   const navigate = useNavigate();
   const handleCancel = async () => {
+    if (isModified && !window.confirm(t("notSaveChanges"))) {
+      return;
+    }
     setDraftInfo({
       production_id_url: "",
       language: lang!,

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -139,7 +139,11 @@ export function CreateProductionPage() {
   const skipWarning = useRef(false);
   const [skipWarningState, setSkipWarningState] = useState(false);
 
-  const handleCancel = () => {
+  useUnsavedChangesBlocker(
+    !skipWarningState && !isSaving && (isInfoModified(draftInfo) || isQuillDirty)
+  );
+  const navigate = useNavigate();
+  const handleCancel = async () => {
     setDraftInfo({
       production_id_url: "",
       language: lang!,
@@ -156,12 +160,9 @@ export function CreateProductionPage() {
     setDraftAttendanceMode("");
     setDraftPerformerType("");
     setIsQuillDirty(false);
+    skipWarning.current = true;
+    navigate("..");
   };
-
-  useUnsavedChangesBlocker(
-    !skipWarningState && !isSaving && (isInfoModified(draftInfo) || isQuillDirty)
-  );
-  const navigate = useNavigate();
   const isModified = useMemo(() => {
     return (
       draftTags.length > 0 ||

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -148,28 +148,29 @@ export function CreateProductionPage() {
     );
   }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
 
-  const isCancelling = useRef(false);
+  const [isCancelling, setIsCancelling] = useState(false);
 
   const blocker = useBlocker(
-    !isSaving && !isCancelling.current && (isInfoModified(draftInfo) || isQuillDirty)
+    !isSaving && !isCancelling && (isInfoModified(draftInfo) || isQuillDirty)
   );
 
   useEffect(() => {
-    if (blocker.state === "blocked") {
-      const confirm = window.confirm(t("notSaveChanges"));
-      if (confirm) {
-        blocker.proceed();
-      } else {
-        blocker.reset();
-      }
+  if (blocker.state === "blocked") {
+    const confirmed = window.confirm(t("notSaveChanges"));
+    if (confirmed) {
+      blocker.proceed();
+    } else {
+      blocker.reset();
     }
-  }, [blocker.state]);
+  }
+}, [blocker.state]);
 
   const handleCancel = async () => {
     if (isModified) {
-      isCancelling.current = true;
+      setIsCancelling(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
       if (!window.confirm(t("notSaveChanges"))) {
-        isCancelling.current = false;
+        setIsCancelling(false);
         return;
       }
     }

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -153,7 +153,12 @@ export function CreateProductionPage() {
   const [isCancelling, setIsCancelling] = useState(false);
 
   const blocker = useBlocker(
-    !isSaving && !isCancelling && (isInfoModified(draftInfo) || isQuillDirty)
+    !isSaving &&
+      !isCancelling &&
+      (isInfoModified(draftInfo) ||
+        draftAttendanceMode !== "" ||
+        draftPerformerType !== "" ||
+        isQuillDirty)
   );
 
   useEffect(() => {

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -181,15 +181,7 @@ export function CreateProductionPage() {
 
   const [isCancelling, setIsCancelling] = useState(false);
 
-  const blocker = useBlocker(
-    (!isSaving &&
-      !isCancelling &&
-      (isInfoModified(draftInfo) ||
-        draftAttendanceMode !== "" ||
-        draftPerformerType !== "" ||
-        isQuillDirty)) ||
-      mediaFiles.length > 0
-  );
+  const blocker = useBlocker(!isSaving && !isCancelling && isModified);
 
   useEffect(() => {
     if (blocker.state === "blocked") {

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -161,7 +161,8 @@ export function CreateProductionPage() {
     setDraftPerformerType("");
     setIsQuillDirty(false);
     skipWarning.current = true;
-    navigate("..");
+    const currentParts = window.location.pathname.split("/");
+    navigate(currentParts[currentParts.length - 1]);
   };
   const isModified = useMemo(() => {
     return (

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -180,7 +180,6 @@ export function CreateProductionPage() {
   ]);
 
   const [isCancelling, setIsCancelling] = useState(false);
-
   const blocker = useBlocker(!isSaving && !isCancelling && isModified);
 
   useEffect(() => {
@@ -194,31 +193,23 @@ export function CreateProductionPage() {
     }
   }, [blocker, t]);
 
-  const isCancellingRef = useRef(false);
-
   const handleCancel = () => {
     if (isModified) {
-      isCancellingRef.current = true;
       setIsCancelling(true);
+      queueMicrotask(() => {
+        const confirmed = window.confirm(t("notSaveChanges"));
+        if (confirmed) {
+          skipWarning.current = true;
+          navigate("/archive");
+        } else {
+          setIsCancelling(false);
+        }
+      });
     } else {
       skipWarning.current = true;
       navigate("/archive");
     }
   };
-
-  useEffect(() => {
-    if (!isCancelling) return;
-    if (!isCancellingRef.current) return;
-    isCancellingRef.current = false;
-
-    const confirmed = window.confirm(t("notSaveChanges"));
-    if (confirmed) {
-      skipWarning.current = true;
-      navigate("/archive");
-    } else {
-      setIsCancelling(false);
-    }
-  }, [isCancelling, t, navigate]);
 
   const _handleAddProduction = () =>
     handleAddProduction(

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -161,8 +161,7 @@ export function CreateProductionPage() {
     setDraftPerformerType("");
     setIsQuillDirty(false);
     skipWarning.current = true;
-    const currentParts = window.location.pathname.split("/");
-    navigate(currentParts[currentParts.length - 1]);
+    navigate("../..");
   };
   const isModified = useMemo(() => {
     return (

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -1,7 +1,7 @@
 import { ProductionInfoSection } from "../components/ProductionInfoSection";
 import { ProductionHeader } from "../components/ProductionHeader";
 import { BackToCollectionLink } from "../components/BackToCollectionLink";
-import { useNavigate, useParams } from "react-router";
+import { useBlocker, useNavigate, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ProductionInfo } from "../types/productionTypes";
@@ -9,7 +9,6 @@ import { EditButton } from "../components/EditButton";
 import { createProduction } from "../services/productionService";
 import {
   getSanitizedHtmlOrUndefined,
-  useUnsavedChangesBlocker,
   isEmptyHtml,
 } from "../utils/productionPageFunctions";
 import type { Tag } from "../types/tagTypes";
@@ -137,11 +136,7 @@ export function CreateProductionPage() {
   const [isQuillDirty, setIsQuillDirty] = useState(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const skipWarning = useRef(false);
-  const [skipWarningState, setSkipWarningState] = useState(false);
 
-  useUnsavedChangesBlocker(
-    !skipWarningState && !isSaving && (isInfoModified(draftInfo) || isQuillDirty)
-  );
   const navigate = useNavigate();
 
   const isModified = useMemo(() => {
@@ -153,28 +148,31 @@ export function CreateProductionPage() {
     );
   }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
 
-  const handleCancel = async () => {
-    if (isModified && !window.confirm(t("notSaveChanges"))) {
-      return;
+  const isCancelling = useRef(false);
+
+  const blocker = useBlocker(
+    !isSaving && !isCancelling.current && (isInfoModified(draftInfo) || isQuillDirty)
+  );
+
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      const confirm = window.confirm(t("notSaveChanges"));
+      if (confirm) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
     }
-    skipWarning.current = true;
-    setSkipWarningState(true);
-    setDraftInfo({
-      production_id_url: "",
-      language: lang!,
-      title: "",
-      supertitle: "",
-      artist: "",
-      tagline: "",
-      teaser: "",
-      description: "",
-      info: "",
-    });
-    setDraftTags([]);
-    setDraftEvents([]);
-    setDraftAttendanceMode("");
-    setDraftPerformerType("");
-    setIsQuillDirty(false);
+  }, [blocker.state]);
+
+  const handleCancel = async () => {
+    if (isModified) {
+      isCancelling.current = true;
+      if (!window.confirm(t("notSaveChanges"))) {
+        isCancelling.current = false;
+        return;
+      }
+    }
     skipWarning.current = true;
     navigate("/archive");
   };
@@ -190,7 +188,7 @@ export function CreateProductionPage() {
       setIsSaving,
       t("archive.create_error"),
       skipWarning,
-      setSkipWarningState,
+      () => {},
       navigate
     );
   // TODO

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -148,7 +148,14 @@ export function CreateProductionPage() {
       draftAttendanceMode !== "" ||
       draftPerformerType !== ""
     );
-  }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
+  }, [
+    draftInfo,
+    draftTags,
+    isQuillDirty,
+    draftEvents,
+    draftAttendanceMode,
+    draftPerformerType,
+  ]);
 
   const [isCancelling, setIsCancelling] = useState(false);
 

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -157,6 +157,8 @@ export function CreateProductionPage() {
     if (isModified && !window.confirm(t("notSaveChanges"))) {
       return;
     }
+    skipWarning.current = true;
+    setSkipWarningState(true);
     setDraftInfo({
       production_id_url: "",
       language: lang!,

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -144,7 +144,9 @@ export function CreateProductionPage() {
       draftTags.length > 0 ||
       draftEvents.length > 0 ||
       isInfoModified(draftInfo) ||
-      isQuillDirty
+      isQuillDirty ||
+      draftAttendanceMode !== "" ||
+      draftPerformerType !== ""
     );
   }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
 

--- a/frontend/tests/unit/CreateProductionPage.test.tsx
+++ b/frontend/tests/unit/CreateProductionPage.test.tsx
@@ -216,4 +216,37 @@ describe("CreateProductionPage", () => {
       })
     );
   });
+
+  it("cancel button resets form fields", async () => {
+    const user = userEvent.setup();
+    renderWithRouterAndTheme({
+      useRealCreateProductionPage: true,
+      initialPath: "/archive/productions/create",
+    });
+
+    const titleInput = await screen.findByPlaceholderText("I18_Archive_addInfo_Title");
+    await user.type(titleInput, "Test productie");
+    expect(titleInput).toHaveValue("Test productie");
+
+    const cancelButton = await screen.findByText("I18N_ProductionPage_Edit_Cancel");
+    await user.click(cancelButton);
+
+    expect(titleInput).toHaveValue("");
+  });
+
+  it("cancel button navigates back to archive", async () => {
+    const user = userEvent.setup();
+    renderWithRouterAndTheme({
+      useRealCreateProductionPage: true,
+      initialPath: "/archive/productions/create",
+    });
+
+    const cancelButton = await screen.findByText("I18N_ProductionPage_Edit_Cancel");
+    await user.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("I18N_ProductionPage_Edit_Cancel")).not.toBeInTheDocument();
+    });
+  });
+
 });

--- a/frontend/tests/unit/CreateProductionPage.test.tsx
+++ b/frontend/tests/unit/CreateProductionPage.test.tsx
@@ -245,8 +245,9 @@ describe("CreateProductionPage", () => {
     await user.click(cancelButton);
 
     await waitFor(() => {
-      expect(screen.queryByText("I18N_ProductionPage_Edit_Cancel")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("I18N_ProductionPage_Edit_Cancel")
+      ).not.toBeInTheDocument();
     });
   });
-
 });

--- a/frontend/tests/unit/CreateProductionPage.test.tsx
+++ b/frontend/tests/unit/CreateProductionPage.test.tsx
@@ -217,7 +217,7 @@ describe("CreateProductionPage", () => {
     );
   });
 
-  it("cancel button resets form fields", async () => {
+  it("cancel button does not reset form fields", async () => {
     const user = userEvent.setup();
     renderWithRouterAndTheme({
       useRealCreateProductionPage: true,
@@ -231,7 +231,7 @@ describe("CreateProductionPage", () => {
     const cancelButton = await screen.findByText("I18N_ProductionPage_Edit_Cancel");
     await user.click(cancelButton);
 
-    expect(titleInput).toHaveValue("");
+    expect(titleInput).toHaveValue("Test productie");
   });
 
   it("cancel button navigates back to archive", async () => {

--- a/frontend/tests/unit/components/EditButton.test.tsx
+++ b/frontend/tests/unit/components/EditButton.test.tsx
@@ -121,6 +121,7 @@ describe("EditButton", () => {
   });
 
   it("restores original values when cancel is clicked", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
     const user = userEvent.setup();
 
     renderEditButton({ isEditing: true });


### PR DESCRIPTION
### Beschrijving
Deze bug werd aangehaald en is erger dan beschreven. Het blokkeerde de volledige flow dus dit is nu normaal opgelost. Nu zou je ook moeten teruggaan naar de archiefpagina, wat wel logisch is.

EDIT: als je perongeluk op cancel drukt, zal je een waarschuwing hebben als je nog changes zou hebben. Dit is ook toegepast op EditButton.

Als je op annuleer drukt en dan toch annuleert, kom je gewoon terug waar je gebleven was (de info wordt niet verwijderd). Als je bevestigt, ga je terug naar archief.


### Aangepaste delen
- CreateProductionPage
- EditButton (je kan er een onCancel aan meegeven)


### Speciale opmerkingen
Geen.


### Afhankelijkheden
Geen.


### Testen
Twee extra testen zijn hiervoor toegevoegd.


Closes #477 

- [X] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
