### PR TITLE
[Subfeat] Scraper updates alles

### DIFF
--- a/backend/src/worker/fetchers/paged_fetcher.py
+++ b/backend/src/worker/fetchers/paged_fetcher.py
@@ -69,7 +69,18 @@ class PagedFetcher:
                 f"Class {__class__} did not set 'endpoint' and can thus not sync"
             )
 
-        parameters = {"updated_at[after]": last_timestamp}
+        # [strictly_after] means that theoretically we could lose an update,
+        # but only on very rare edge cases where there were multiple items
+        # updated at the exact same time, and for some reason the scraper did
+        # not get all of those items. In that case the updateds that we did not
+        # get will be lost.
+
+        # If this edge case must be catched, than a solution could be to hold a
+        # list somewhere of the viernulvier_id's of all the items that were
+        # fetched the last sync and had that last timestamp. Then those could
+        # be ignored during this next update round.
+
+        parameters = {"updated_at[strictly_after]": last_timestamp}
         return self.fetch_all(self.endpoint, parameters)
 
     def fetch_all(self, link: str, parameters: dict) -> list:

--- a/backend/src/worker/sync/sync_updated.py
+++ b/backend/src/worker/sync/sync_updated.py
@@ -18,7 +18,7 @@ UPDATE_FUNCTIONS: dict[ResourceType, types.FunctionType] = {
     ResourceType.EVENT: store_updated_events,
     ResourceType.EVENT_PRICES: store_updated_eventprices,
     ResourceType.GENRES: store_updated_genres,
-    ResourceType.HALLS: lambda: (),  # Not implemented
+    ResourceType.HALLS: lambda _1, _2: (),  # Not implemented
 }
 
 

--- a/backend/src/worker/sync/sync_updated.py
+++ b/backend/src/worker/sync/sync_updated.py
@@ -1,0 +1,84 @@
+import logging
+import types
+
+from sqlalchemy.orm import Session
+from src.models.sync_state import ResourceType, SyncType
+from src.worker.fetchers.paged_fetcher import PagedFetcher
+from src.worker.sync.db_sync import get_last_sync, update_sync_state
+from src.worker.sync.update.event import store_updated_events
+from src.worker.sync.update.eventprice import store_updated_eventprices
+from src.worker.sync.update.genre import store_updated_genres
+from src.worker.sync.update.production import store_updated_productions
+
+logger = logging.getLogger(__name__)
+
+
+UPDATE_FUNCTIONS: dict[ResourceType, types.FunctionType] = {
+    ResourceType.PRODUCTION: store_updated_productions,
+    ResourceType.EVENT: store_updated_events,
+    ResourceType.EVENT_PRICES: store_updated_eventprices,
+    ResourceType.GENRES: store_updated_genres,
+    ResourceType.HALLS: lambda: (),  # Not implemented
+}
+
+
+def store_updated_items(
+    db_session: Session,
+    resource_type: ResourceType,
+    items: list[dict],
+):
+    """
+    Generic function that calls the correct function based on `resource_type`.
+
+    ---
+
+    :returns: the newest timestamp
+    :raises ValueError: when there is no update function for the given `resource_type`
+    """
+    updated_fn = UPDATE_FUNCTIONS.get(resource_type)
+    if not updated_fn:
+        raise ValueError(f"No update function registered for {resource_type}")
+
+    return updated_fn(db_session, items)
+
+
+def sync_updated_items(
+    db_session: Session,
+    fetcher: PagedFetcher,
+    resource_type: ResourceType,
+):
+    """
+    Function that, given a `fetcher` and `resource_type`, will do the
+    database lookup for the last sync, perform a new sync, and update the
+    database with the updated data and new sync-timestamp.
+
+    WARNING: fetcher and resource_type must be representing the same type
+
+    ---
+
+    :param db_session: open database connection
+    :param fetcher: a fetcher inhereting from PagedFetcher for getting new data
+    :param resource_type: type of resource to look up in database
+    """
+    last_timestamp = get_last_sync(db_session, resource_type, SyncType.UPDATED_AT)
+
+    items = []
+    try:
+        items = fetcher.get_updated_items_after(last_timestamp)
+    except ConnectionError:
+        if fetcher.has_partial_data():
+            items = fetcher.get_and_clear_partial_data()
+
+    logger.info(f"fetched {len(items)} updated {resource_type.value}(s) from API")
+
+    if not items or len(items) == 0:
+        return
+
+    newest_timestamp = store_updated_items(db_session, resource_type, items)
+    if not newest_timestamp:
+        newest_timestamp = last_timestamp
+
+    update_sync_state(db_session, resource_type, SyncType.UPDATED_AT, newest_timestamp)
+
+    db_session.commit()
+    logger.debug(f"committed sync_updated_items({resource_type.value})")

--- a/backend/src/worker/sync_job.py
+++ b/backend/src/worker/sync_job.py
@@ -50,8 +50,7 @@ def sync_all():
             with VNV_Wrapper() as wrapper:
                 fetcher = fetcher_class(wrapper)
                 sync_new_items(db, fetcher, resource_type)
