### PR TITLE
Aanmaken van nieuwe tags

### DIFF
--- a/frontend/app/features/archive/components/EditButton.tsx
+++ b/frontend/app/features/archive/components/EditButton.tsx
@@ -23,6 +23,7 @@ type EditButtonProps = {
   setDraftEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>;
   setNewEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>;
   setDeletedEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>;
+  setNewTags: React.Dispatch<React.SetStateAction<Tag[]>>;
   setDraftAttendanceMode: React.Dispatch<React.SetStateAction<string>>;
   setDraftPerformerType: React.Dispatch<React.SetStateAction<string>>;
   originalAttendanceMode: string;
@@ -45,6 +46,7 @@ export function EditButton({
   setDraftEvents,
   setNewEvents,
   setDeletedEvents,
+  setNewTags,
   setDraftAttendanceMode,
   setDraftPerformerType,
   originalAttendanceMode,
@@ -90,6 +92,7 @@ export function EditButton({
               );
               setNewEvents([]);
               setDeletedEvents([]);
+              setNewTags([]);
               setIsEditing(false);
               setDraftAttendanceMode(originalAttendanceMode);
               setDraftPerformerType(originalPerformerType);

--- a/frontend/app/features/archive/components/TagSection.tsx
+++ b/frontend/app/features/archive/components/TagSection.tsx
@@ -57,8 +57,7 @@ function CreateTagDialog({
     preferredLanguage === "en" ? (initialValue ?? "") : ""
   );
   function onClose() {
-    setDutchName("");
-    setEnglishName("");
+    setIsOpen(false);
   }
 
   return (

--- a/frontend/app/features/archive/components/TagSection.tsx
+++ b/frontend/app/features/archive/components/TagSection.tsx
@@ -42,12 +42,14 @@ function CreateTagDialog({
   isOpen,
   setIsOpen,
   onSubmit,
+  allTags,
 }: {
   preferredLanguage: string;
   initialValue?: string;
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onSubmit: (dutchName: string, EnglishName: string) => void;
+  allTags: Tag[];
 }) {
   const { t } = useTranslation();
   const [dutchName, setDutchName] = useState(
@@ -59,6 +61,22 @@ function CreateTagDialog({
   function onClose() {
     setIsOpen(false);
   }
+
+  function normalize(value: string) {
+    return value.trim().toLowerCase();
+  }
+
+  const duplicateDutchTag = allTags.find((tag) =>
+    tag.names.some((name) => normalize(name.name) === normalize(dutchName))
+  );
+
+  const duplicateEnglishTag = allTags.find((tag) =>
+    tag.names.some((name) => normalize(name.name) === normalize(englishName))
+  );
+
+  const hasDuplicate =
+    (!!dutchName.trim() && !!duplicateDutchTag) ||
+    (!!englishName.trim() && !!duplicateEnglishTag);
 
   return (
     <Dialog
@@ -88,6 +106,10 @@ function CreateTagDialog({
             label={t("productionPage.edit.dutch_tag_name")}
             autoFocus
             value={dutchName}
+            error={!!duplicateDutchTag}
+            helperText={
+              duplicateDutchTag ? t("productionPage.edit.tag_already_exists") : ""
+            }
             onChange={(event) => {
               setDutchName(event.target.value);
             }}
@@ -96,6 +118,10 @@ function CreateTagDialog({
             label={t("productionPage.edit.english_tag_name")}
             autoFocus
             value={englishName}
+            error={!!duplicateEnglishTag}
+            helperText={
+              duplicateEnglishTag ? t("productionPage.edit.tag_already_exists") : ""
+            }
             onChange={(event) => {
               setEnglishName(event.target.value);
             }}
@@ -112,7 +138,11 @@ function CreateTagDialog({
           {t("users.actions.cancel")}
         </Button>
 
-        <Button sx={primaryButtonSx} onClick={() => onSubmit(dutchName, englishName)}>
+        <Button
+          sx={primaryButtonSx}
+          disabled={hasDuplicate}
+          onClick={() => onSubmit(dutchName, englishName)}
+        >
           {t("productionPage.edit.create")}
         </Button>
       </DialogActions>
@@ -366,6 +396,7 @@ export default function Tags({
           key={`${language}-${initalTagDialogValue}`}
           preferredLanguage={language}
           initialValue={initalTagDialogValue}
+          allTags={[...allTags, ...newTags]}
           isOpen={isCreateTagDialogOpen}
           setIsOpen={setIsCreateTagDialogOpen}
           onSubmit={(dutchName, englishName) => {
@@ -399,7 +430,7 @@ export default function Tags({
         {isDropdownOpen && (
           <TagDropdown
             isLoading={isLoading}
-            allTags={allTags}
+            allTags={[...allTags, ...newTags]}
             selectedTags={draftTags}
             setSelectedTags={setDraftTags}
             setIsCreateTagDialogOpen={setIsCreateTagDialogOpen}

--- a/frontend/app/features/archive/components/TagSection.tsx
+++ b/frontend/app/features/archive/components/TagSection.tsx
@@ -7,6 +7,14 @@ import { useClickOutside } from "~/shared/hooks/useClickOutside";
 
 import Add from "@mui/icons-material/Add";
 import Close from "@mui/icons-material/Close";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import { ArchiveTextField } from "~/shared/components/ArchiveTextField";
 
 // prefer active language, then dutch, then first available tag name
 function getTagNameByLanguage(tag: Tag, language: string) {
@@ -16,6 +24,98 @@ function getTagNameByLanguage(tag: Tag, language: string) {
     if (name.language === "nl") fallback = name.name;
   }
   return fallback;
+}
+
+const dialogPaperSx = {
+  borderRadius: "1.75rem",
+  border: "1px solid var(--archive-border)",
+  backgroundColor: "var(--archive-surface-strong)",
+  color: "var(--archive-ink)",
+  backdropFilter: "blur(18px)",
+  boxShadow: "0 28px 90px rgba(0, 0, 0, 0.24)",
+};
+
+const dialogBackdropSx = {
+  backgroundColor: "rgba(17, 16, 14, 0.48)",
+  backdropFilter: "blur(4px)",
+};
+
+function CreateTagDialog({
+  preferredLanguage,
+  initialValue,
+  isOpen,
+  setIsOpen,
+  onSubmit,
+}: {
+  preferredLanguage: string;
+  initialValue?: string;
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onSubmit: (dutchName: string, EnglishName: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [dutchName, setDutchName] = useState(
+    preferredLanguage === "nl" ? (initialValue ?? "") : ""
+  );
+  const [englishName, setEnglishName] = useState(
+    preferredLanguage === "en" ? (initialValue ?? "") : ""
+  );
+  function onClose() {
+    setDutchName("");
+    setEnglishName("");
+  }
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      slotProps={{
+        paper: { sx: dialogPaperSx },
+        backdrop: { sx: dialogBackdropSx },
+      }}
+    >
+      <DialogTitle>{t("productionPage.edit.create_tag")}</DialogTitle>
+      <DialogContent>
+        <form
+          id={"create-tag-form-dialog"}
+          onSubmit={() => {}}
+          className="mt-6 flex flex-col gap-5"
+        >
+          <ArchiveTextField
+            label={t("Dutch Name")}
+            autoFocus
+            value={dutchName}
+            onChange={(event) => {
+              setDutchName(event.target.value);
+            }}
+          />
+          <ArchiveTextField
+            label={t("English Name")}
+            autoFocus
+            value={englishName}
+            onChange={(event) => {
+              setEnglishName(event.target.value);
+            }}
+          />
+        </form>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={() => {
+            setIsOpen(false);
+          }}
+        >
+          {t("users.actions.cancel")}
+        </Button>
+
+        <Button onClick={() => onSubmit(dutchName, englishName)}>
+          {t("productionPage.edit.create")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
 }
 
 type TagListItemProps = React.LiHTMLAttributes<HTMLLIElement> & {
@@ -37,8 +137,10 @@ type TagsProps = {
   originalTags: Tag[];
   isEditing?: boolean;
   draftTags: Tag[];
+  newTags: Tag[];
   preferredLanguage?: string;
   setDraftTags: React.Dispatch<React.SetStateAction<Tag[]>>;
+  setNewTags: React.Dispatch<React.SetStateAction<Tag[]>>;
 };
 
 function TagDropdown({
@@ -46,6 +148,8 @@ function TagDropdown({
   allTags,
   selectedTags,
   setSelectedTags,
+  setIsCreateTagDialogOpen,
+  setInitialTagDialogValue,
   setIsOpen,
   language,
 }: {
@@ -54,6 +158,8 @@ function TagDropdown({
   selectedTags: Tag[];
   setSelectedTags: React.Dispatch<React.SetStateAction<Tag[]>>;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsCreateTagDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setInitialTagDialogValue: React.Dispatch<React.SetStateAction<string>>;
   language: string;
 }) {
   const { t } = useTranslation();
@@ -124,6 +230,21 @@ function TagDropdown({
             </li>
           ))}
 
+          {search.length > 0 && (
+            <li>
+              <button
+                className="hover:bg-archive-control text-archive-accent flex w-full cursor-pointer items-center rounded-lg px-3 py-2 text-left text-sm transition"
+                onClick={() => {
+                  setInitialTagDialogValue(search);
+                  setIsCreateTagDialogOpen(true);
+                }}
+              >
+                <Add />
+                {t("productionPage.edit.create_new_tag", { tag: search })}
+              </button>
+            </li>
+          )}
+
           {filteredTags.length === 0 && (
             <li className="px-3 py-2 text-sm opacity-60">
               {t("productionPage.edit.no_tags")}
@@ -140,6 +261,8 @@ export default function Tags({
   originalTags,
   draftTags,
   setDraftTags,
+  newTags,
+  setNewTags,
   isEditing,
   preferredLanguage,
 }: TagsProps) {
@@ -147,6 +270,8 @@ export default function Tags({
   const language = preferredLanguage ?? lang!;
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isCreateTagDialogOpen, setIsCreateTagDialogOpen] = useState(false);
+  const [initalTagDialogValue, setInitialTagDialogValue] = useState("");
 
   const [allTags, setAllTags] = useState<Tag[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -161,6 +286,9 @@ export default function Tags({
 
   function removeTag(id_url: string) {
     setDraftTags((prev) => prev.filter((tag) => tag.id_url !== id_url));
+  }
+  function removeNewTag(id_url: string) {
+    setNewTags((prev) => prev.filter((tag) => tag.id_url !== id_url));
   }
 
   return (
@@ -202,6 +330,20 @@ export default function Tags({
               </TagListItem>
             ))}
 
+        {isEditing &&
+          newTags &&
+          newTags.map((tag) => (
+            <TagListItem key={tag.id_url}>
+              {getTagNameByLanguage(tag, language)}
+              <Close
+                aria-label={`remove-${getTagNameByLanguage(tag, language)}`}
+                sx={{ fontSize: "1rem" }}
+                className="cursor-pointer text-red-500"
+                onClick={() => removeNewTag(tag.id_url)}
+              />
+            </TagListItem>
+          ))}
+
         {/* Add tag button */}
         {isEditing && (
           <button
@@ -213,12 +355,49 @@ export default function Tags({
             </TagListItem>
           </button>
         )}
+
+        <CreateTagDialog
+          key={`${language}-${initalTagDialogValue}`}
+          preferredLanguage={language}
+          initialValue={initalTagDialogValue}
+          isOpen={isCreateTagDialogOpen}
+          setIsOpen={setIsCreateTagDialogOpen}
+          onSubmit={(dutchName, englishName) => {
+            const names = [];
+
+            if (dutchName.trim()) {
+              names.push({
+                language: "nl",
+                name: dutchName.trim(),
+              });
+            }
+
+            if (englishName.trim()) {
+              names.push({
+                language: "en",
+                name: englishName.trim(),
+              });
+            }
+
+            const newTag: Tag = {
+              id_url: Math.random().toString(36),
+              names,
+            };
+
+            setNewTags((prev) => [...prev, newTag]);
+            setIsCreateTagDialogOpen(false);
+            setInitialTagDialogValue("");
+          }}
+        />
+
         {isDropdownOpen && (
           <TagDropdown
             isLoading={isLoading}
             allTags={allTags}
             selectedTags={draftTags}
             setSelectedTags={setDraftTags}
+            setIsCreateTagDialogOpen={setIsCreateTagDialogOpen}
+            setInitialTagDialogValue={setInitialTagDialogValue}
             setIsOpen={setIsDropdownOpen}
             language={language}
           />

--- a/frontend/app/features/archive/components/TagSection.tsx
+++ b/frontend/app/features/archive/components/TagSection.tsx
@@ -5,6 +5,7 @@ import type { Tag } from "../types/tagTypes";
 import { useTranslation } from "react-i18next";
 import { useClickOutside } from "~/shared/hooks/useClickOutside";
 
+import Check from "@mui/icons-material/Check";
 import Add from "@mui/icons-material/Add";
 import Close from "@mui/icons-material/Close";
 import {
@@ -186,13 +187,7 @@ function TagDropdown({
       return false;
     }
 
-    const matchesSearch = localizedName.toLowerCase().includes(search.toLowerCase());
-
-    const alreadySelected = selectedTags.some(
-      (draftTag) => draftTag.id_url === tag.id_url
-    );
-
-    return matchesSearch && !alreadySelected;
+    return localizedName.toLowerCase().includes(search.toLowerCase());
   });
 
   useClickOutside(dropdownRef, () => {
@@ -219,16 +214,26 @@ function TagDropdown({
         <li className="px-3 py-2 text-sm opacity-60">{t("loading")}</li>
       ) : (
         <ul className="max-h-64 overflow-y-auto">
-          {filteredTags.map((tag) => (
-            <li key={tag.id_url}>
-              <button
-                className="hover:bg-archive-control w-full cursor-pointer rounded-lg px-3 py-2 text-left text-sm transition"
-                onClick={() => addTag(tag)}
-              >
-                {getTagNameByLanguage(tag, language)}
-              </button>
-            </li>
-          ))}
+          {filteredTags.map((tag) => {
+            const isSelected = selectedTags.some(
+              (draftTag) => draftTag.id_url === tag.id_url
+            );
+
+            return (
+              <li key={tag.id_url}>
+                <button
+                  className="hover:bg-archive-control flex w-full cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition"
+                  onClick={() => addTag(tag)}
+                >
+                  <span>{getTagNameByLanguage(tag, language)}</span>
+
+                  {isSelected && (
+                    <Check sx={{ fontSize: "1rem" }} className="text-archive-accent" />
+                  )}
+                </button>
+              </li>
+            );
+          })}
 
           {search.length > 0 && (
             <li>

--- a/frontend/app/features/archive/components/TagSection.tsx
+++ b/frontend/app/features/archive/components/TagSection.tsx
@@ -16,6 +16,15 @@ import {
   DialogTitle,
 } from "@mui/material";
 import { ArchiveTextField } from "~/shared/components/ArchiveTextField";
+import {
+  dialogActionsSx,
+  dialogBackdropSx,
+  dialogContentSx,
+  dialogPaperSx,
+  dialogTitleSx,
+  primaryButtonSx,
+  secondaryButtonSx,
+} from "~/features/users/pages/UserManagementPage";
 
 // prefer active language, then dutch, then first available tag name
 function getTagNameByLanguage(tag: Tag, language: string) {
@@ -26,20 +35,6 @@ function getTagNameByLanguage(tag: Tag, language: string) {
   }
   return fallback;
 }
-
-const dialogPaperSx = {
-  borderRadius: "1.75rem",
-  border: "1px solid var(--archive-border)",
-  backgroundColor: "var(--archive-surface-strong)",
-  color: "var(--archive-ink)",
-  backdropFilter: "blur(18px)",
-  boxShadow: "0 28px 90px rgba(0, 0, 0, 0.24)",
-};
-
-const dialogBackdropSx = {
-  backgroundColor: "rgba(17, 16, 14, 0.48)",
-  backdropFilter: "blur(4px)",
-};
 
 function CreateTagDialog({
   preferredLanguage,
@@ -77,8 +72,14 @@ function CreateTagDialog({
         backdrop: { sx: dialogBackdropSx },
       }}
     >
-      <DialogTitle>{t("productionPage.edit.create_tag")}</DialogTitle>
-      <DialogContent>
+      <DialogTitle sx={dialogTitleSx}>
+        {t("productionPage.edit.create_tag")}
+      </DialogTitle>
+      <DialogContent sx={dialogContentSx}>
+        <p className="mb-2 text-sm leading-relaxed text-[color:var(--archive-ink)] opacity-70">
+          {t("productionPage.edit.create_tag_description", { username: "" })}
+        </p>
+
         <form
           id={"create-tag-form-dialog"}
           onSubmit={() => {}}
@@ -102,8 +103,9 @@ function CreateTagDialog({
           />
         </form>
       </DialogContent>
-      <DialogActions>
+      <DialogActions sx={dialogActionsSx}>
         <Button
+          sx={secondaryButtonSx}
           onClick={() => {
             setIsOpen(false);
           }}
@@ -111,7 +113,7 @@ function CreateTagDialog({
           {t("users.actions.cancel")}
         </Button>
 
-        <Button onClick={() => onSubmit(dutchName, englishName)}>
+        <Button sx={primaryButtonSx} onClick={() => onSubmit(dutchName, englishName)}>
           {t("productionPage.edit.create")}
         </Button>
       </DialogActions>

--- a/frontend/app/features/archive/components/TagSection.tsx
+++ b/frontend/app/features/archive/components/TagSection.tsx
@@ -84,7 +84,7 @@ function CreateTagDialog({
           className="mt-6 flex flex-col gap-5"
         >
           <ArchiveTextField
-            label={t("Dutch Name")}
+            label={t("productionPage.edit.dutch_tag_name")}
             autoFocus
             value={dutchName}
             onChange={(event) => {
@@ -92,7 +92,7 @@ function CreateTagDialog({
             }}
           />
           <ArchiveTextField
-            label={t("English Name")}
+            label={t("productionPage.edit.english_tag_name")}
             autoFocus
             value={englishName}
             onChange={(event) => {

--- a/frontend/app/features/archive/pages/CreateProductionPage.tsx
+++ b/frontend/app/features/archive/pages/CreateProductionPage.tsx
@@ -19,6 +19,7 @@ import Tags from "../components/TagSection";
 import EventSection from "../components/EventSection";
 import { ProductionGeneralInfo } from "../components/ProductionGeneralInfo";
 import { ARCHIVE_PERMISSIONS } from "../archive.constants";
+import { createTag } from "../services/tagService";
 
 function isInfoModified(draftInfo: ProductionInfo | null): boolean {
   if (!draftInfo) return false;
@@ -41,6 +42,7 @@ async function handleAddProduction(
   draftInfo: ProductionInfo | null,
   draftTags: Tag[],
   draftEvents: EventWithResolvedRelations[],
+  newTags: Tag[],
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
   errorMessage: string,
   skipWarning: React.RefObject<boolean>,
@@ -51,6 +53,16 @@ async function handleAddProduction(
   setIsSaving(true);
 
   try {
+    const newCreatedTags = await Promise.all(
+      newTags.map(async (event) => {
+        return await createTag({
+          names: event.names,
+        });
+      })
+    );
+
+    const allTags = [...draftTags, ...newCreatedTags];
+
     const response = await createProduction({
       attendance_mode: attendanceMode,
       performer_type: performerType,
@@ -64,7 +76,7 @@ async function handleAddProduction(
         description: draftInfo.description,
         info: draftInfo.info,
       },
-      tag_id_urls: draftTags.map((tag) => tag.id_url),
+      tag_id_urls: allTags.map((tag) => tag.id_url),
     });
     skipWarning.current = true;
     setSkipWarning(true);
@@ -132,6 +144,7 @@ export function CreateProductionPage() {
     info: "",
   });
   const [draftTags, setDraftTags] = useState<Tag[]>([]);
+  const [newTags, setNewTags] = useState<Tag[]>([]);
   const [draftEvents, setDraftEvents] = useState<EventWithResolvedRelations[]>([]);
 
   const [isQuillDirty, setIsQuillDirty] = useState(false);
@@ -147,10 +160,11 @@ export function CreateProductionPage() {
     return (
       draftTags.length > 0 ||
       draftEvents.length > 0 ||
+      newTags.length > 0 ||
       isInfoModified(draftInfo) ||
       isQuillDirty
     );
-  }, [draftInfo, draftTags, isQuillDirty, draftEvents]);
+  }, [draftInfo, draftTags, isQuillDirty, draftEvents, newTags]);
 
   const _handleAddProduction = () =>
     handleAddProduction(
@@ -160,6 +174,7 @@ export function CreateProductionPage() {
       draftInfo,
       draftTags,
       draftEvents,
+      newTags,
       setIsSaving,
       t("archive.create_error"),
       skipWarning,
@@ -217,6 +232,8 @@ export function CreateProductionPage() {
               originalTags={[]}
               draftTags={draftTags}
               setDraftTags={setDraftTags}
+              newTags={newTags}
+              setNewTags={setNewTags}
               isEditing={true}
             />
             <ProductionGeneralInfo
@@ -272,6 +289,7 @@ export function CreateProductionPage() {
             setDraftEvents={() => {}}
             setNewEvents={() => {}}
             setDeletedEvents={() => {}}
+            setNewTags={() => {}}
             enable_save={isModified}
             setDraftAttendanceMode={() => {}}
             setDraftPerformerType={() => {}}

--- a/frontend/app/features/archive/pages/ProductionPage.tsx
+++ b/frontend/app/features/archive/pages/ProductionPage.tsx
@@ -38,6 +38,7 @@ import EventSection from "../components/EventSection";
 import Tags from "../components/TagSection";
 import { ARCHIVE_PERMISSIONS } from "../archive.constants";
 import { ProductionGeneralInfo } from "../components/ProductionGeneralInfo";
+import { createTag } from "../services/tagService";
 
 interface ProductionPageProps {
   production: Production;
@@ -126,6 +127,9 @@ async function handleInfoSave(
   setNewEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>,
   deletedEvents: EventWithResolvedRelations[],
   setDeletedEvents: React.Dispatch<React.SetStateAction<EventWithResolvedRelations[]>>,
+  newTags: Tag[],
+  setNewTags: React.Dispatch<React.SetStateAction<Tag[]>>,
+  setDraftTags: React.Dispatch<React.SetStateAction<Tag[]>>,
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>,
   setIsSaving: React.Dispatch<React.SetStateAction<boolean>>,
   language: string,
@@ -196,10 +200,41 @@ async function handleInfoSave(
       await deleteByUrl(event.id_url);
     }
 
+    const createdTags: Tag[] = [];
+    for (const tag of newTags) {
+      const createdTag = await createTag({
+        names: tag.names,
+      });
+
+      createdTags.push(createdTag);
+    }
+
+    const persistedTags = [...draftTags, ...createdTags];
+
+    await updateProductionByUrl(production_id_url, {
+      attendance_mode: attendance_mode,
+      performer_type: performer_type,
+      production_infos: [
+        {
+          language: language,
+          title: draftInfo.title,
+          supertitle: draftInfo.supertitle,
+          artist: draftInfo.artist,
+          tagline: draftInfo.tagline,
+          teaser: draftInfo.teaser,
+          description: draftInfo.description,
+          info: draftInfo.info,
+        },
+      ],
+      tag_id_urls: persistedTags.map((tag) => tag.id_url),
+    });
+
     // sync local "source of truth"
     setOriginalAttendanceMode(attendance_mode);
     setOriginalPerformerType(performer_type);
-    setOriginalTags(draftTags);
+    setOriginalTags(persistedTags);
+    setDraftTags(persistedTags);
+    setNewTags([]);
     setOriginalInfo(draftInfo);
     setOriginalEvents([...draftEvents, ...createdEvents]);
     setDraftEvents([...draftEvents, ...createdEvents]);
@@ -248,6 +283,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
   });
   const [originalTags, setOriginalTags] = useState<Tag[]>(production.tags ?? []);
   const [draftTags, setDraftTags] = useState<Tag[]>(production.tags ?? []);
+  const [newTags, setNewTags] = useState<Tag[]>([]);
 
   // General Info
   const [draftPerformerType, setDraftPerformerType] = useState<string>(
@@ -285,6 +321,9 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
       setNewEvents,
       deletedEvents,
       setDeletedEvents,
+      newTags,
+      setNewTags,
+      setDraftTags,
       setIsEditing,
       setIsSaving,
       language,
@@ -308,7 +347,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
     const generalModified =
       originalAttendanceMode !== draftAttendanceMode ||
       originalPerformerType !== draftPerformerType;
-    const tagsModified = areTagsModified(originalTags, draftTags);
+    const tagsModified = areTagsModified(originalTags, draftTags) || newTags.length > 0;
     return (
       tagsModified ||
       generalModified ||
@@ -326,6 +365,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
     draftAttendanceMode,
     originalPerformerType,
     draftPerformerType,
+    newTags,
   ]);
 
   useEffect(() => {
@@ -523,6 +563,8 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
           originalTags={originalTags}
           draftTags={draftTags}
           setDraftTags={setDraftTags}
+          newTags={newTags}
+          setNewTags={setNewTags}
           isEditing={isEditing}
         />
 
@@ -606,6 +648,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
             setDraftEvents={setDraftEvents}
             setNewEvents={setNewEvents}
             setDeletedEvents={setDeletedEvents}
+            setNewTags={setNewTags}
             setDraftAttendanceMode={setDraftAttendanceMode}
             setDraftPerformerType={setDraftPerformerType}
             originalAttendanceMode={originalAttendanceMode}
@@ -636,6 +679,7 @@ export function ProductionPage({ production, preferredLanguage }: ProductionPage
             setDraftEvents={setDraftEvents}
             setNewEvents={setNewEvents}
             setDeletedEvents={setDeletedEvents}
+            setNewTags={setNewTags}
             setDraftAttendanceMode={setDraftAttendanceMode}
             setDraftPerformerType={setDraftPerformerType}
             originalAttendanceMode={originalAttendanceMode}

--- a/frontend/app/features/users/pages/UserManagementPage.tsx
+++ b/frontend/app/features/users/pages/UserManagementPage.tsx
@@ -900,7 +900,7 @@ const bannerSx = {
   "& .MuiAlert-icon": { color: "var(--archive-accent)" },
 };
 
-const secondaryButtonSx = {
+export const secondaryButtonSx = {
   py: 1.15,
   px: 2.35,
   borderRadius: "999px",
@@ -913,7 +913,7 @@ const secondaryButtonSx = {
   border: "1px solid var(--archive-border)",
 };
 
-const primaryButtonSx = {
+export const primaryButtonSx = {
   ...secondaryButtonSx,
   "color": "#f6f0e8",
   "borderColor": "transparent",
@@ -932,7 +932,7 @@ const dangerButtonSx = {
   },
 };
 
-const dialogTitleSx = {
+export const dialogTitleSx = {
   fontFamily: "var(--font-serif)",
   fontStyle: "italic",
   fontSize: "1.9rem",
@@ -942,14 +942,14 @@ const dialogTitleSx = {
   pt: 3,
 };
 
-const dialogContentSx = {
+export const dialogContentSx = {
   pt: "0.25rem !important",
   pb: 1,
   px: 3,
   color: "var(--archive-ink)",
 };
 
-const dialogActionsSx = {
+export const dialogActionsSx = {
   px: 3,
   pt: 2,
   pb: 3,
@@ -957,7 +957,7 @@ const dialogActionsSx = {
   borderTop: "1px solid var(--archive-border)",
 };
 
-const dialogPaperSx = {
+export const dialogPaperSx = {
   borderRadius: "1.75rem",
   border: "1px solid var(--archive-border)",
   backgroundColor: "var(--archive-surface-strong)",
@@ -966,7 +966,7 @@ const dialogPaperSx = {
   boxShadow: "0 28px 90px rgba(0, 0, 0, 0.24)",
 };
 
-const dialogBackdropSx = {
+export const dialogBackdropSx = {
   backgroundColor: "rgba(17, 16, 14, 0.48)",
   backdropFilter: "blur(4px)",
 };

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -170,7 +170,10 @@
       "teaser": "Teaser",
       "info": "Info",
       "search_tags": "Search tags...",
-      "no_tags": "No tags found"
+      "create_new_tag": "Create new tag \"{{tag}}\"",
+      "create_tag": "Create tag",
+      "no_tags": "No tags found",
+      "create": "Create"
     },
     "delete": {
       "delete": "Delete info (en)",

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -184,6 +184,7 @@
       "search_tags": "Search tags...",
       "create_new_tag": "Create new tag \"{{tag}}\"",
       "create_tag": "Create tag",
+      "create_tag_description": "Enter the Dutch and English names for the tag.",
       "no_tags": "No tags found",
       "create": "Create"
     },

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -185,6 +185,7 @@
       "create_new_tag": "Create new tag \"{{tag}}\"",
       "create_tag": "Create tag",
       "create_tag_description": "Enter the Dutch and English names for the tag.",
+      "tag_already_exists": "Tag already exists",
       "no_tags": "No tags found",
       "create": "Create"
     },

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -169,6 +169,8 @@
       "description": "Description",
       "teaser": "Teaser",
       "info": "Info",
+      "english_tag_name": "English name",
+      "dutch_tag_name": "Dutch name",
       "search_tags": "Search tags...",
       "create_new_tag": "Create new tag \"{{tag}}\"",
       "create_tag": "Create tag",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -172,7 +172,10 @@
       "search_tags": "Zoek tags...",
       "create_new_tag": "Maak nieuwe tag \"{{tag}}\" aan",
       "create_tag": "Tag aanmaken",
-      "no_tags": "Geen tags gevonden"
+      "english_tag_name": "Engelse naam",
+      "dutch_tag_name": "Nederlandse naam",
+      "no_tags": "Geen tags gevonden",
+      "create": "Aanmaken"
     },
     "delete": {
       "delete": "Verwijder info (nl)",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -182,6 +182,7 @@
       "search_tags": "Zoek tags...",
       "create_new_tag": "Maak nieuwe tag \"{{tag}}\" aan",
       "create_tag": "Tag aanmaken",
+      "create_tag_description": "Voer de Nederlandse en Engelse naam van de tag in.",
       "english_tag_name": "Engelse naam",
       "dutch_tag_name": "Nederlandse naam",
       "no_tags": "Geen tags gevonden",

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -170,6 +170,8 @@
       "teaser": "Teaser",
       "info": "Info",
       "search_tags": "Zoek tags...",
+      "create_new_tag": "Maak nieuwe tag \"{{tag}}\" aan",
+      "create_tag": "Tag aanmaken",
       "no_tags": "Geen tags gevonden"
     },
     "delete": {

--- a/frontend/app/locales/nl/translation.json
+++ b/frontend/app/locales/nl/translation.json
@@ -185,6 +185,7 @@
       "create_tag_description": "Voer de Nederlandse en Engelse naam van de tag in.",
       "english_tag_name": "Engelse naam",
       "dutch_tag_name": "Nederlandse naam",
+      "tag_already_exists": "Tag bestaat al",
       "no_tags": "Geen tags gevonden",
       "create": "Aanmaken"
     },

--- a/frontend/tests/unit/components/EditButton.test.tsx
+++ b/frontend/tests/unit/components/EditButton.test.tsx
@@ -56,6 +56,7 @@ const setDraftTags = vi.fn();
 const setDraftAttendanceMode = vi.fn();
 const setDraftPerformerType = vi.fn();
 const handleSave = vi.fn();
+const setNewTags = vi.fn();
 
 function renderEditButton(overrides = {}, user = baseUser) {
   vi.spyOn(loginServiceModule, "restoreSession").mockResolvedValue(user);
@@ -74,6 +75,7 @@ function renderEditButton(overrides = {}, user = baseUser) {
         setDeletedEvents={setDeletedEvents}
         originalTags={originalTags}
         setDraftTags={setDraftTags}
+        setNewTags={setNewTags}
         enable_save={true}
         is_saving={false}
         _handleSave={handleSave}
@@ -135,6 +137,7 @@ describe("EditButton", () => {
     expect(setDraftEvents).toHaveBeenCalledWith([{ ...originalEvents[0] }]);
     expect(setNewEvents).toHaveBeenCalledWith([]);
     expect(setDeletedEvents).toHaveBeenCalledWith([]);
+    expect(setNewTags).toHaveBeenCalledWith([]);
     expect(setIsEditing).toHaveBeenCalledWith(false);
   });
 

--- a/frontend/tests/unit/components/productionTags.test.tsx
+++ b/frontend/tests/unit/components/productionTags.test.tsx
@@ -36,6 +36,7 @@ function TagsTestWrapper({
   isEditing?: boolean;
 }) {
   const [draftTags, setDraftTags] = useState(initialTags);
+  const [newTags, setNewTags] = useState<Tag[]>([]);
   vi.mocked(getAllTags).mockResolvedValue(mockTags);
 
   return (
@@ -44,6 +45,8 @@ function TagsTestWrapper({
       originalTags={initialTags}
       draftTags={draftTags}
       setDraftTags={setDraftTags}
+      newTags={newTags}
+      setNewTags={setNewTags}
       isEditing={isEditing}
       preferredLanguage="en"
     />
@@ -102,5 +105,56 @@ describe("Tags", () => {
     const dropdown = screen.getByTestId("tag-dropdown");
     expect(within(dropdown).queryByText("Classical")).not.toBeInTheDocument();
     expect(within(dropdown).getByText("Experimental")).toBeInTheDocument();
+  });
+
+  it("creates a new tag from the dropdown search", async () => {
+    const user = userEvent.setup();
+    render(<TagsTestWrapper initialTags={[]} />);
+
+    await user.click(screen.getByLabelText("Add Tag"));
+
+    const searchInput = screen.getByRole("textbox");
+    await user.type(searchInput, "TagName");
+
+    await user.click(screen.getByText(/create_new_tag/i));
+
+    const dutchInput = screen.getByLabelText("Dutch Name");
+    const englishInput = screen.getByLabelText("English Name");
+
+    // english should already be prefilled because preferredLanguage="en"
+    expect(englishInput).toHaveValue("TagName");
+
+    await user.type(dutchInput, "TagName NL");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /create/i,
+      })
+    );
+
+    // newly created tag should appear
+    expect(screen.getByText("TagName")).toBeInTheDocument();
+  });
+
+  it("creates a tag with only one language filled in", async () => {
+    const user = userEvent.setup();
+    render(<TagsTestWrapper initialTags={[]} />);
+
+    await user.click(screen.getByLabelText("Add Tag"));
+
+    const searchInput = screen.getByRole("textbox");
+    await user.type(searchInput, "Noise");
+
+    await user.click(screen.getByText(/create_new_tag/i));
+
+    const englishInput = screen.getByLabelText("English Name");
+    expect(englishInput).toHaveValue("Noise");
+    await user.click(
+      screen.getByRole("button", {
+        name: /create/i,
+      })
+    );
+
+    expect(screen.getByText("Noise")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/unit/components/productionTags.test.tsx
+++ b/frontend/tests/unit/components/productionTags.test.tsx
@@ -118,8 +118,8 @@ describe("Tags", () => {
 
     await user.click(screen.getByText(/create_new_tag/i));
 
-    const dutchInput = screen.getByLabelText("Dutch Name");
-    const englishInput = screen.getByLabelText("English Name");
+    const dutchInput = screen.getByLabelText(/dutch_tag_name/i);
+    const englishInput = screen.getByLabelText(/english_tag_name/i);
 
     // english should already be prefilled because preferredLanguage="en"
     expect(englishInput).toHaveValue("TagName");
@@ -147,7 +147,7 @@ describe("Tags", () => {
 
     await user.click(screen.getByText(/create_new_tag/i));
 
-    const englishInput = screen.getByLabelText("English Name");
+    const englishInput = screen.getByLabelText(/english_tag_name/i);
     expect(englishInput).toHaveValue("Noise");
     await user.click(
       screen.getByRole("button", {

--- a/frontend/tests/unit/components/productionTags.test.tsx
+++ b/frontend/tests/unit/components/productionTags.test.tsx
@@ -164,4 +164,27 @@ describe("Tags", () => {
 
     expect(screen.getByText("Noise")).toBeInTheDocument();
   });
+
+  it("shows an error and disables submit when creating a duplicate tag", async () => {
+    const user = userEvent.setup();
+    render(<TagsTestWrapper initialTags={[]} />);
+
+    await user.click(screen.getByLabelText("Add Tag"));
+
+    const searchInput = screen.getByRole("textbox");
+    await user.type(searchInput, "Classical");
+
+    await user.click(screen.getByText(/create_new_tag/i));
+
+    const englishInput = screen.getByLabelText(/english_tag_name/i);
+    expect(englishInput).toHaveValue("Classical");
+
+    // duplicate validation message should appear
+    expect(screen.getByText(/tag_already_exists/i)).toBeInTheDocument();
+
+    const createButton = screen.getByRole("button", {
+      name: /create/i,
+    });
+    expect(createButton).toBeDisabled();
+  });
 });

--- a/frontend/tests/unit/components/productionTags.test.tsx
+++ b/frontend/tests/unit/components/productionTags.test.tsx
@@ -95,16 +95,23 @@ describe("Tags", () => {
     expect(screen.queryByText("Classical")).not.toBeInTheDocument();
   });
 
-  it("does not show already selected tags", async () => {
+  it("shows already selected tags with a checkmark", async () => {
     const user = userEvent.setup();
     vi.mocked(getAllTags).mockResolvedValue(mockTags);
+
     render(<TagsTestWrapper initialTags={[mockTags[0]]} />);
 
     await user.click(screen.getByLabelText("Add Tag"));
-
     const dropdown = screen.getByTestId("tag-dropdown");
-    expect(within(dropdown).queryByText("Classical")).not.toBeInTheDocument();
+
+    expect(within(dropdown).getByText("Classical")).toBeInTheDocument();
     expect(within(dropdown).getByText("Experimental")).toBeInTheDocument();
+
+    const classicalButton = within(dropdown).getByText("Classical").closest("button");
+
+    expect(
+      within(classicalButton as HTMLElement).getByTestId("CheckIcon")
+    ).toBeInTheDocument();
   });
 
   it("creates a new tag from the dropdown search", async () => {


### PR DESCRIPTION
### Beschrijving
Deze PR staat toe om nieuwe tags aan te maken tijdens het toevoegen van tags aan een production.

### Aangepaste delen
- CreateTagDialog toegevoegd aan TagSection
- Aanmaken van nieuwe tags laten gebeuren in CreateProductionPage
- Aanmaken van nieuwe tags laten gebeuren in editen van ProductionPage

### Screenshots
<img width="730" height="318" alt="image" src="https://github.com/user-attachments/assets/67d4779f-f3da-4cdf-8db5-0c70bcb452b1" />

<img width="761" height="325" alt="image" src="https://github.com/user-attachments/assets/a607dd9a-a2a6-44bf-8cdd-ec1cd58afddb" />


### Testen
Er zijn testen

- [x] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
