### PR TITLE
fix color in blockquote

### DIFF
--- a/frontend/app/styles/app.css
+++ b/frontend/app/styles/app.css
@@ -157,6 +157,14 @@
   list-style-type: lower-roman;
 }
 
+.prose blockquote {
+  color: inherit;
+}
+
+.prose blockquote p {
+  color: inherit;
+}
+
 html,
 body {
   min-height: 100%;


### PR DESCRIPTION
### Beschrijving
Blockquotes hadden eigen css, waardoor het niet zichtbaar was in dark mode.
<img width="1197" height="498" alt="image" src="https://github.com/user-attachments/assets/27f05889-5ee7-4860-bfdb-6442b3683b79" />

Is nu opgelost.
<img width="1635" height="510" alt="image" src="https://github.com/user-attachments/assets/f935d9cd-f874-49fd-95db-ff1305e11911" />



### Aangepaste delen
- css


### Speciale opmerkingen
<Was er iets dat speciaal aan de implementering?>


### Afhankelijkheden
<Welke eventuele PR's moeten eerder gesloten worden voor dit kan gemerged worden>


### Testen
<Vermeld of er al testen zijn voor nieuwe functionaliteit en hoe de coverage is,
als er iets niet gecovered is, leg dit uit waarom dit niet nodig zou zijn.>


Closes <issue-nr>

- [ ] Goede testen toegevoegd.
- [ ] Auteur wil zelf mergen.
