### PR TITLE
Hotfix/filter unknown date

### DIFF
--- a/backend/src/services/production.py
+++ b/backend/src/services/production.py
@@ -159,10 +159,14 @@ def get_productions_paginated(
 
     # Date filter
     if earliest_at:
-        base_query = base_query.filter(Production.latest_at >= earliest_at)
+        base_query = base_query.filter(
+            or_(Production.latest_at >= earliest_at, Production.latest_at == None)
+        )
 
     if latest_at:
-        base_query = base_query.filter(Production.earliest_at <= latest_at)
+        base_query = base_query.filter(
+            or_(Production.earliest_at <= latest_at, Production.earliest_at == None)
+        )
 
     # Tags filter
     if tags:

--- a/backend/src/services/production.py
+++ b/backend/src/services/production.py
@@ -160,12 +160,12 @@ def get_productions_paginated(
     # Date filter
     if earliest_at:
         base_query = base_query.filter(
-            or_(Production.latest_at >= earliest_at, Production.latest_at == None)
+            or_(Production.latest_at >= earliest_at, Production.latest_at is None)
         )
 
     if latest_at:
         base_query = base_query.filter(
-            or_(Production.earliest_at <= latest_at, Production.earliest_at == None)
+            or_(Production.earliest_at <= latest_at, Production.earliest_at is None)
         )
 
     # Tags filter


### PR DESCRIPTION
### Beschrijving
Nu de frontend automatisch de filter zet op vandaag, zag ik dat producties zonder events (dus geen datum) nooit meer weergegeven werden. Na grondig onderzoek vond ik dat verantwoordelijke code. Deze paste ik aan zodat die ook producties zonder datum teruggeeft. Dit zou geen problemen mogen geven aangezien de frontend deze producties helemaal onderaan weergeeft.


### Aangepaste delen
Backend service.


### Testen
Slagen nog steeds.