### PR TITLE
[FIX] Geef alle buttons `cursor-pointer`

### DIFF
--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -172,3 +172,15 @@ body {
 #root {
   min-height: 100vh;
 }
+
+/* Give all buttons a cursor-pointer unless it is disabled */
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
+  button:disabled {
+	  cursor: not-allowed;
+  }
+}

--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -181,6 +181,6 @@ body {
   }
 
   button:disabled {
-	  cursor: not-allowed;
+    cursor: not-allowed;
   }
 }


### PR DESCRIPTION
### Beschrijving
Ik merkte op dat er in de media-pagina nog een heleboel `cursor-pointer`s ontbraken. Toen ik die wou toevoegen was dat wel wat werk, dus besloot ik de luie route te nemen: globaal aan Tailwind vragen om alle knoppen een `cursor-pointer` te geven. Verder gaf ik dan ook dezelfde stijl voor als een knop `disabled` is. 

Ik besloot niet door de hele codebase te gaan om alle `cursor-pointer`s te verwijderen van buttons, als dit gewenst is kan dat wel, maar dat zal waarschijnlijk nog wat vervelende merge conflicten geven met andere PR's die nu openstaan.


### Aangepaste delen
Enkel globable CSS bestand aangepast.


### Testen
Geen testen



- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