-                # And later:
-                # sync_updated_items(db, lang_map, fetcher, resource_type)
+                sync_updated_items(db, fetcher, resource_type)
 
         logger.info("Starting media sync")
         with VNV_Wrapper() as wrapper:

--- a/backend/src/worker/sync_job.py
+++ b/backend/src/worker/sync_job.py
@@ -3,17 +3,15 @@ import logging
 from src.database import SESSION_LOCAL
 from src.models.sync_state import ResourceType
 from src.worker.fetchers.event import EventFetcher
-from src.worker.fetchers.halls import HallFetcher
 from src.worker.fetchers.eventprice import EventPriceFetcher
+from src.worker.fetchers.genres import GenreFetcher
+from src.worker.fetchers.halls import HallFetcher
 from src.worker.fetchers.paged_fetcher import PagedFetcher
 from src.worker.fetchers.production import ProductionFetcher
-from src.worker.fetchers.genres import GenreFetcher
-from src.worker.sync.sync_new import sync_new_items
-from src.worker.vnv_wrapper import VNV_Wrapper
-
-from src.worker.sync.store.production import store_new_productions
 from src.worker.sync.store.media import sync_all_media
-
+from src.worker.sync.sync_new import sync_new_items
+from src.worker.sync.sync_updated import sync_updated_items
+from src.worker.vnv_wrapper import VNV_Wrapper
 
 # Logging is used in the other classes, but seeing as this file is the main
 # one, setting the config here feels appropriate.
@@ -63,6 +61,10 @@ def sync_all():
 
 
 def sync_one_production(production_id: int):
+    # This import should rarely be used, only for short development, thus is
+    # placed here instead of at the top of the file
+    from src.worker.sync.store.production import store_new_productions
+
     db = SESSION_LOCAL()
     logger.info(f"Syncing single production vnv_id={production_id}")
     try:

--- a/backend/tests/unit/worker/test_fetchers.py
+++ b/backend/tests/unit/worker/test_fetchers.py
@@ -62,7 +62,7 @@ def test_get_updated_after_calls_fetch_all(fetcher_class, endpoint):
 
     # Check if the overriden method was called exactly once
     fetcher.fetch_all.assert_called_once_with(
-        endpoint, {"updated_at[after]": "2024-01-01"}
+        endpoint, {"updated_at[strictly_after]": "2024-01-01"}
     )
 
     assert result == ["data"]

