### PR TITLE
[TWEAK] End date defaults to today

### DIFF
--- a/frontend/app/features/archive/pages/ArchivePage.tsx
+++ b/frontend/app/features/archive/pages/ArchivePage.tsx
@@ -99,7 +99,11 @@ export default function ArchivePage() {
   const [showFilters, setShowFilters] = useState(false);
   const [searchQuery, debouncedSearch, setSearchQuery] = useDebouncedState("");
   const [dateFrom, debouncedDateFrom, setDateFrom] = useDebouncedState("");
-  const [dateTo, debouncedDateTo, setDateTo] = useDebouncedState("");
+  const date = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const [dateTo, debouncedDateTo, setDateTo] = useDebouncedState(
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+  );
   const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
   const [selectedArtists, setSelectedArtists] = useState<string[]>([]);
   const [productionList, setProductionList] = useState<ProductionList | null>(null);

--- a/frontend/tests/integration/ArchivePage.test.tsx
+++ b/frontend/tests/integration/ArchivePage.test.tsx
@@ -15,6 +15,10 @@ vi.mock("~/features/archive/services/artistService");
 vi.mock("~/features/archive/services/productionGroupService");
 vi.mock("~/features/archive/services/tagService");
 
+const date = new Date();
+const pad = (n: number) => String(n).padStart(2, "0");
+const DATE_TODAY = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
 const PRODUCTION_GROUPS = [
   {
     id_url: "/api/v1/archive/series/1",
@@ -262,7 +266,7 @@ describe("Archive", () => {
         artists: undefined,
         earliest_at: undefined,
         series_ids: undefined,
-        latest_at: undefined,
+        latest_at: DATE_TODAY,
         production_name: undefined,
         sort_order: "Descending",
         tag_ids: undefined,
@@ -278,7 +282,7 @@ describe("Archive", () => {
         artists: undefined,
         earliest_at: undefined,
         series_ids: undefined,
-        latest_at: undefined,
+        latest_at: DATE_TODAY,
         sort_order: "Descending",
         production_name: undefined,
         tag_ids: undefined,
@@ -311,7 +315,7 @@ describe("Archive", () => {
         artists: undefined,
         earliest_at: undefined,
         series_ids: undefined,
-        latest_at: undefined,
+        latest_at: DATE_TODAY,
         production_name: undefined,
         sort_order: "Descending",
         tag_ids: undefined,
@@ -332,7 +336,7 @@ describe("Archive", () => {
         artists: undefined,
         earliest_at: undefined,
         series_ids: ["2"],
-        latest_at: undefined,
+        latest_at: DATE_TODAY,
         production_name: undefined,
         sort_order: "Descending",
         tag_ids: undefined,


### PR DESCRIPTION
### Beschrijving
Zie titel


### Aangepaste delen
Eind datum terug op vandaag gezet in ArchivePage, en gezorgd dat testen dynamisch op datum werken.


### Speciale opmerkingen
geen


### Afhankelijkheden
geen


### Testen
geupdated


- [ ] Auteur wil zelf mergen.
