### PR TITLE
Update nginx.prod.conf to allow minio to work

### DIFF
--- a/proxy/nginx.prod.conf
+++ b/proxy/nginx.prod.conf
@@ -10,6 +10,9 @@ http {
     upstream backend {
         server backend:8000;
     }
+    upstream minio {
+        server minio:9000;
+    }
 
     server {
         listen 80;
@@ -32,6 +35,8 @@ http {
         ssl_certificate_key /etc/letsencrypt/live/sel2-3.ugent.be/privkey.pem;
 
         location /api/ {
+			client_max_body_size 30M;
+
             proxy_pass http://backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -46,6 +51,41 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Writes (POST/DELETE) go to /api/v1/media/ and are handled by the backend.
+        location /media/ {
+            proxy_pass http://minio/media/;
+            proxy_set_header Host minio:9000;
+
+            # Strip auth headers so MinIO doesn't reject anonymous reads
+            proxy_set_header Authorization "";
+
+            # Cache aggressively, images are immutable once uploaded
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Vary Accept-Encoding;
+
+            # Block reads at the nginx level
+            limit_except GET HEAD {
+                deny all;
+            }
+        }
+
+        location /visuals/ {
+            proxy_pass http://minio/visuals/;
+            proxy_set_header Host minio:9000;
+
+            # Strip auth headers so MinIO doesn't reject anonymous reads
+            proxy_set_header Authorization "";
+
+            # Cache aggressively, images are immutable once uploaded
+            add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Vary Accept-Encoding;
+
+            # Block reads at the nginx level
+            limit_except GET HEAD {
+                deny all;
+            }
         }
     }
 }


### PR DESCRIPTION
### Beschrijving
Update nginx prod config zodat minio er bij hoort. De nieuwe delen zijn gekopieerd van de gewone `proxy/nginx.conf`