--- a/backend/tests/unit/worker/test_sync_updated.py
+++ b/backend/tests/unit/worker/test_sync_updated.py
@@ -1,0 +1,178 @@
+"""
+This is the test file for 'src/worker/sync/sync_updated.py'. That file's main
+task is to call the right functions for the given types, more does it not
+really do.
+To test we make use of mocks and just check if the correct functions are
+called.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+import src.worker.sync.sync_updated as sync_updated
+from src.models.sync_state import ResourceType
+from src.worker.sync.sync_updated import sync_updated_items
+
+OLD_TS = datetime(2024, 1, 1)
+NEW_TS = datetime(2024, 1, 5)
+
+
+def overwrite_functions(monkeypatch):
+    """
+    Uses pytest's `monkeypatch` function to overwrite complete functions,
+    we need that for `store_new_XXX()` functions and `get_last_sync()` and
+    `update_sync_state()`.
+
+    The important part here is that we don't overwrite the function where it is
+    defined, but where it is used, so use the `src.worker.sync.sync_new`
+    namespace!
+
+    Returns the mocked functions so that they can be tested against.
+    """
+    get_last_sync = MagicMock()
+    update_sync_state = MagicMock()
+
+    store_updated_productions = MagicMock(return_value=NEW_TS)
+    store_updated_events = MagicMock(return_value=NEW_TS)
+    store_updated_eventprices = MagicMock(return_value=NEW_TS)
+    store_updated_tags = MagicMock(return_value=NEW_TS)
+    store_updated_genres = MagicMock(return_value=NEW_TS)
+
+    monkeypatch.setattr("src.worker.sync.sync_updated.get_last_sync", get_last_sync)
+    monkeypatch.setattr(
+        "src.worker.sync.sync_updated.update_sync_state", update_sync_state
+    )
+
+    monkeypatch.setitem(
+        sync_updated.UPDATE_FUNCTIONS,
+        ResourceType.PRODUCTION,
+        store_updated_productions,
+    )
+    monkeypatch.setitem(
+        sync_updated.UPDATE_FUNCTIONS, ResourceType.EVENT, store_updated_events
+    )
+    monkeypatch.setitem(
+        sync_updated.UPDATE_FUNCTIONS,
+        ResourceType.EVENT_PRICES,
+        store_updated_eventprices,
+    )
+    monkeypatch.setitem(
+        sync_updated.UPDATE_FUNCTIONS, ResourceType.TAGS, store_updated_tags
+    )
+    monkeypatch.setitem(
+        sync_updated.UPDATE_FUNCTIONS, ResourceType.GENRES, store_updated_genres
+    )
+
+    return {
+        "get_last_sync": get_last_sync,
+        "update_sync_state": update_sync_state,
+        "store_updated_productions": store_updated_productions,
+        "store_updated_events": store_updated_events,
+        "store_updated_eventprices": store_updated_eventprices,
+        "store_updated_tags": store_updated_tags,
+        "store_updated_genres": store_updated_genres,
+    }
+
+
+# Test all the normal paths to see if the right functions get called
+@pytest.mark.parametrize(
+    "resource_type,expected_update_fn",
+    [
+        (ResourceType.PRODUCTION, "store_updated_productions"),
+        (ResourceType.EVENT, "store_updated_events"),
+        (ResourceType.EVENT_PRICES, "store_updated_eventprices"),
+        (ResourceType.TAGS, "store_updated_tags"),
+        (ResourceType.GENRES, "store_updated_genres"),
+    ],
+)
+def test_sync_updated_items_dispatch_good_path(
+    resource_type, expected_update_fn, monkeypatch
+):
+    mocks = overwrite_functions(monkeypatch)
+
+    db_session = MagicMock()
+    fetcher = MagicMock()
+    fetcher.get_updated_items_after.return_value = [{"id": 4}]
+
+    sync_updated_items(db_session, fetcher, resource_type)
+
+    fetcher.get_updated_items_after.assert_called_once()
+    mocks["get_last_sync"].assert_called_once()
+    mocks["update_sync_state"].assert_called_once()
+
+    for name in [
+        "store_updated_productions",
+        "store_updated_events",
+        "store_updated_eventprices",
+    ]:
+        if name == expected_update_fn:
+            mocks[name].assert_called_once()
+        else:
+            mocks[name].assert_not_called()
+
+
+# Test if PagedFetcher partial data gets read on ConnectionError
+def test_sync_updated_items_connection_error(monkeypatch):
+    _ = overwrite_functions(monkeypatch)
+
+    db_session = MagicMock()
+    fetcher = MagicMock()
+    fetcher.get_updated_items_after.side_effect = ConnectionError()
+    fetcher.has_partial_data.return_value = True
+    fetcher.get_and_clear_partial_data.return_value = [{"id": 4}]
+
+    # Type of resource type does not matter here
+    sync_updated_items(db_session, fetcher, ResourceType.PRODUCTION)
+
+    fetcher.get_updated_items_after.assert_called_once()
+    fetcher.get_and_clear_partial_data.assert_called_once()
+
+
+# Test if 'sync_new_items' returns early when there are no items
+def test_updatedc_new_items_no_data(monkeypatch):
+    mocks = overwrite_functions(monkeypatch)
+
+    db_session = MagicMock()
+    fetcher = MagicMock()
+    fetcher.get_updated_items_after.return_value = []
+
+    # Type of resource type does not matter here
+    sync_updated_items(db_session, fetcher, ResourceType.PRODUCTION)
+
+    fetcher.get_updated_items_after.assert_called_once()
+    mocks["store_updated_productions"].assert_not_called()
+    mocks["update_sync_state"].assert_not_called()
+
+
+# Test if the old timestamp is used when no new items were fetched
+def test_sync_updated_items_falls_back_to_last_timestamp(monkeypatch):
+    mocks = overwrite_functions(monkeypatch)
+
+    db_session = MagicMock()
+    fetcher = MagicMock()
+
+    fetcher.get_updated_items_after.return_value = [{"id": 4}]
+
+    mocks["get_last_sync"].return_value = OLD_TS
+    # Override the `store_new_productions` to act like it stored nothing
+    mocks["store_updated_productions"].return_value = None
+
+    sync_updated_items(db_session, fetcher, ResourceType.PRODUCTION)
+
+    mocks["update_sync_state"].assert_called_once_with(
+        db_session,
+        ResourceType.PRODUCTION,
+        sync_updated.SyncType.UPDATED_AT,
+        OLD_TS,
+    )
+
+
+# To be 100% complete, also test that unknow resource types will throw so that
+# they do not silently fail
+def test_sync_new_items_throws_for_unknown_type():
+    with pytest.raises(
+        ValueError, match="No update function registered for unknown_resource_type"
+    ):
+        db_session = MagicMock()
+        sync_updated.store_updated_items(db_session, "unknown_resource_type", [])


### PR DESCRIPTION
### Beschrijving
Deze PR is het resultaat van de 4 voorgaande PR's: ze lijmt hun code aan mekaar zodat de scraper nu ook echt alle updates synchroniseert.


### Aangepaste delen
Sync worker


### Testen
Ik denk dat ik alles gecovered heb.


Closes #46 
Closes #9 

- [X] Goede testen toegevoegd.
- [X] Auteur wil zelf mergen.
